### PR TITLE
Cache eth_feeHistory inner value

### DIFF
--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -19,7 +19,8 @@
   */
 
 enum CACHE_KEY {
-    GAS_PRICE = 'gas_price'
+    GAS_PRICE = 'gas_price',
+    FEE_HISTORY = 'fee_history'
 }
 enum CACHE_TTL {
     ONE_HOUR = 3_600_000

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -127,7 +127,7 @@ export class EthImpl implements Eth {
    * Gets the fee history.
    */
   async feeHistory(blockCount: number, newestBlock: string, rewardPercentiles: Array<number> | null) {
-    this.logger.trace('feeHistory()');
+    this.logger.trace(`feeHistory(blockCount=${blockCount}, newestBlock=${newestBlock}, rewardPercentiles=${rewardPercentiles})`);
     try {
       let feeHistory: object | undefined = cache.get(constants.CACHE_KEY.FEE_HISTORY);
       if (!feeHistory) {
@@ -141,7 +141,7 @@ export class EthImpl implements Eth {
 
       return feeHistory;
     } catch (e) {
-      this.logger.trace(e);
+      this.logger.error(e, 'Error constructing default feeHistory');
     }
   }
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -27,6 +27,7 @@ dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 import { RelayImpl } from '@hashgraph/json-rpc-relay';
 import { EthImpl } from '../../src/lib/eth';
 import { MirrorNodeClient } from '../../src/lib/clients/mirrorNodeClient';
+import { MirrorNode } from '../../src/lib/mirrorNode';
 import {expectUnsupportedMethod} from '../helpers';
 
 const cache = require('js-cache');
@@ -81,7 +82,7 @@ describe('Eth calls using MirrorNode', async function () {
   // @ts-ignore
   const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), instance);
   // @ts-ignore
-  const ethImpl = new EthImpl(null, null, mirrorNodeInstance, logger, '0x12a');
+  const ethImpl = new EthImpl(null, new MirrorNode(logger.child({ name: `mirror-node-faux` })), mirrorNodeInstance, logger, '0x12a');
 
   const blockHashTrimmed = '0x3c08bbbee74d287b1dcd3f0ca6d1d2cb92c90883c4acf9747de9f3f3162ad25b';
   const blockHash = `${blockHashTrimmed}999fc7e86699f60f2a3fb3ed9a646c6b`;  
@@ -882,6 +883,34 @@ describe('Eth calls using MirrorNode', async function () {
       expectLogData1(result[0]);
       expectLogData2(result[1]);
     });
+  });
+
+  it('eth_feeHistory', async function() {
+    mock.onGet(`network/fees`).reply(200, defaultNetworkFees);
+    const feeHistory = await ethImpl.feeHistory(1, 'latest', [25, 75]);
+    expect(feeHistory).to.exist;
+    expect(feeHistory['baseFeePerGasArray'][0]).to.equal('0x84b6a5c400');
+    expect(feeHistory['gasUsedRatioArray'][0]).to.equal('0.5');
+    expect(feeHistory['oldestBlockNumber']).to.equal('0x0');
+    const rewards = feeHistory['reward'][0];
+    expect(rewards[0]).to.equal('0x0');
+    expect(rewards[1]).to.equal('0x0');
+  });
+
+  it('eth_feeHistory verify cached value', async function() {
+    mock.onGet(`network/fees`).reply(200, defaultNetworkFees);
+    const firstFeeHistory = await ethImpl.feeHistory(1, 'latest', [25, 75]);
+    expect(firstFeeHistory).to.exist;
+    expect(firstFeeHistory['baseFeePerGasArray'][0]).to.equal('0x84b6a5c400');
+    expect(firstFeeHistory['gasUsedRatioArray'][0]).to.equal('0.5');
+    expect(firstFeeHistory['oldestBlockNumber']).to.equal('0x0');
+    const rewards = firstFeeHistory['reward'][0];
+    expect(rewards[0]).to.equal('0x0');
+    expect(rewards[1]).to.equal('0x0');
+
+    const secondFeeHistory = await ethImpl.feeHistory(2, 'latest', [25, 75]);
+
+    expect(firstFeeHistory).to.equal(secondFeeHistory);
   });
 
   it('eth_gasPrice', async function() {


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Given the fees don't change much we should cache the result for some time

- Add a cache key for feeHistory
- Add tests

**Related issue(s)**:

Fixes #174

**Notes for reviewer**:
Tested local instance against previewnet

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
