### PR TITLE
Improve startup logs

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -111,27 +111,26 @@ export class MirrorNodeClient {
         }
 
         this.logger = logger;
-        this.logger.info("Restarting.");
+        this.logger.info(`Mirror Node client successfully configured to ${this.baseUrl}`);
     }
 
     async request(path: string, allowedErrorStatuses?: number[]): Promise<any> {
         try {
-            this.logger.debug(`Mirror Request: ${path}`);
             const response = await this.client.get(path);
+            this.logger.debug(`Mirror Node Response: [GET] ${path} ${response.status}`);
             return response.data;
         } catch (error) {
-            this.handleError(error, allowedErrorStatuses);
+            this.handleError(error, path, allowedErrorStatuses);
         }
         return null;
     }
 
-    handleError(error: any, allowedErrorStatuses?: number[]) {
+    handleError(error: any, path: string, allowedErrorStatuses?: number[]) {
         if (allowedErrorStatuses && allowedErrorStatuses.length) {
-            if (error.response && allowedErrorStatuses.indexOf(error.response.status) === -1) {
-                throw error;
+            if (error.response && allowedErrorStatuses.indexOf(error.response.status) !== -1) {
+                this.logger.debug(`Mirror Node Response: [GET] ${path} ${error.response.status} status`);
+                return null;
             }
-
-            return null;
         }
 
         this.logger.error(error, 'Unexpected request error');

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -765,7 +765,8 @@ export class EthImpl implements Eth {
     } else {
       blockResponse = await this.mirrorNodeClient.getBlock(blockHashOrNumber);
     }
-    if (blockResponse.hash === undefined) {
+    
+    if (_.isNil(blockResponse) || blockResponse.hash === undefined) {
       // block not found
       return null;
     }

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -43,13 +43,15 @@ export class RelayImpl implements Relay {
 
   constructor(logger: Logger) {
     dotenv.config({ path: findConfig('.env') || '' });
+    logger.info('Configurations successully loaded');
+
     const hederaNetwork: string = process.env.HEDERA_NETWORK || '{}';
 
     const configuredChainId =
       process.env.CHAIN_ID || RelayImpl.chainIds[hederaNetwork] || '298';
     const chainId = EthImpl.prepend0x(Number(configuredChainId).toString(16));
 
-    this.clientMain = this.initClient(hederaNetwork);
+    this.clientMain = this.initClient(logger, hederaNetwork);
 
     this.web3Impl = new Web3Impl(this.clientMain);
     this.netImpl = new NetImpl(this.clientMain, chainId);
@@ -85,13 +87,15 @@ export class RelayImpl implements Relay {
     return this.ethImpl;
   }
 
-  initClient(hederaNetwork: string, type: string | null = null): Client {
+  initClient(logger: Logger, hederaNetwork: string, type: string | null = null): Client {
     let client: Client;
     if (hederaNetwork.toLowerCase() in RelayImpl.chainIds) {
       client = Client.forName(hederaNetwork);
     } else {
       client = Client.forNetwork(JSON.parse(hederaNetwork));
     }
+    
+    logger.info(`SDK client successfully configured to ${JSON.stringify(hederaNetwork)}`);
 
     switch (type) {
       case 'eth_sendRawTransaction': {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1169,9 +1169,16 @@ describe('Eth', async function () {
   describe('eth_getTransactionReceipt', async function () {
     it('returns `null` for non-existent hash', async function () {
       const txHash = '0x0000000000000000000000000000000000000000000000000000000000000001';
-      const txId = cache.get(txHash);
-      expect(txId).to.not.exist;
-      const receipt = await Relay.eth().getTransactionReceipt(txHash);
+      mock.onGet(`contracts/results/${txHash}`).reply(404, {
+        '_status': {
+          'messages': [
+            {
+              'message': 'No correlating transaction'
+            }
+          ]
+        }
+      });
+      const receipt = await ethImpl.getTransactionReceipt(txHash);
       expect(receipt).to.be.null;
     });
 
@@ -1229,7 +1236,7 @@ describe('Eth', async function () {
         }
       });
 
-      const result = await ethImpl.getTransactionByHash('0x4444444444444444444444444444444444444444444444444444444444444444');
+      const result = await ethImpl.getTransactionByHash(defaultTxHash);
       expect(result).to.equal(null);
     });
 

--- a/packages/server/tests/server.spec.ts
+++ b/packages/server/tests/server.spec.ts
@@ -316,29 +316,6 @@ describe('RPC Server', async function() {
 
     BaseTest.unsupportedJsonRpcMethodChecks(res);
   });
-
-  it('should execute "eth_getLogs"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_getLogs',
-      'params': [null]
-    });
-
-    BaseTest.defaultResponseChecks(res);
-    expect(res.data.result.length).to.be.gte(0);
-    if (res.data.result.length) {
-      expect(res.data.result[0]).to.have.property('address');
-      expect(res.data.result[0]).to.have.property('blockHash');
-      expect(res.data.result[0]).to.have.property('blockNumber');
-      expect(res.data.result[0]).to.have.property('data');
-      expect(res.data.result[0]).to.have.property('logIndex');
-      expect(res.data.result[0]).to.have.property('removed');
-      expect(res.data.result[0]).to.have.property('topics');
-      expect(res.data.result[0]).to.have.property('transactionHash');
-      expect(res.data.result[0]).to.have.property('transactionIndex');
-    }
-  });
 });
 
 class BaseTest {


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Make startup logs more informative to relay configuration
- Add log for mirror node endpoint
- Add log for consensus node endpoint
- Add response log for Mirror Node calls
- Simplify mirror error response handling
- Remove getLogs server tests as it's not properly set up to work without proper mirror node mocking. COverage already in eth.spec.ts and acceptance tests

**Related issue(s)**:

Fixes #186 

**Notes for reviewer**:
Could add sdkclient response calls but might need a refactor to make it easier and in one place like i did for acceptance tests.
Also generally SDKCLient calls pas or fail, they don't do supported errors

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
