### PR TITLE
Expand acceptance test to query external nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1794,7 +1794,6 @@
         "node_modules/@babel/runtime": {
             "version": "7.18.3",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "regenerator-runtime": "^0.13.4"
             },
@@ -9430,6 +9429,16 @@
                 "axios": ">= 0.9.0"
             }
         },
+        "node_modules/axios-retry": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.5.tgz",
+            "integrity": "sha512-a8umkKbfIkTiYJQLx3v3TzKM85TGKB8ZQYz4zwykt2fpO64TsRlUhjaPaAb3fqMWCXFm2YhWcd8V5FHDKO9bSA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/runtime": "^7.15.4",
+                "is-retry-allowed": "^2.2.0"
+            }
+        },
         "node_modules/axios/node_modules/form-data": {
             "version": "4.0.0",
             "license": "MIT",
@@ -14058,6 +14067,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-retry-allowed": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+            "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-root": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
@@ -18328,8 +18349,7 @@
         },
         "node_modules/regenerator-runtime": {
             "version": "0.13.9",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.0",
@@ -21576,6 +21596,7 @@
                 "@types/koa-router": "^7.4.4",
                 "@types/mocha": "^9.1.0",
                 "@types/node": "^17.0.31",
+                "axios-retry": "^3.2.5",
                 "chai": "^4.3.6",
                 "shelljs": "^0.8.5",
                 "ts-mocha": "^9.0.2",
@@ -23280,7 +23301,6 @@
         },
         "@babel/runtime": {
             "version": "7.18.3",
-            "peer": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
             }
@@ -26335,6 +26355,7 @@
                 "@types/mocha": "^9.1.0",
                 "@types/node": "^17.0.31",
                 "axios": "^0.27.2",
+                "axios-retry": "^3.2.5",
                 "chai": "^4.3.6",
                 "dotenv": "^16.0.0",
                 "koa": "^2.13.4",
@@ -29871,6 +29892,16 @@
                 "is-buffer": "^2.0.5"
             }
         },
+        "axios-retry": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.5.tgz",
+            "integrity": "sha512-a8umkKbfIkTiYJQLx3v3TzKM85TGKB8ZQYz4zwykt2fpO64TsRlUhjaPaAb3fqMWCXFm2YhWcd8V5FHDKO9bSA==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.15.4",
+                "is-retry-allowed": "^2.2.0"
+            }
+        },
         "babel-plugin-dynamic-import-node": {
             "version": "2.3.3",
             "peer": true,
@@ -32917,6 +32948,12 @@
                 "has-tostringtag": "^1.0.0"
             }
         },
+        "is-retry-allowed": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+            "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+            "dev": true
+        },
         "is-root": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
@@ -35841,8 +35878,7 @@
             }
         },
         "regenerator-runtime": {
-            "version": "0.13.9",
-            "peer": true
+            "version": "0.13.9"
         },
         "regenerator-transform": {
             "version": "0.15.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,6 +30,7 @@
         "@types/koa-router": "^7.4.4",
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.31",
+        "axios-retry": "^3.2.5",
         "chai": "^4.3.6",
         "shelljs": "^0.8.5",
         "ts-mocha": "^9.0.2",


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Current acceptance test axios mirror node client and SDK clients always point locally.

- Add logic to configure SDK network accordingly
- Add logic to pick up MIRROR_NODE_URL environment variable
- Add axios-retry package to allow for retries since Mirror node won't immediately get info

**Related issue(s)**:

Fixes #169 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
