### PR TITLE
chore: remove duplicate restart policy from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     ports:
       - 7546:7546
     pull_policy: always    
-    restart: unless-stopped
     tty: true
     volumes:
       - ./.env.sample:/home/node/app/.env.sample


### PR DESCRIPTION
**Description**:
Removes duplicate restart policy entry in the docker-compose file.

**Related issue(s)**:

Fixes: #153 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
