### PR TITLE
Remove org path from artifact build command

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Build and push images
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{env.TAG}}
+      
       - name: Produce artifact
         run: tar -czf hedera-json-rpc-relay.tgz -C ./packages . 
 
@@ -41,12 +50,3 @@ jobs:
           name: ${{ env.MODULE }}
           path: ./*.tgz
           if-no-files-found: error
-
-      - name: Build and push images
-        uses: docker/build-push-action@v2
-        with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64, linux/arm64
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{env.TAG}}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Produce artifact
-        run: tar -czf ${{ github.repository }}.tgz -C ./packages . 
+        run: tar -czf hedera-json-rpc-relay.tgz -C ./packages . 
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
- Use explicit package name instead of full org path
- Move docker build flow above npm package in terms of priority

**Related issue(s)**:

Fixes #159 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
