### PR TITLE
Acceptance tests for eth_getTransactionReceipt

### DIFF
--- a/packages/server/tests/acceptance.spec.ts
+++ b/packages/server/tests/acceptance.spec.ts
@@ -19,10 +19,7 @@
  */
 
 // external resources
-import {
-    Client,
-    PrivateKey,
-} from "@hashgraph/sdk";
+import { Client } from "@hashgraph/sdk";
 import Axios from 'axios';
 import axiosRetry from 'axios-retry';
 import { expect } from 'chai';
@@ -103,7 +100,6 @@ let mirrorSecondaryAccount;
 let ethCompPrivateKey3;
 let ethCompAccountInfo3;
 let ethCompAccountEvmAddr3;
-let ethCompNonce = 0;
 
 describe('RPC Server Integration Tests', async function () {
     this.timeout(180 * 1000);
@@ -401,7 +397,6 @@ describe('RPC Server Integration Tests', async function () {
         expect(utils.subtractBigNumberHexes(senderInitialBalance, senderEndBalance).toHexString()).to.not.eq(oneHbarInWeiHexString);
         expect(BigNumber.from(senderInitialBalance).sub(BigNumber.from(senderEndBalance)).gt(0)).to.eq(true);
 
-        ethCompNonce++;
     });
 
     it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions', async function () {
@@ -409,7 +404,7 @@ describe('RPC Server Integration Tests', async function () {
         const signedTx = await utils.signRawTransaction({
             ...defaultLegacy2930TransactionData,
             to: mirrorContract.evm_address,
-            nonce: ethCompNonce
+            nonce: await utils.getAccountNonce(ethCompAccountEvmAddr3)
         }, ethCompPrivateKey3);
 
         const res = await utils.callFailingRelayMethod(this.relayClient, 'eth_sendRawTransaction', [signedTx]);
@@ -426,7 +421,7 @@ describe('RPC Server Integration Tests', async function () {
         const signedTx = await utils.signRawTransaction({
             ...defaultLondonTransactionData,
             to: mirrorContract.evm_address,
-            nonce: ethCompNonce
+            nonce:  await utils.getAccountNonce(ethCompAccountEvmAddr3)
         }, ethCompPrivateKey3);
 
         const res = await utils.callSupportedRelayMethod(this.relayClient, 'eth_sendRawTransaction', [signedTx]);
@@ -441,8 +436,6 @@ describe('RPC Server Integration Tests', async function () {
         expect(senderInitialBalance).to.not.eq(senderEndBalance);
         expect(utils.subtractBigNumberHexes(senderInitialBalance, senderEndBalance).toHexString()).to.not.eq(oneHbarInWeiHexString);
         expect(BigNumber.from(senderInitialBalance).sub(BigNumber.from(senderEndBalance)).gt(0)).to.eq(true);
-
-        ethCompNonce++;
     });
 
     it('should execute "eth_syncing"', async function () {
@@ -498,12 +491,11 @@ describe('RPC Server Integration Tests', async function () {
         const txRequest = {
             ...defaultLegacyTransactionData,
             to: mirrorContract.evm_address,
-            nonce: ethCompNonce
+            nonce: await utils.getAccountNonce(ethCompAccountEvmAddr3)
         };
         const signedTx = await utils.signRawTransaction(txRequest, ethCompPrivateKey3);
         const txRes = await utils.callSupportedRelayMethod(this.relayClient, 'eth_sendRawTransaction', [signedTx]);
         expect(txRes.data.result).to.be.not.be.null;
-        ethCompNonce++;
 
         await utils.sleep(3000);
 
@@ -520,13 +512,12 @@ describe('RPC Server Integration Tests', async function () {
         const txRequest = {
             ...defaultLondonTransactionData,
             to: mirrorContract.evm_address,
-            nonce: ethCompNonce
+            nonce: await utils.getAccountNonce(ethCompAccountEvmAddr3)
         };
 
         const signedTx = await utils.signRawTransaction(txRequest, ethCompPrivateKey3);
         const londonRes = await utils.callSupportedRelayMethod(this.relayClient, 'eth_sendRawTransaction', [signedTx]);
         expect(londonRes.data.result).to.be.not.be.null;
-        ethCompNonce++;
 
         await utils.sleep(3000);
 

--- a/packages/server/tests/acceptance.spec.ts
+++ b/packages/server/tests/acceptance.spec.ts
@@ -493,15 +493,9 @@ describe('RPC Server Integration Tests', async function () {
             to: mirrorContract.evm_address,
             nonce: await utils.getAccountNonce(ethCompAccountEvmAddr3)
         };
-        const signedTx = await utils.signRawTransaction(txRequest, ethCompPrivateKey3);
-        const txRes = await utils.callSupportedRelayMethod(this.relayClient, 'eth_sendRawTransaction', [signedTx]);
-        expect(txRes.data.result).to.be.not.be.null;
-
+        const submittedLegacyTransactionHash = await utils.sendRawTransaction(txRequest, ethCompPrivateKey3);
         await utils.sleep(3000);
-
-        const submittedLegacyTransactionHash = txRes.data.result;
         const res = await utils.callSupportedRelayMethod(this.relayClient, 'eth_getTransactionReceipt', [submittedLegacyTransactionHash]);
-
         utils.assertTransactionReceipt(res.data.result, txRequest, {
             from: ethCompAccountEvmAddr3
         });
@@ -514,16 +508,9 @@ describe('RPC Server Integration Tests', async function () {
             to: mirrorContract.evm_address,
             nonce: await utils.getAccountNonce(ethCompAccountEvmAddr3)
         };
-
-        const signedTx = await utils.signRawTransaction(txRequest, ethCompPrivateKey3);
-        const londonRes = await utils.callSupportedRelayMethod(this.relayClient, 'eth_sendRawTransaction', [signedTx]);
-        expect(londonRes.data.result).to.be.not.be.null;
-
+        const submittedLondonTransactionHash = await utils.sendRawTransaction(txRequest, ethCompPrivateKey3);
         await utils.sleep(3000);
-
-        const submittedLegacyTransactionHash = londonRes.data.result;
-        const res = await utils.callSupportedRelayMethod(this.relayClient, 'eth_getTransactionReceipt', [submittedLegacyTransactionHash]);
-
+        const res = await utils.callSupportedRelayMethod(this.relayClient, 'eth_getTransactionReceipt', [submittedLondonTransactionHash]);
         utils.assertTransactionReceipt(res.data.result, txRequest, {
             from: ethCompAccountEvmAddr3
         });

--- a/packages/server/tests/acceptance.spec.ts
+++ b/packages/server/tests/acceptance.spec.ts
@@ -495,11 +495,12 @@ describe('RPC Server Integration Tests', async function () {
     });
 
     it('should execute "eth_getTransactionReceipt" for hash of legacy transaction', async function () {
-        const signedTx = await utils.signRawTransaction({
+        const txRequest = {
             ...defaultLegacyTransactionData,
             to: mirrorContract.evm_address,
             nonce: ethCompNonce
-        }, ethCompPrivateKey3);
+        };
+        const signedTx = await utils.signRawTransaction(txRequest, ethCompPrivateKey3);
         const txRes = await utils.callSupportedRelayMethod(this.relayClient, 'eth_sendRawTransaction', [signedTx]);
         expect(txRes.data.result).to.be.not.be.null;
         ethCompNonce++;
@@ -509,20 +510,20 @@ describe('RPC Server Integration Tests', async function () {
         const submittedLegacyTransactionHash = txRes.data.result;
         const res = await utils.callSupportedRelayMethod(this.relayClient, 'eth_getTransactionReceipt', [submittedLegacyTransactionHash]);
 
-        utils.assertReceiptNotNull(res.data.result);
+        utils.assertTransactionReceipt(res.data.result, txRequest, {
+            from: ethCompAccountEvmAddr3
+        });
 
-        expect(res.data.result.status).to.eq('0x1');
-        expect(res.data.result.from).to.eq(ethCompAccountEvmAddr3);
-        expect(res.data.result.to).to.eq(mirrorContract.evm_address);
-        expect(res.data.result.logs.length).to.eq(0);
     });
 
     it('should execute "eth_getTransactionReceipt" for hash of London transaction', async function () {
-        const signedTx = await utils.signRawTransaction({
+        const txRequest = {
             ...defaultLondonTransactionData,
             to: mirrorContract.evm_address,
             nonce: ethCompNonce
-        }, ethCompPrivateKey3);
+        };
+
+        const signedTx = await utils.signRawTransaction(txRequest, ethCompPrivateKey3);
         const londonRes = await utils.callSupportedRelayMethod(this.relayClient, 'eth_sendRawTransaction', [signedTx]);
         expect(londonRes.data.result).to.be.not.be.null;
         ethCompNonce++;
@@ -532,12 +533,9 @@ describe('RPC Server Integration Tests', async function () {
         const submittedLegacyTransactionHash = londonRes.data.result;
         const res = await utils.callSupportedRelayMethod(this.relayClient, 'eth_getTransactionReceipt', [submittedLegacyTransactionHash]);
 
-        utils.assertReceiptNotNull(res.data.result);
-
-        expect(res.data.result.status).to.eq('0x1');
-        expect(res.data.result.from).to.eq(ethCompAccountEvmAddr3);
-        expect(res.data.result.to).to.eq(mirrorContract.evm_address);
-        expect(res.data.result.logs.length).to.eq(0);
+        utils.assertTransactionReceipt(res.data.result, txRequest, {
+            from: ethCompAccountEvmAddr3
+        });
     });
 
     it('should execute "eth_getTransactionReceipt" for non-existing hash', async function () {

--- a/packages/server/tests/utils.ts
+++ b/packages/server/tests/utils.ts
@@ -355,12 +355,25 @@ export default class TestUtils {
         return new Promise(resolve => setTimeout(resolve, ms));
     };
 
-    getAccountNonce = async (evmAddress) => {
+    /**
+     * @param evmAddress
+     *
+     * Returns: The nonce of the account with the provided `evmAddress`
+     */
+    getAccountNonce = async (evmAddress): Promise<number> => {
         const nonce = await this.JsonRpcProvider.send('eth_getTransactionCount', [evmAddress, 'latest']);
         return Number(nonce);
     };
 
-    sendRawTransaction = async (tx, privateKey) => {
+    /**
+     * @param tx
+     * @param privateKey
+     * Signs a transaction request with the provided privateKey and sends it via `ethers.jsonRpcProvider`.
+     * This invokes the relay logic from eth.ts/sendRawTransaction.
+     *
+     * Returns: Transaction hash
+     */
+    sendRawTransaction = async (tx, privateKey): Promise<string> => {
         const signedTx = await this.signRawTransaction(tx, privateKey);
         return this.JsonRpcProvider.send('eth_sendRawTransaction', [signedTx]);
     };

--- a/packages/server/tests/utils.ts
+++ b/packages/server/tests/utils.ts
@@ -355,6 +355,11 @@ export default class TestUtils {
         return new Promise(resolve => setTimeout(resolve, ms));
     };
 
+    getAccountNonce = async (evmAddress) => {
+        const nonce = await this.JsonRpcProvider.send('eth_getTransactionCount', [evmAddress, 'latest']);
+        return Number(nonce);
+    };
+
     assertTransactionReceipt = (transactionReceipt, transactionRequest, overwriteValues = {}) => {
         const staticValues = {
             status: '0x1',

--- a/packages/server/tests/utils.ts
+++ b/packages/server/tests/utils.ts
@@ -360,6 +360,11 @@ export default class TestUtils {
         return Number(nonce);
     };
 
+    sendRawTransaction = async (tx, privateKey) => {
+        const signedTx = await this.signRawTransaction(tx, privateKey);
+        return this.JsonRpcProvider.send('eth_sendRawTransaction', [signedTx]);
+    };
+
     assertTransactionReceipt = (transactionReceipt, transactionRequest, overwriteValues = {}) => {
         const staticValues = {
             status: '0x1',

--- a/packages/server/tests/utils.ts
+++ b/packages/server/tests/utils.ts
@@ -355,24 +355,36 @@ export default class TestUtils {
         return new Promise(resolve => setTimeout(resolve, ms));
     };
 
-    assertReceiptNotNull = (receipt) => {
-        expect(receipt.blockHash).to.exist;
-        expect(receipt.blockHash).to.not.eq('0x0');
-        expect(receipt.blockNumber).to.exist;
-        expect(Number(receipt.blockNumber)).to.gt(0);
-        expect(receipt.cumulativeGasUsed).to.exist;
-        expect(Number(receipt.cumulativeGasUsed)).to.gt(0);
-        expect(receipt.gasUsed).to.exist;
-        expect(Number(receipt.gasUsed)).to.gt(0);
-        expect(receipt.logsBloom).to.exist;
-        expect(receipt.logsBloom).to.not.eq('0x0');
-        expect(receipt.transactionHash).to.exist;
-        expect(receipt.transactionHash).to.not.eq('0x0');
-        expect(receipt.transactionIndex).to.exist;
-        expect(receipt.effectiveGasPrice).to.exist;
-        expect(Number(receipt.effectiveGasPrice)).to.gt(0);
-        expect(receipt.status).to.exist;
-        expect(receipt.logs).to.exist;
+    assertTransactionReceipt = (transactionReceipt, transactionRequest, overwriteValues = {}) => {
+        const staticValues = {
+            status: '0x1',
+            logs: [],
+            from: '',
+            ...overwriteValues
+        };
+
+        expect(transactionReceipt.blockHash).to.exist;
+        expect(transactionReceipt.blockHash).to.not.eq('0x0');
+        expect(transactionReceipt.blockNumber).to.exist;
+        expect(Number(transactionReceipt.blockNumber)).to.gt(0);
+        expect(transactionReceipt.cumulativeGasUsed).to.exist;
+        expect(Number(transactionReceipt.cumulativeGasUsed)).to.gt(0);
+        expect(transactionReceipt.gasUsed).to.exist;
+        expect(Number(transactionReceipt.gasUsed)).to.gt(0);
+        expect(transactionReceipt.logsBloom).to.exist;
+        expect(transactionReceipt.logsBloom).to.not.eq('0x0');
+        expect(transactionReceipt.transactionHash).to.exist;
+        expect(transactionReceipt.transactionHash).to.not.eq('0x0');
+        expect(transactionReceipt.transactionIndex).to.exist;
+        expect(transactionReceipt.effectiveGasPrice).to.exist;
+        expect(Number(transactionReceipt.effectiveGasPrice)).to.gt(0);
+        expect(transactionReceipt.status).to.exist;
+        expect(transactionReceipt.logs).to.exist;
+        expect(transactionReceipt.logs.length).to.eq(staticValues.logs.length);
+        expect(transactionReceipt.status).to.eq(staticValues.status);
+        expect(transactionReceipt.from).to.eq(staticValues.from);
+        expect(transactionReceipt.to).to.eq(transactionRequest.to);
+
     };
 }
 

--- a/packages/server/tests/utils.ts
+++ b/packages/server/tests/utils.ts
@@ -351,5 +351,28 @@ export default class TestUtils {
         return BigNumber.from(hex1).sub(BigNumber.from(hex2));
     };
 
+    sleep = async (ms) => {
+        return new Promise(resolve => setTimeout(resolve, ms));
+    };
+
+    assertReceiptNotNull = (receipt) => {
+        expect(receipt.blockHash).to.exist;
+        expect(receipt.blockHash).to.not.eq('0x0');
+        expect(receipt.blockNumber).to.exist;
+        expect(Number(receipt.blockNumber)).to.gt(0);
+        expect(receipt.cumulativeGasUsed).to.exist;
+        expect(Number(receipt.cumulativeGasUsed)).to.gt(0);
+        expect(receipt.gasUsed).to.exist;
+        expect(Number(receipt.gasUsed)).to.gt(0);
+        expect(receipt.logsBloom).to.exist;
+        expect(receipt.logsBloom).to.not.eq('0x0');
+        expect(receipt.transactionHash).to.exist;
+        expect(receipt.transactionHash).to.not.eq('0x0');
+        expect(receipt.transactionIndex).to.exist;
+        expect(receipt.effectiveGasPrice).to.exist;
+        expect(Number(receipt.effectiveGasPrice)).to.gt(0);
+        expect(receipt.status).to.exist;
+        expect(receipt.logs).to.exist;
+    };
 }
 


### PR DESCRIPTION
**Description**:
Add tests for the method `eth_getTransactionReceipt` for:
- Negative test for Legacy transaction - contains `value`, `gasPrice`, `gasLimit`, `to`, `nonce`
- Legacy 155 transaction - contains `value`, `gasPrice`, `gasLimit`, `to` and `chainId`, `nonce`
- London transaction - contains `value`, `maxPriorityFeePerGas`, `maxFeePerGas`, `gasLimit`, `to`, `chainId`, `nonce` and `type=2`
- Negative test for Legacy 2930 transaction - contains `value`, `gasPrice`, `gasLimit`, `to`, `chainId`and `type=1`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
