### PR TITLE
Fix blocks transactions and r and s signatures assignments

### DIFF
--- a/packages/relay/src/lib/mirrorNode.ts
+++ b/packages/relay/src/lib/mirrorNode.ts
@@ -20,7 +20,7 @@
 
 import { Logger } from "pino";
 // Used for temporary purposes to store block info. As the mirror node supports the APIs, we will remove this.
-import { Block } from './model';
+import { Block, CachedBlock } from './model';
 
 export class MirrorNode {
   // A FAKE implementation until mirror node is integrated and ready.
@@ -50,12 +50,12 @@ export class MirrorNode {
       this.logger.info("Restarting.");
     } else {
       this.logger.info("Fresh start, creating genesis block with no transactions");
-      const genesisBlock = new Block(null, null);
+      const genesisBlock = new CachedBlock(null, null);
       this.storeBlock(genesisBlock);
     }
   }
 
-  public async getFeeHistory(fee : number, _blockCount: number, _newestBlock: string, rewardPercentiles: Array<number>|null) {
+  public async getFeeHistory(fee: number, _blockCount: number, _newestBlock: string, rewardPercentiles: Array<number> | null) {
     // FIXME: This is a fake implementation. It works for now, but should
     //        actually delegate to the mirror node.
     this.logger.trace('getFeeHistory()');
@@ -89,11 +89,11 @@ export class MirrorNode {
 
   // FIXME this is for demo/temp purposes, remove it when the mirror node has real blocks
   //       that they get from the main net nodes
-  public storeBlock(block: Block) {
+  public storeBlock(block: CachedBlock) {
     this.store.set(MirrorNode.MOST_RECENT_BLOCK_NUMBER_KEY, block.getNum());
     this.store.set(MirrorNode.MOST_RECENT_BLOCK_KEY, block);
     this.store.set(block.getNum().toString(), block);
-    this.store.set(block.transactions[0], block);
+    this.store.set(block.transactionHashes[0], block);
   }
 
   public async getMostRecentBlockNumber(): Promise<number> {
@@ -104,7 +104,7 @@ export class MirrorNode {
     return num === undefined ? 0 : Number(num);
   }
 
-  public async getMostRecentBlock(): Promise<Block | null> {
+  public async getMostRecentBlock(): Promise<CachedBlock | null> {
     // FIXME: Fake implementation for now. Should go to the mirror node.
     this.logger.trace('getMostRecentBlock()');
     const block = this.store.get(MirrorNode.MOST_RECENT_BLOCK_KEY);

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -23,8 +23,8 @@ import {Status, TransactionRecord} from "@hashgraph/sdk";
 
 export class Block {
     public readonly timestamp:string = '0x' + new Date().valueOf().toString(16);
-    public readonly number:string;
-    public readonly hash:string;
+    public number!: string;
+    public hash!: string;
 
     public readonly difficulty:string = '0x1';
     public readonly extraData:string = '';
@@ -36,28 +36,17 @@ export class Block {
     public readonly mixHash:string =
         '0x0000000000000000000000000000000000000000000000000000000000000000';
     public readonly nonce:string = '0x0000000000000000';
-    public readonly parentHash:string;
+    public parentHash!: string;
     public readonly receiptsRoot:string = '0x0';
     public readonly sha3Uncles:string = '0x0';
     public readonly size:string = '0x0';
     public readonly stateRoot:string = '0x0';
     public readonly totalDifficulty:string = '0x1';
-    public readonly transactions:string[] = [];
+    public readonly transactions:string[] | Transaction[] = [];
     public readonly transactionsRoot:string = '0x0';
     public readonly uncles:any[] = [];
 
-    constructor(parentBlock:(null | Block), transaction:(string|null), args?:any) {
-        const num = parentBlock == null ? 0 : parentBlock.getNum() + 1;
-        this.number = '0x' + Number(num).toString(16);
-        this.parentHash = parentBlock == null ? '0x0' : parentBlock.hash;
-        if (transaction) {
-            this.transactions.push(transaction);
-        }
-
-        const numberAsString = num.toString();
-        const baseHash = "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b";
-        this.hash = baseHash.slice(0, baseHash.length - numberAsString.length) + numberAsString;
-
+    constructor(args?:any) {
         if (args) {
             this.timestamp = args.timestamp;
             this.number = args.number;
@@ -77,13 +66,11 @@ export class Block {
             this.size = args.size;
             this.stateRoot = args.stateRoot;
             this.totalDifficulty = args.totalDifficulty;
-            if (args.transactions === undefined) {
-                this.transactions = [];
-            } else {
-                this.transactions.splice(0, this.transactions.length, ...args.transactions);
-            }
+            this.transactions = args.transactions;
             this.transactionsRoot = args.transactionsRoot;
             this.uncles = [];
+            
+            console.log(`*** model, this.transactions: ${JSON.stringify(this.transactions)}, args.transactions: ${JSON.stringify(args.transactions)}`);
         }
     }
 
@@ -92,6 +79,27 @@ export class Block {
      */
     public getNum():number {
         return Number(this.number.substring(2));
+    }
+}
+
+export class CachedBlock extends Block {
+    public readonly parentBlock:Block|null;
+    public readonly transactionHashes:string[] = [];
+
+    constructor(parentBlock:(null | Block), transactionHash:(string|null), args?:any) {
+        super(args);
+        this.parentBlock = parentBlock;
+
+        const num = parentBlock == null ? 0 : parentBlock.getNum() + 1;
+        this.number = '0x' + Number(num).toString(16);
+        this.parentHash = parentBlock == null ? '0x0' : parentBlock.hash;
+        if (transactionHash) {
+            this.transactionHashes.push(transactionHash);
+        }
+
+        const numberAsString = num.toString();
+        const baseHash = "0xc6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b";
+        this.hash = baseHash.slice(0, baseHash.length - numberAsString.length) + numberAsString;
     }
 }
 

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -69,8 +69,6 @@ export class Block {
             this.transactions = args.transactions;
             this.transactionsRoot = args.transactionsRoot;
             this.uncles = [];
-            
-            console.log(`*** model, this.transactions: ${JSON.stringify(this.transactions)}, args.transactions: ${JSON.stringify(args.transactions)}`);
         }
     }
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -31,6 +31,7 @@ import { MirrorNodeClient } from '../../src/lib/clients/mirrorNodeClient';
 const cache = require('js-cache');
 
 import pino from 'pino';
+import { Transaction } from '../../src/lib/model';
 const logger = pino();
 
 const Relay = new RelayImpl(logger);
@@ -188,6 +189,12 @@ describe('Eth calls using MirrorNode', async function () {
     'v': 1
   };
 
+  const defaultDetailedContractResultsWithNullNullableValues = {
+    ...defaultDetailedContractResults,
+    r: null,
+    s: null
+  };
+
   const results = defaultContractResults.results;
   const totalGasUsed = results[0].gas_used + results[1].gas_used;
 
@@ -224,7 +231,9 @@ describe('Eth calls using MirrorNode', async function () {
     // mirror node request mocks
     mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
     mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultContractResults);
-    const result = await ethImpl.getBlockByNumber(blockNumber.toString(), false);
+    mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResults);
+    mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults);
+    const result = await ethImpl.getBlockByNumber(blockNumber, false);
     expect(result).to.exist;
     if (result == null) return;
 
@@ -235,6 +244,43 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result.number).equal(blockNumber);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
     expect(result.timestamp).equal(firstTransactionTimestampSeconds);
+    expect(result.transactions.length).equal(2);
+    expect((result.transactions[0] as string)).equal(contractHash1);
+    expect((result.transactions[1] as string)).equal(contractHash1);
+
+    // verify expected constants
+    expect(result.baseFeePerGas).equal(0);
+    expect(result.difficulty).equal(EthImpl.zeroHex);
+    expect(result.extraData).equal(EthImpl.emptyHex);
+    expect(result.miner).equal(EthImpl.emptyHex);
+    expect(result.mixHash).equal(EthImpl.emptyHex);
+    expect(result.nonce).equal(EthImpl.emptyHex);
+    expect(result.receiptsRoot).equal(EthImpl.emptyHex);
+    expect(result.sha3Uncles).equal(EthImpl.emptyArrayHex);
+    expect(result.stateRoot).equal(EthImpl.emptyHex);
+    expect(result.totalDifficulty).equal(EthImpl.zeroHex);
+    expect(result.uncles).to.deep.equal([]);
+  });
+
+  it('eth_getBlockByNumber with match and details', async function () {
+    // mirror node request mocks
+    mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
+    mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultContractResults);
+    mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResultsWithNullNullableValues);
+    mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResultsWithNullNullableValues);
+    const result = await ethImpl.getBlockByNumber(blockNumber, true);
+    expect(result).to.exist;
+
+    // verify aggregated info
+    expect(result.hash).equal(blockHashTrimmed);
+    expect(result.gasUsed).equal(totalGasUsed);
+    expect(result.gasLimit).equal(maxGasLimit);
+    expect(result.number).equal(blockNumber);
+    expect(result.parentHash).equal(blockHashPreviousTrimmed);
+    expect(result.timestamp).equal(firstTransactionTimestampSeconds);
+    expect(result.transactions.length).equal(2);
+    expect((result.transactions[0] as Transaction).hash).equal(contractHash1);
+    expect((result.transactions[1] as Transaction).hash).equal(contractHash1);
 
     // verify expected constants
     expect(result.baseFeePerGas).equal(0);
@@ -314,6 +360,8 @@ describe('Eth calls using MirrorNode', async function () {
     // mirror node request mocks
     mock.onGet(`blocks/${blockHash}`).reply(200, defaultBlock);
     mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultContractResults);
+    mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResults);
+    mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults);
 
     const result = await ethImpl.getBlockByHash(blockHash, false);
     expect(result).to.exist;
@@ -326,6 +374,9 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result.number).equal(blockNumber);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
     expect(result.timestamp).equal(firstTransactionTimestampSeconds);
+    expect(result.transactions.length).equal(2);
+    expect((result.transactions[0] as string)).equal(contractHash1);
+    expect((result.transactions[1] as string)).equal(contractHash1);
 
     // verify expected constants
     expect(result.baseFeePerGas).equal(0);
@@ -335,6 +386,42 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result.mixHash).equal(EthImpl.emptyHex);
     expect(result.nonce).equal(EthImpl.emptyHex);
     expect(result.receiptsRoot).equal(EthImpl.emptyHex);
+    expect(result.sha3Uncles).equal(EthImpl.emptyArrayHex);
+    expect(result.stateRoot).equal(EthImpl.emptyHex);
+    expect(result.totalDifficulty).equal(EthImpl.zeroHex);
+    expect(result.uncles).to.deep.equal([]);
+  });
+
+  it('eth_getBlockByHash with match and details', async function () {
+    // mirror node request mocks
+    mock.onGet(`blocks/${blockHash}`).reply(200, defaultBlock);
+    mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultContractResults);
+    mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResultsWithNullNullableValues);
+    mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResultsWithNullNullableValues);
+
+    const result = await ethImpl.getBlockByHash(blockHash, true);
+    expect(result).to.exist;
+
+    // verify aggregated info
+    expect(result.hash).equal(blockHashTrimmed);
+    expect(result.gasUsed).equal(totalGasUsed);
+    expect(result.gasLimit).equal(maxGasLimit);
+    expect(result.number).equal(blockNumber);
+    expect(result.parentHash).equal(blockHashPreviousTrimmed);
+    expect(result.timestamp).equal(firstTransactionTimestampSeconds);
+    expect(result.transactions.length).equal(2);
+    expect((result.transactions[0] as Transaction).hash).equal(contractHash1);
+    expect((result.transactions[1] as Transaction).hash).equal(contractHash1);
+
+    // verify expected constants
+    expect(result.baseFeePerGas).equal(0);
+    expect(result.difficulty).equal(EthImpl.zeroHex);
+    expect(result.extraData).equal(EthImpl.emptyHex);
+    expect(result.miner).equal(EthImpl.emptyHex);
+    expect(result.mixHash).equal(EthImpl.emptyHex);
+    expect(result.nonce).equal(EthImpl.emptyHex);
+    expect(result.receiptsRoot).equal(EthImpl.emptyHex);
+    expect(result.sha3Uncles).equal(EthImpl.emptyArrayHex);
     expect(result.sha3Uncles).equal(EthImpl.emptyArrayHex);
     expect(result.stateRoot).equal(EthImpl.emptyHex);
     expect(result.totalDifficulty).equal(EthImpl.zeroHex);
