### PR TITLE
Fix transactionsRoot return value in case of empty transactions array

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -52,6 +52,7 @@ export class EthImpl implements Eth {
   static defaultGas = 0x3d0900;
   static ethTxType = 'EthereumTransaction';
   static ethFunctionalityCode = 84;
+  static ethEmptyTrie = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421';
 
   /**
    * The sdk client use for connecting to both the consensus nodes and mirror node. The account
@@ -805,6 +806,7 @@ export class EthImpl implements Eth {
     }
 
     const blockHash = blockResponse.hash.substring(0, 66);
+    const transactionArray = showDetails ? transactionObjects : transactionHashes;
     return new Block({
       baseFeePerGas: EthImpl.numberTo0x(0), //TODO should be gasPrice
       difficulty: EthImpl.zeroHex,
@@ -824,8 +826,8 @@ export class EthImpl implements Eth {
       size: EthImpl.numberTo0x(blockResponse.size | 0),
       stateRoot: EthImpl.emptyArrayHex,
       totalDifficulty: EthImpl.zeroHex,
-      transactions: showDetails ? transactionObjects : transactionHashes,
-      transactionsRoot: blockHash,
+      transactions: transactionArray,
+      transactionsRoot: transactionArray.length == 0 ? EthImpl.ethEmptyTrie : blockHash,
       uncles: [],
     });
   }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -390,7 +390,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
-    expect(result.gasUsed).equal(0);
+    expect(result.gasUsed).equal('0x0');
     expect(result.gasLimit).equal(maxGasLimitHex);
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -381,7 +381,7 @@ describe('Eth calls using MirrorNode', async function () {
   it('eth_getBlockByNumber with zero transactions', async function () {
     // mirror node request mocks
     mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
-    mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultEmptyContractResults);
+    mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultContractResults);
     mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultEmptyContractResults);
     mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultEmptyContractResults);
     const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -385,7 +385,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result.gasLimit).equal('0x0');
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
-    expect(result.timestamp).equal(firstTransactionTimestampSecondsHex);
+    expect(result.timestamp).equal('0x0');
     expect(result.transactions.length).equal(0);
     expect(result.transactionsRoot).equal(EthImpl.ethEmptyTrie);
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -216,13 +216,6 @@ describe('Eth calls using MirrorNode', async function () {
     'v': 1
   };
 
-  const defaultEmptyContractResults = {
-    'results': [],
-    'links': {
-      'next': '/api/v1/contracts/results?limit=2&timestamp=lt:1653077542.701408897'
-    }
-  };
-
   const defaultDetailedContractResults2 = {...defaultDetailedContractResults, ...{
     'timestamp': contractTimestamp2,
     'block_hash': blockHash2,
@@ -382,8 +375,6 @@ describe('Eth calls using MirrorNode', async function () {
     // mirror node request mocks
     mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
     mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, { 'results': []});
-    mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultEmptyContractResults);
-    mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultEmptyContractResults);
     const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
     expect(result).to.exist;
     if (result == null) return;
@@ -391,7 +382,7 @@ describe('Eth calls using MirrorNode', async function () {
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
     expect(result.gasUsed).equal('0x0');
-    expect(result.gasLimit).equal(maxGasLimitHex);
+    expect(result.gasLimit).equal('0x0');
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
     expect(result.timestamp).equal(firstTransactionTimestampSecondsHex);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -390,7 +390,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
-    expect(result.gasUsed).equal(totalGasUsed);
+    expect(result.gasUsed).equal(0);
     expect(result.gasLimit).equal(maxGasLimitHex);
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -381,7 +381,7 @@ describe('Eth calls using MirrorNode', async function () {
   it('eth_getBlockByNumber with zero transactions', async function () {
     // mirror node request mocks
     mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
-    mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultContractResults);
+    mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, { 'results': []});
     mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultEmptyContractResults);
     mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultEmptyContractResults);
     const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);


### PR DESCRIPTION
Signed-off-by: Mitchell Martin <mitch@swirldslabs.com>

**Description**:
Return the [proper transactionRoot](https://eth.wiki/json-rpc/API#:~:text=%22transactionsRoot%22%3A%20%220x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421%22%2C) if no transactions exist (instead of blockhash). 

**Related issue(s)**:

Fixes #179

**Result with correct transactionsRoot**:
```
curl -X POST http://localhost:7546 \
                                        -H 'Content-Type: application/json' \
                                        -d '{"id":"2","jsonrpc":"2.0","method":"eth_getBlockByNumber","params":[21370223,true]}' --silent | jq
{
  "result": {
    "timestamp": "0x0",
    "difficulty": "0x0",
    "extraData": "0x",
    "gasLimit": "0x0",
    "baseFeePerGas": "0x0",
    "gasUsed": "0x0",
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "miner": "0x0000000000000000000000000000000000000000",
    "mixHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "nonce": "0x0000000000000000",
    "receiptsRoot": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "sha3Uncles": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "size": "0x0",
    "stateRoot": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
    "totalDifficulty": "0x0",
    "transactions": [],
    "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
    "uncles": [],
    "number": "0x146156f",
    "hash": "0x7983627d806b9888f818591ebb4dee99ceec9f9e3808f6e4ee0e85ccd9309fad",
    "parentHash": "0x60fa091d11691db6f2cf05bd30359384c71e51c32f69fa2ea9ca27f350d5d59c"
  },
  "jsonrpc": "2.0",
  "id": "2"
}
```