### PR TITLE
Add cost call to avoid insufficient fee issue

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -93,7 +93,7 @@ export class SDKClient {
     }
 
     async getRecord(transactionResponse: TransactionResponse) {
-      return transactionResponse.getRecord(this.clientMain);
+        return transactionResponse.getRecord(this.clientMain);
     }
 
     async submitEthereumTransaction(transactionBuffer: Uint8Array): Promise<TransactionResponse> {
@@ -109,10 +109,14 @@ export class SDKClient {
             ? ContractId.fromSolidityAddress(contract)
             : ContractId.fromEvmAddress(0, 0, contract);
 
-        return (new ContractCallQuery()
+        const contractCallQuery = new ContractCallQuery()
             .setContractId(contractId)
             .setFunctionParameters(Buffer.from(callData, 'hex'))
-            .setGas(gas))
+            .setGas(gas);
+
+        const cost = await contractCallQuery.getCost(this.clientMain);
+        return (contractCallQuery)
+            .setQueryPayment(cost)
             .execute(this.clientMain);
     }
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -307,14 +307,14 @@ export class EthImpl implements Eth {
     //        the mirror nodes need to have the ability to give me the **CURRENT**
     //        account balance *and* the account balance for any given block.
     this.logger.trace('getBalance(account=%s, blockNumberOrTag=%s)', account, blockNumberOrTag);
-    const blockNumber = this.translateBlockTag(blockNumberOrTag);
+    const blockNumber = await this.translateBlockTag(blockNumberOrTag);
     try {
       const weibars = await this.sdkClient.getAccountBalanceInWeiBar(account);
       return EthImpl.numberTo0x(weibars);
     } catch (e: any) {
       // handle INVALID_ACCOUNT_ID
       if (e?.status?._code === Status.InvalidAccountId._code) {
-        this.logger.debug('Unable to find account %s in block "%s", returning 0x0 balance', account, blockNumber);
+        this.logger.debug(`Unable to find account ${account} in block ${JSON.stringify(blockNumber)}(${blockNumberOrTag}), returning 0x0 balance`);
         return EthImpl.zeroHex;
       }
 


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Contract Calls were failing with insufficient fees and were blocking token transfers

- Add cost query logic
- Set query payment to this amount

**Related issue(s)**:

Fixes #107 

**Notes for reviewer**:
We could explore setting this as a max or even less but lets start here to unblock us.
Test against preview net with local instance

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
