### PR TITLE
Add prometheus support and health endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "koa-cors": "^0.0.16",
                 "pino": "^7.11.0",
                 "pino-pretty": "^7.6.1",
+                "prom-client": "^14.0.1",
                 "typescript": "^4.6.3"
             },
             "devDependencies": {
@@ -3185,6 +3186,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/bintrees": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+            "integrity": "sha512-tbaUB1QpTIj4cKY8c1rvNAvEQXA+ekzHmbe4jzNfW3QWsF9GnnP/BRWyl6/qqS53heoYJ93naaFcm/jooONH8g=="
         },
         "node_modules/boxen": {
             "version": "5.1.2",
@@ -9316,6 +9322,17 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/prom-client": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+            "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+            "dependencies": {
+                "tdigest": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/promise-inflight": {
             "version": "1.0.1",
             "dev": true,
@@ -10555,6 +10572,14 @@
             },
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/tdigest": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+            "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+            "dependencies": {
+                "bintrees": "1.0.1"
             }
         },
         "node_modules/teeny-request": {
@@ -19160,6 +19185,11 @@
         "binary-extensions": {
             "version": "2.2.0"
         },
+        "bintrees": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+            "integrity": "sha512-tbaUB1QpTIj4cKY8c1rvNAvEQXA+ekzHmbe4jzNfW3QWsF9GnnP/BRWyl6/qqS53heoYJ93naaFcm/jooONH8g=="
+        },
         "boxen": {
             "version": "5.1.2",
             "dev": true,
@@ -23200,6 +23230,14 @@
             "version": "2.0.3",
             "dev": true
         },
+        "prom-client": {
+            "version": "14.0.1",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.0.1.tgz",
+            "integrity": "sha512-HxTArb6fkOntQHoRGvv4qd/BkorjliiuO2uSWC2KC17MUTKYttWdDoXX/vxOhQdkoECEM9BBH0pj2l8G8kev6w==",
+            "requires": {
+                "tdigest": "^0.1.1"
+            }
+        },
         "promise-inflight": {
             "version": "1.0.1",
             "dev": true
@@ -24003,6 +24041,14 @@
                 "minizlib": "^2.1.1",
                 "mkdirp": "^1.0.3",
                 "yallist": "^4.0.0"
+            }
+        },
+        "tdigest": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+            "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+            "requires": {
+                "bintrees": "1.0.1"
             }
         },
         "teeny-request": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "koa-cors": "^0.0.16",
         "pino": "^7.11.0",
         "pino-pretty": "^7.6.1",
+        "prom-client": "^14.0.1",
         "typescript": "^4.6.3"
     }
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -18,9 +18,10 @@
  *
  */
 
+import { Relay, RelayImpl } from '@hashgraph/json-rpc-relay';
 import Koa from 'koa';
 import koaJsonRpc from 'koa-jsonrpc';
-import { Relay, RelayImpl } from '@hashgraph/json-rpc-relay';
+import { collectDefaultMetrics, Counter, Registry } from 'prom-client';
 
 import pino from 'pino';
 const mainLogger = pino({
@@ -37,6 +38,72 @@ const cors = require('koa-cors');
 const app = new Koa();
 const rpc = koaJsonRpc();
 
+const register = new Registry();
+collectDefaultMetrics({ register, prefix: 'rpc_relay_' });
+const methodCounter = new Counter({ name: 'rpc_method_counter', help: 'JSON RPC method counter', labelNames: ['method'], registers: [register] });
+const successCounter = new Counter({ name: 'rpc_success_counter', help: 'JSON RPC success counter', labelNames: ['success'], registers: [register] });
+
+/**
+ * middleware for request timing
+ */
+app.use(async (ctx, next) => {
+  const start = Date.now();
+  await next();
+  const ms = Date.now() - start;
+  logger.info(`[${ctx.method}]: ${ctx.url} ${ms} ms`);
+
+  if (ctx.method === 'POST') {
+    const success = ctx.body.result ? 'true' : 'false';
+    successCounter.inc({ success: success });
+  }
+});
+
+/**
+ * prometheus metrics exposure
+ */
+app.use(async (ctx, next) => {
+  if (ctx.url === '/metrics') {
+    ctx.status = 200;
+    ctx.body = await register.metrics();
+  } else {
+    return next();
+  }
+});
+
+/**
+ * liveness endpoint
+ */
+app.use(async (ctx, next) => {
+  if (ctx.url === '/health/liveness') {
+    ctx.status = 200;
+  } else {
+    return next();
+  }
+});
+
+/**
+ * readiness endpoint
+ */
+app.use(async (ctx, next) => {
+  if (ctx.url === '/health/readiness') {
+    try {
+      const result = relay.eth().chainId();
+      if (result.indexOf('0x12') > 0) {
+        ctx.status = 200;
+        ctx.body = 'OK';
+      } else {
+        ctx.body = 'DOWN';
+        ctx.status = 503; // UNAVAILABLE
+      }
+    } catch (e) {
+      logger.error(e);
+      throw e;
+    }
+  } else {
+    return next();
+  }
+});
+
 /**
  * returns: false
  */
@@ -49,6 +116,8 @@ rpc.use('net_listening', async () => {
  *  Returns the current network ID
  */
 rpc.use('net_version', async () => {
+  methodCounter.inc();
+  methodCounter.inc({ method: 'net_version' });
   logger.debug("net_version");
   return relay.net().version();
 });
@@ -59,6 +128,8 @@ rpc.use('net_version', async () => {
  * returns: Block number - hex encoded integer
  */
 rpc.use('eth_blockNumber', async () => {
+  methodCounter.inc();
+  methodCounter.inc({ method: 'eth_blockNumber' });
   logger.debug("eth_blockNumber");
   return toHexString(await relay.eth().blockNumber());
 });
@@ -104,6 +175,8 @@ rpc.use('eth_getCode', async (params: any) => {
  * returns: Chain ID - integer
  */
 rpc.use('eth_chainId', async () => {
+  methodCounter.inc();
+  methodCounter.inc({ method: 'eth_chainId' });
   logger.debug("eth_chainId");
   const result = relay.eth().chainId();
   logger.debug(result);
@@ -154,7 +227,7 @@ rpc.use('eth_gasPrice', async () => {
 rpc.use('eth_getTransactionCount', async (params: any) => {
   logger.debug("eth_getTransactionCount");
   try {
-    return toHexString(await relay.eth().getTransactionCount(params?.[0],params?.[1]));
+    return toHexString(await relay.eth().getTransactionCount(params?.[0], params?.[1]));
   } catch (e) {
     logger.error(e);
     throw e;
@@ -428,6 +501,8 @@ rpc.use('eth_syncing', async (params: any) => {
  * returns: string
  */
 rpc.use('web3_client_version', async (params: any) => {
+  methodCounter.inc();
+  methodCounter.inc({ method: 'web3_client_version' });
   logger.debug("web3_client_version");
   return relay.web3().clientVersion();
 });


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Relay currently lacks any monitoring support.

- Add a `/metrics` endpoint to support prometheus metrics retrieval
- Add simple request latency measurements
- Add initial method and success counters
- Add health endpoint support
  - `health/readiness` - ensures valid chainId can be retrieved
  - `/health/liveness` - returns success when up

**Related issue(s)**:

Fixes #87 
Fixes #88 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
