### PR TITLE
Fix latency metric capture logic

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -49,7 +49,7 @@ const register = new Registry();
 collectDefaultMetrics({ register, prefix: 'rpc_relay_' });
 
 const methodResponseHistogram = new Histogram({
-  name: 'rpc_relay_method_response_histogram',
+  name: 'rpc_relay_method_response',
   help: 'JSON RPC method statusCode latency histogram',
   labelNames: ['method', 'statusCode'],
   registers: [register]

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -21,7 +21,7 @@
 import { Relay, RelayImpl, JsonRpcError } from '@hashgraph/json-rpc-relay';
 import Koa from 'koa';
 import koaJsonRpc from 'koa-jsonrpc';
-import { collectDefaultMetrics, Counter, Histogram, Registry } from 'prom-client';
+import { collectDefaultMetrics, Histogram, Registry } from 'prom-client';
 
 import pino from 'pino';
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -50,8 +50,8 @@ collectDefaultMetrics({ register, prefix: 'rpc_relay_' });
 
 const methodResponseHistogram = new Histogram({
   name: 'rpc_relay_method_response_histogram',
-  help: 'JSON RPC method status latency histogram',
-  labelNames: ['method', 'status'],
+  help: 'JSON RPC method statusCode latency histogram',
+  labelNames: ['method', 'statusCode'],
   registers: [register]
 });
 


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Capture latency correctly in prom-client

- remove latency from counter
- add latency to histogram


**Related issue(s)**:

Fixes #176 

**Notes for reviewer**:
Tested against previewnet and wallet

Example output
```
# HELP rpc_relay_method_response_hist JSON RPC method status latency histogram
# TYPE rpc_relay_method_response_hist histogram
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_blockNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_blockNumber",status="200"} 8
rpc_relay_method_response_hist_sum{method="eth_blockNumber",status="200"} 3086
rpc_relay_method_response_hist_count{method="eth_blockNumber",status="200"} 8
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_getBlockByNumber",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_getBlockByNumber",status="200"} 6
rpc_relay_method_response_hist_sum{method="eth_getBlockByNumber",status="200"} 1656
rpc_relay_method_response_hist_count{method="eth_getBlockByNumber",status="200"} 6
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_getBalance",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_getBalance",status="200"} 44
rpc_relay_method_response_hist_sum{method="eth_getBalance",status="200"} 2084
rpc_relay_method_response_hist_count{method="eth_getBalance",status="200"} 44
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_feeHistory",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_feeHistory",status="200"} 18
rpc_relay_method_response_hist_sum{method="eth_feeHistory",status="200"} 8887
rpc_relay_method_response_hist_count{method="eth_feeHistory",status="200"} 18
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="1",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="5",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="10",method="eth_gasPrice",status="200"} 3
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_gasPrice",status="200"} 4
rpc_relay_method_response_hist_sum{method="eth_gasPrice",status="200"} 375
rpc_relay_method_response_hist_count{method="eth_gasPrice",status="200"} 4
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_call",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_call",status="200"} 8
rpc_relay_method_response_hist_sum{method="eth_call",status="200"} 732
rpc_relay_method_response_hist_count{method="eth_call",status="200"} 8
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_call",status="-32603"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_call",status="-32603"} 15
rpc_relay_method_response_hist_sum{method="eth_call",status="-32603"} 1262
rpc_relay_method_response_hist_count{method="eth_call",status="-32603"} 15
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="1",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="5",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="10",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_sum{method="eth_estimateGas",status="200"} 0
rpc_relay_method_response_hist_count{method="eth_estimateGas",status="200"} 4
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_getTransactionCount",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_getTransactionCount",status="200"} 2
rpc_relay_method_response_hist_sum{method="eth_getTransactionCount",status="200"} 169
rpc_relay_method_response_hist_count{method="eth_getTransactionCount",status="200"} 2
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_sendRawTransaction",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_sendRawTransaction",status="200"} 2
rpc_relay_method_response_hist_sum{method="eth_sendRawTransaction",status="200"} 6445
rpc_relay_method_response_hist_count{method="eth_sendRawTransaction",status="200"} 2
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_getCode",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_getCode",status="200"} 1
rpc_relay_method_response_hist_sum{method="eth_getCode",status="200"} 52
rpc_relay_method_response_hist_count{method="eth_getCode",status="200"} 1
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_getTransactionReceipt",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_getTransactionReceipt",status="200"} 2
rpc_relay_method_response_hist_sum{method="eth_getTransactionReceipt",status="200"} 445
rpc_relay_method_response_hist_count{method="eth_getTransactionReceipt",status="200"} 2
rpc_relay_method_response_hist_bucket{le="0.005",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.01",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.025",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.05",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.1",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.25",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="0.5",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="1",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="2.5",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="5",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="10",method="eth_getBlockByHash",status="200"} 0
rpc_relay_method_response_hist_bucket{le="+Inf",method="eth_getBlockByHash",status="200"} 2
rpc_relay_method_response_hist_sum{method="eth_getBlockByHash",status="200"} 965
rpc_relay_method_response_hist_count{method="eth_getBlockByHash",status="200"} 2
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