@@ -845,6 +932,39 @@ describe('Eth', async function () {
       expect(result.nonce).to.eq(defaultTransaction.nonce);
       expect(result.r).to.eq(defaultTransaction.r);
       expect(result.s).to.eq(defaultTransaction.s);
+      expect(result.to).to.eq(defaultTransaction.to);
+      expect(result.transactionIndex).to.eq(defaultTransaction.transactionIndex);
+      expect(result.type).to.eq(defaultTransaction.type);
+      expect(result.v).to.eq(defaultTransaction.v);
+      expect(result.value).to.eq(defaultTransaction.value);
+    });
+
+    it('returns correct transaction for existing hash w no sigs', async function () {
+      // mirror node request mocks
+      const detailedResultsWithNullNullableValues = {
+        ...defaultDetailedContractResultByHash,
+        r: null,
+        s: null
+      };
+
+      mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, detailedResultsWithNullNullableValues);
+      const result = await ethImpl.getTransactionByHash(defaultTxHash);
+
+      expect(result).to.exist;
+      expect(result.accessList).to.eq(defaultTransaction.accessList);
+      expect(result.blockHash).to.eq(defaultTransaction.blockHash);
+      expect(result.blockNumber).to.eq(`0x${defaultTransaction.blockNumber.toString(16)}`);
+      expect(result.chainId).to.eq(defaultTransaction.chainId);
+      expect(result.from).to.eq(defaultTransaction.from);
+      expect(result.gas).to.eq(defaultTransaction.gas);
+      expect(result.gasPrice).to.eq(defaultTransaction.gasPrice);
+      expect(result.hash).to.eq(defaultTransaction.hash);
+      expect(result.input).to.eq(defaultTransaction.input);
+      expect(result.maxFeePerGas).to.eq(defaultTransaction.maxFeePerGas);
+      expect(result.maxPriorityFeePerGas).to.eq(defaultTransaction.maxPriorityFeePerGas);
+      expect(result.nonce).to.eq(defaultTransaction.nonce);
+      expect(result.r).to.be.null;
+      expect(result.s).to.be.null;
       expect(result.to).to.eq(defaultTransaction.to);
       expect(result.transactionIndex).to.eq(defaultTransaction.transactionIndex);
       expect(result.type).to.eq(defaultTransaction.type);


### PR DESCRIPTION
**Description**:
Previewnet testing highlighted scenarios where the r and s signatures were not set, as well as the fact that transactions in blocks weren't getting set.

- Guard against unset r and s signatures
- Replace async foreach with simple for and async to ensure transactions are set
- Split block caching logic out from Block Model

**Related issue(s)**:

Fixes #97 

**Notes for reviewer**:
The Block caching logic should see an update that queries the mirror node based on transaction hash.
The exact response for a duplicate transaction needs to be considered.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
