### PR TITLE
Improve transfer-only gas estimate

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -47,11 +47,11 @@ export interface Eth {
 
   blockNumber(): Promise<string>;
 
-  call(call: any, blockParam: string): Promise<string>;
+  call(call: any, blockParam: string | null): Promise<string>;
 
   coinbase(): JsonRpcError;
 
-  estimateGas(): Promise<string>;
+  estimateGas(transaction:any, blockParam: string| null): Promise<string>;
 
   gasPrice(): Promise<string>;
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -49,8 +49,8 @@ export class EthImpl implements Eth {
   static emptyArrayHex = '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347';
   static zeroAddressHex = '0x0000000000000000000000000000000000000000';
   static emptyBloom = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-  static defaultGas = 0x3d0900;
-  static gasTxBaseCost = 21_000;
+  static defaultGas = EthImpl.numberTo0x(400_000);
+  static gasTxBaseCost = EthImpl.numberTo0x(21_000);
   static ethTxType = 'EthereumTransaction';
   static ethEmptyTrie = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421';
 
@@ -206,13 +206,12 @@ export class EthImpl implements Eth {
    * Estimates the amount of gas to execute a call.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async estimateGas(transaction: any, blockParam: string | null) {
+  async estimateGas(transaction: any, _blockParam: string | null) {
     this.logger.trace('estimateGas()');
     if (!transaction || !transaction.data || transaction.data === '0x') {
-      return EthImpl.numberTo0x(EthImpl.gasTxBaseCost);
+      return EthImpl.gasTxBaseCost;
     } else {
-      // FIXME: For now, we are going to have an arbitrary estimate for non-transfers but in the future we will do something more sophisticated.
-      return EthImpl.numberTo0x(EthImpl.defaultGas);
+      return EthImpl.defaultGas;
     }
   }
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -18,16 +18,16 @@
  *
  */
 
-import { Eth } from '../index';
+import {Eth} from '../index';
 import { ContractId, Status, Hbar } from '@hashgraph/sdk';
-import { BigNumber } from '@hashgraph/sdk/lib/Transfer';
-import { Logger } from 'pino';
+import {BigNumber} from '@hashgraph/sdk/lib/Transfer';
+import {Logger} from 'pino';
 import { Block, CachedBlock, Transaction, Log } from './model';
-import { MirrorNode } from './mirrorNode';
-import { MirrorNodeClient, SDKClient } from './clients';
-import { JsonRpcError, predefined } from './errors';
+import {MirrorNode} from './mirrorNode';
+import {MirrorNodeClient, SDKClient} from './clients';
+import {JsonRpcError, predefined} from './errors';
 import constants from './constants';
-import { Precheck } from './precheck';
+import {Precheck} from './precheck';
 
 const _ = require('lodash');
 const cache = require('js-cache');
@@ -50,6 +50,7 @@ export class EthImpl implements Eth {
   static zeroAddressHex = '0x0000000000000000000000000000000000000000';
   static emptyBloom = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
   static defaultGas = 0x3d0900;
+  static gasTxBaseCost = 21_000;
   static ethTxType = 'EthereumTransaction';
   static ethEmptyTrie = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421';
 
@@ -203,20 +204,16 @@ export class EthImpl implements Eth {
 
   /**
    * Estimates the amount of gas to execute a call.
-   *
-   * TODO: API signature is not right, some kind of call info needs to be passed through:
-   *   "params": [{
-   *     "from": "0xb60e8dd61c5d32be8058bb8eb970870f07233155",
-   *     "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
-   *     "gas": "0x76c0",
-   *     "gasPrice": "0x9184e72a000",
-   *     "value": "0x9184e72a",
-   *     "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"}],
    */
-  async estimateGas() {
-    // FIXME: For now, we are going to have a rough estimate but in the future we can do something more sophisticated.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async estimateGas(transaction: any, blockParam: string | null) {
     this.logger.trace('estimateGas()');
-    return EthImpl.numberTo0x(EthImpl.defaultGas);
+    if (!transaction || !transaction.data || transaction.data === '0x') {
+      return EthImpl.numberTo0x(EthImpl.gasTxBaseCost);
+    } else {
+      // FIXME: For now, we are going to have an arbitrary estimate for non-transfers but in the future we will do something more sophisticated.
+      return EthImpl.numberTo0x(EthImpl.defaultGas);
+    }
   }
 
   /**
@@ -599,7 +596,7 @@ export class EthImpl implements Eth {
    * @param call
    * @param blockParam
    */
-  async call(call: any, blockParam: string) {
+  async call(call: any, blockParam: string | null) {
     // FIXME: In the future this will be implemented by making calls to the mirror node. For the
     //        time being we'll eat the cost and ask the main consensus nodes instead.
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -911,6 +911,7 @@ describe('Eth calls using MirrorNode', async function () {
     mock.onGet(`network/fees`).reply(200, defaultNetworkFees);
     const feeHistory = await ethImpl.feeHistory(1, 'latest', [25, 75]);
     expect(feeHistory).to.exist;
+    if (feeHistory == null) return;
     expect(feeHistory['baseFeePerGasArray'][0]).to.equal('0x84b6a5c400');
     expect(feeHistory['gasUsedRatioArray'][0]).to.equal('0.5');
     expect(feeHistory['oldestBlockNumber']).to.equal('0x0');
@@ -923,6 +924,7 @@ describe('Eth calls using MirrorNode', async function () {
     mock.onGet(`network/fees`).reply(200, defaultNetworkFees);
     const firstFeeHistory = await ethImpl.feeHistory(1, 'latest', [25, 75]);
     expect(firstFeeHistory).to.exist;
+    if (firstFeeHistory == null) return;
     expect(firstFeeHistory['baseFeePerGasArray'][0]).to.equal('0x84b6a5c400');
     expect(firstFeeHistory['gasUsedRatioArray'][0]).to.equal('0.5');
     expect(firstFeeHistory['oldestBlockNumber']).to.equal('0x0');
@@ -934,6 +936,27 @@ describe('Eth calls using MirrorNode', async function () {
 
     expect(firstFeeHistory).to.equal(secondFeeHistory);
   });
+
+  it('eth_estimateGas contract call returns default', async function() {
+    const gas = await ethImpl.estimateGas({input:"0x01"}, null);
+    expect(gas).to.equal(EthImpl.numberTo0x(EthImpl.defaultGas));
+  });
+
+  it('eth_estimateGas empty call returns transfer cost', async function() {
+    const gas = await ethImpl.estimateGas({}, null);
+    expect(gas).to.equal(EthImpl.numberTo0x(EthImpl.gasTxBaseCost));
+  });
+
+  it('eth_estimateGas empty input transfer cost', async function() {
+    const gas = await ethImpl.estimateGas({input:""}, null);
+    expect(gas).to.equal(EthImpl.numberTo0x(EthImpl.gasTxBaseCost));
+  });
+
+  it('eth_estimateGas zero input returns transfer cost', async function() {
+    const gas = await ethImpl.estimateGas({input:"0x"}, null);
+    expect(gas).to.equal(EthImpl.numberTo0x(EthImpl.gasTxBaseCost));
+  });
+
 
   it('eth_gasPrice', async function() {
     mock.onGet(`network/fees`).reply(200, defaultNetworkFees);
@@ -966,7 +989,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     try {
       await ethImpl.gasPrice();
-    } catch (error) {
+    } catch (error: any) {
       expect(error.message).to.equal('Error encountered estimating the gas price');
     }
   });
@@ -984,7 +1007,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     try {
       await ethImpl.gasPrice();
-    } catch (error) {
+    } catch (error: any) {
       expect(error.message).to.equal('Error encountered estimating the gas price');
     }
   });

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -938,25 +938,24 @@ describe('Eth calls using MirrorNode', async function () {
   });
 
   it('eth_estimateGas contract call returns default', async function() {
-    const gas = await ethImpl.estimateGas({input:"0x01"}, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(EthImpl.defaultGas));
+    const gas = await ethImpl.estimateGas({data:"0x01"}, null);
+    expect(gas).to.equal(EthImpl.defaultGas);
   });
 
   it('eth_estimateGas empty call returns transfer cost', async function() {
     const gas = await ethImpl.estimateGas({}, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(EthImpl.gasTxBaseCost));
+    expect(gas).to.equal(EthImpl.gasTxBaseCost);
   });
 
   it('eth_estimateGas empty input transfer cost', async function() {
-    const gas = await ethImpl.estimateGas({input:""}, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(EthImpl.gasTxBaseCost));
+    const gas = await ethImpl.estimateGas({data:""}, null);
+    expect(gas).to.equal(EthImpl.gasTxBaseCost);
   });
 
   it('eth_estimateGas zero input returns transfer cost', async function() {
-    const gas = await ethImpl.estimateGas({input:"0x"}, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(EthImpl.gasTxBaseCost));
+    const gas = await ethImpl.estimateGas({data:"0x"}, null);
+    expect(gas).to.equal(EthImpl.gasTxBaseCost);
   });
-
 
   it('eth_gasPrice', async function() {
     mock.onGet(`network/fees`).reply(200, defaultNetworkFees);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -163,8 +163,8 @@ rpc.use('eth_blockNumber', async () => {
  *
  * returns: Gas used - hex encoded integer
  */
-rpc.use('eth_estimateGas', async () => {
-  return logAndHandleResponse('eth_estimateGas', () => relay.eth().estimateGas());
+rpc.use('eth_estimateGas', async (params: any) => {
+  return logAndHandleResponse('eth_estimateGas', () => relay.eth().estimateGas(params?.[0], params?.[1]));
 });
 
 /**


### PR DESCRIPTION
Improve the transfer only gas cost.  If no data is detected return 21k
gas, which is the base tx fee.

Signed-off-by: Danno Ferrin <danno.ferrin@hedera.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

for #166

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
