### PR TITLE
Improve client logs and capture client metrics

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -47,7 +47,7 @@ export interface Eth {
 
   blockNumber(): Promise<string>;
 
-  call(call: any, blockParam: string | null): Promise<string | null>;
+  call(call: any, blockParam: string | null): Promise<string | JsonRpcError>;
 
   coinbase(): JsonRpcError;
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -47,7 +47,7 @@ export interface Eth {
 
   blockNumber(): Promise<string>;
 
-  call(call: any, blockParam: string | null): Promise<string>;
+  call(call: any, blockParam: string | null): Promise<string | null>;
 
   coinbase(): JsonRpcError;
 

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -101,7 +101,7 @@ export interface Eth {
 
   protocolVersion(): JsonRpcError;
 
-  sendRawTransaction(transaction: string): Promise<string>;
+  sendRawTransaction(transaction: string): Promise<string | JsonRpcError>;
 
   sendTransaction(): JsonRpcError;
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -133,18 +133,18 @@ export class MirrorNodeClient {
         this.logger.info(`Mirror Node client successfully configured to ${this.baseUrl}`);
     }
 
-    async request(path: string, allowedErrorStatuses?: number[]): Promise<any> {
+    async request(path: string, pathLabel: string, allowedErrorStatuses?: number[]): Promise<any> {
         const start = Date.now();
         let ms;
         try {
             const response = await this.client.get(path);
             ms = Date.now() - start;
             this.logger.debug(`Mirror Node Response: [GET] ${path} ${response.status} ${ms} ms`);
-            this.mirrorResponseHistogram.labels(path, response.status).observe(ms);
+            this.mirrorResponseHistogram.labels(pathLabel, response.status).observe(ms);
             return response.data;
         } catch (error: any) {
             ms = Date.now() - start;
-            this.mirrorResponseHistogram.labels(path, error.response.status).observe(ms);
+            this.mirrorResponseHistogram.labels(pathLabel, error.response.status).observe(ms);
             this.handleError(error, path, allowedErrorStatuses);
         }
         return null;
@@ -163,15 +163,21 @@ export class MirrorNodeClient {
     }
 
     public async getAccountLatestTransactionByAddress(idOrAliasOrEvmAddress: string): Promise<object> {
-        return this.request(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}?order=desc&limit=1`, [400]);
+        return this.request(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}?order=desc&limit=1`,
+            MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
+            [400]);
     }
 
     public async getAccount(idOrAliasOrEvmAddress: string): Promise<object> {
-        return this.request(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}`, [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}`,
+            MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
+            [400, 404]);
     }
 
     public async getBlock(hashOrBlockNumber: string | number) {
-        return this.request(`${MirrorNodeClient.GET_BLOCK_ENDPOINT}${hashOrBlockNumber}`, [400]);
+        return this.request(`${MirrorNodeClient.GET_BLOCK_ENDPOINT}${hashOrBlockNumber}`,
+            MirrorNodeClient.GET_BLOCK_ENDPOINT,
+            [400]);
     }
 
     public async getBlocks(blockNumber?: number | string[], timestamp?: string, limitOrderParams?: ILimitOrderParams) {
@@ -180,15 +186,21 @@ export class MirrorNodeClient {
         this.setQueryParam(queryParamObject, 'timestamp', timestamp);
         this.setLimitOrderParams(queryParamObject, limitOrderParams);
         const queryParams = this.getQueryParams(queryParamObject);
-        return this.request(`${MirrorNodeClient.GET_BLOCKS_ENDPOINT}${queryParams}`, [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_BLOCKS_ENDPOINT}${queryParams}`,
+            MirrorNodeClient.GET_BLOCKS_ENDPOINT,
+            [400, 404]);
     }
 
     public async getContract(contractIdOrAddress: string) {
-        return this.request(`${MirrorNodeClient.GET_CONTRACT_ENDPOINT}${contractIdOrAddress}`, [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_CONTRACT_ENDPOINT}${contractIdOrAddress}`,
+            MirrorNodeClient.GET_CONTRACT_ENDPOINT,
+            [400, 404]);
     }
 
     public async getContractResult(transactionIdOrHash: string) {
-        return this.request(`${MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT}${transactionIdOrHash}`, [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT}${transactionIdOrHash}`,
+            MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT,
+            [400, 404]);
     }
 
     public async getContractResults(contractResultsParams?: IContractResultsParams, limitOrderParams?: ILimitOrderParams) {
@@ -196,11 +208,15 @@ export class MirrorNodeClient {
         this.setContractResultsParams(queryParamObject, contractResultsParams);
         this.setLimitOrderParams(queryParamObject, limitOrderParams);
         const queryParams = this.getQueryParams(queryParamObject);
-        return this.request(`${MirrorNodeClient.GET_CONTRACT_RESULTS_ENDPOINT}${queryParams}`, [400]);
+        return this.request(`${MirrorNodeClient.GET_CONTRACT_RESULTS_ENDPOINT}${queryParams}`,
+            MirrorNodeClient.GET_CONTRACT_RESULTS_ENDPOINT,
+            [400]);
     }
 
     public async getContractResultsDetails(contractId: string, timestamp: string) {
-        return this.request(`${this.getContractResultsDetailsByContractIdAndTimestamp(contractId, timestamp)}`, [400]);
+        return this.request(`${this.getContractResultsDetailsByContractIdAndTimestamp(contractId, timestamp)}`,
+            MirrorNodeClient.GET_CONTRACT_RESULTS_DETAILS_BY_CONTRACT_ID_ENDPOINT,
+            [400]);
     }
 
     public async getContractResultsByAddress(
@@ -211,11 +227,15 @@ export class MirrorNodeClient {
         this.setContractResultsParams(queryParamObject, contractResultsParams);
         this.setLimitOrderParams(queryParamObject, limitOrderParams);
         const queryParams = this.getQueryParams(queryParamObject);
-        return this.request(`${MirrorNodeClient.getContractResultsByAddressPath(contractIdOrAddress)}${queryParams}`, [400]);
+        return this.request(`${MirrorNodeClient.getContractResultsByAddressPath(contractIdOrAddress)}${queryParams}`,
+            MirrorNodeClient.GET_CONTRACT_RESULTS_BY_ADDRESS_ENDPOINT,
+            [400]);
     }
 
     public async getContractResultsByAddressAndTimestamp(contractIdOrAddress: string, timestamp: string) {
-        return this.request(`${MirrorNodeClient.getContractResultsByAddressPath(contractIdOrAddress)}/${timestamp}`, [206, 400, 404]);
+        return this.request(`${MirrorNodeClient.getContractResultsByAddressPath(contractIdOrAddress)}/${timestamp}`,
+            MirrorNodeClient.GET_CONTRACT_RESULTS_BY_ADDRESS_ENDPOINT,
+            [206, 400, 404]);
     }
 
     private prepareLogsParams(
@@ -239,7 +259,9 @@ export class MirrorNodeClient {
         contractLogsResultsParams?: IContractLogsResultsParams,
         limitOrderParams?: ILimitOrderParams) {
         const queryParams = this.prepareLogsParams(contractLogsResultsParams, limitOrderParams);
-        return this.request(`${MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT}${queryParams}`, [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT}${queryParams}`,
+            MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT,
+            [400, 404]);
     }
 
     public async getContractResultsLogsByAddress(
@@ -252,7 +274,9 @@ export class MirrorNodeClient {
             MirrorNodeClient.ADDRESS_PLACEHOLDER,
             address
         );
-        return this.request(`${apiEndpoint}${queryParams}`, [400, 404]);
+        return this.request(`${apiEndpoint}${queryParams}`,
+            MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_BY_ADDRESS_ENDPOINT,
+            [400, 404]);
     }
 
     public async getLatestBlock() {
@@ -267,7 +291,9 @@ export class MirrorNodeClient {
         const queryParamObject = {};
         this.setQueryParam(queryParamObject, 'timestamp', timestamp);
         const queryParams = this.getQueryParams(queryParamObject);
-        return this.request(`${MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT}${queryParams}`, [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT}${queryParams}`, 
+        MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT,
+        [400, 404]);
     }
 
     public async getNetworkFees(timestamp?: string, order?: string) {
@@ -275,7 +301,9 @@ export class MirrorNodeClient {
         this.setQueryParam(queryParamObject, 'timestamp', timestamp);
         this.setQueryParam(queryParamObject, 'order', order);
         const queryParams = this.getQueryParams(queryParamObject);
-        return this.request(`${MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT}${queryParams}`, [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT}${queryParams}`, 
+        MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT,
+        [400, 404]);
     }
 
     private static getContractResultsByAddressPath(address: string) {

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -158,7 +158,7 @@ export class MirrorNodeClient {
             }
         }
 
-        this.logger.error(error, 'Unexpected request error');
+        this.logger.error(new Error(error.message), `Mirror Node Response: [GET] ${path} ${error.response.status} status`);
         throw predefined.INTERNAL_ERROR;
     }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -38,7 +38,6 @@ import {
     FeeComponents,
     Query,
     Transaction,
-    Hbar,
     TransactionRecord,
     TransactionReceipt,
     Status

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -109,13 +109,6 @@ export class SDKClient {
         });
     }
 
-    async getOperatorAccountBalance(): Promise<Hbar> {
-        const accountBalance = await (new AccountBalanceQuery()
-            .setAccountId(this.clientMain.operatorAccountId!))
-            .execute(this.clientMain);
-        return accountBalance.hbars;
-    }
-
     async getAccountBalance(account: string): Promise<AccountBalance> {
         return this.executeQuery(new AccountBalanceQuery()
             .setAccountId(AccountId.fromString(account)), this.clientMain);
@@ -209,9 +202,8 @@ export class SDKClient {
 
         const cost = await contractCallQuery
             .getCost(this.clientMain);
-        const contractResult = await this.executeQuery(contractCallQuery
+        return this.executeQuery(contractCallQuery
             .setQueryPayment(cost), this.clientMain);
-        return contractResult;
     }
 
     private convertGasPriceToTinyBars = (feeComponents: FeeComponents | undefined, exchangeRates: ExchangeRates) => {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -93,12 +93,12 @@ export class SDKClient {
             help: 'Relay operator balance gauge',
             labelNames: ['mode', 'type'],
             registers: [register],
-            async collect() {
-                // Invoked when the registry collects its metrics' values.
-                // This can be synchronous or it can return a promise/be an async function.
-                const balance = await getOperatorAccountBalance();
-                this.set(balance);
-            },
+            // async collect() {
+            //     // Invoked when the registry collects its metrics' values.
+            //     // This can be synchronous or it can return a promise/be an async function.
+            //     const balance = await getOperatorAccountBalance();
+            //     this.set(balance);
+            // },
         });
     }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -93,12 +93,19 @@ export class SDKClient {
             help: 'Relay operator balance gauge',
             labelNames: ['mode', 'type'],
             registers: [register],
-            // async collect() {
-            //     // Invoked when the registry collects its metrics' values.
-            //     // This can be synchronous or it can return a promise/be an async function.
-            //     const balance = await getOperatorAccountBalance();
-            //     this.set(balance);
-            // },
+            async collect() {
+                // Invoked when the registry collects its metrics' values.
+                // Allows for updated account balance tracking
+                try {
+                    const accountBalance = await (new AccountBalanceQuery()
+                        .setAccountId(clientMain.operatorAccountId!))
+                        .execute(clientMain);
+                    this.set(accountBalance.hbars.toTinybars().toNumber());
+                } catch (e: any) {
+                    logger.error(e, `Error collecting operator balance. Setting 0 default`);
+                    this.set(0);
+                }
+            },
         });
     }
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -23,6 +23,7 @@ import axios from 'axios';
 import dotenv from 'dotenv';
 import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
+import { Registry } from 'prom-client';
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 import { RelayImpl } from '@hashgraph/json-rpc-relay';
 import { EthImpl } from '../../src/lib/eth';
@@ -30,14 +31,12 @@ import { MirrorNodeClient } from '../../src/lib/clients/mirrorNodeClient';
 import { MirrorNode } from '../../src/lib/mirrorNode';
 import {expectUnsupportedMethod} from '../helpers';
 
-const cache = require('js-cache');
-
 import pino from 'pino';
 import { Block, Transaction } from '../../src/lib/model';
 import constants from '../../src/lib/constants';
 const logger = pino();
-
-const Relay = new RelayImpl(logger);
+const registry = new Registry();
+const Relay = new RelayImpl(logger, registry);
 
 const validateHash = (hash: string, len?: number) => {
   let regex;
@@ -80,7 +79,7 @@ describe('Eth calls using MirrorNode', async function () {
   // @ts-ignore
   const mock = new MockAdapter(instance, { onNoMatch: "throwException" });
   // @ts-ignore
-  const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), instance);
+  const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
   // @ts-ignore
   const ethImpl = new EthImpl(null, new MirrorNode(logger.child({ name: `mirror-node-faux` })), mirrorNodeInstance, logger, '0x12a');
 
@@ -89,7 +88,6 @@ describe('Eth calls using MirrorNode', async function () {
   const blockHash2 = `${blockHashTrimmed}999fc7e86699f60f2a3fb3ed9a646c6c`;
   const blockHash3 = `${blockHashTrimmed}999fc7e86699f60f2a3fb3ed9a646c6d`;
   const blockHashPreviousTrimmed = '0xf7d6481f659c866c35391ee230c374f163642ebf13a5e604e04a95a9ca48a298';
-  const blockHashPrevious = `${blockHashPreviousTrimmed}dc2dfa10f51bcbaab8ae23bc6d662a0b`;
   const blockNumber = 3;
   const blockNumber2 = 4;
   const blockNumber3 = 5;

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -52,7 +52,7 @@ describe('MirrorNodeClient', async function () {
 
   it('`baseUrl` is exposed and correct', async () => {
     const domain = process.env.MIRROR_NODE_URL.replace(/^https?:\/\//, "");
-    const prodMirrorNodeInstance = new MirrorNodeClient(domain, logger.child({ name: `mirror-node` }));
+    const prodMirrorNodeInstance = new MirrorNodeClient(domain, logger.child({ name: `mirror-node` }), null);
     expect(prodMirrorNodeInstance.baseUrl).to.eq(`https://${domain}/api/v1/`);
   });
 

--- a/packages/relay/tests/lib/net.spec.ts
+++ b/packages/relay/tests/lib/net.spec.ts
@@ -19,12 +19,13 @@
  */
 
 import { expect } from 'chai';
+import { Registry } from 'prom-client';
 import { RelayImpl } from '@hashgraph/json-rpc-relay';
 
 import pino from 'pino';
 const logger = pino();
 
-const Relay = new RelayImpl(logger);
+const Relay = new RelayImpl(logger, new Registry());
 
 describe('Net', async function() {
   it('should execute "net_listening"', async function() {

--- a/packages/relay/tests/lib/web3.spec.ts
+++ b/packages/relay/tests/lib/web3.spec.ts
@@ -21,6 +21,7 @@
 import path from 'path';
 import dotenv from 'dotenv';
 import { expect } from 'chai';
+import { Registry } from 'prom-client';
 import { RelayImpl } from '@hashgraph/json-rpc-relay';
 
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
@@ -28,7 +29,7 @@ dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 import pino from 'pino';
 const logger = pino();
 
-const Relay = new RelayImpl(logger);
+const Relay = new RelayImpl(logger, new Registry());
 
 describe('Web3', async function() {
   it('should execute "web3_clientVersion"', async function() {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -37,15 +37,15 @@ const mainLogger = pino({
   }
 });
 const logger = mainLogger.child({ name: 'rpc-server' });
+const register = new Registry();
 
-const relay: Relay = new RelayImpl(logger);
+const relay: Relay = new RelayImpl(logger, register);
 const cors = require('koa-cors');
 const app = new Koa();
 const rpc = koaJsonRpc();
 
 const responseSuccessStatusCode = '200';
 const responseInternalErrorCode = '-32603';
-const register = new Registry();
 collectDefaultMetrics({ register, prefix: 'rpc_relay_' });
 
 const methodResponseHistogram = new Histogram({

--- a/packages/server/tests/acceptance.spec.ts
+++ b/packages/server/tests/acceptance.spec.ts
@@ -437,7 +437,7 @@ describe('RPC Server Acceptance Tests', async function () {
         }, ethCompPrivateKey3);
 
         const res = await utils.callFailingRelayMethod('eth_sendRawTransaction', [signedTx]);
-        expect(res.data.error.message).to.be.equal('Internal error');
+        expect(res.data.error.message).to.be.equal('Unknown error invoking RPC');
         expect(res.data.error.code).to.be.equal(-32603);
     });
 
@@ -449,7 +449,7 @@ describe('RPC Server Acceptance Tests', async function () {
         }, ethCompPrivateKey3);
 
         const res = await utils.callFailingRelayMethod('eth_sendRawTransaction', [signedTx]);
-        expect(res.data.error.message).to.be.equal('Internal error');
+        expect(res.data.error.message).to.be.equal('Unknown error invoking RPC');
         expect(res.data.error.code).to.be.equal(-32603);
     });
 


### PR DESCRIPTION
**Description**:
Currently most logs and metrics focus on the `server` and `eth` classes.
This currently results in leaked info, verbose logs and little insight as to sdkClient and mirrorNode clients.

- Add loggers to sdkClient and mirrorNode clients
- Log responses with response codes
- Manage `NOT_SUPPORTED` errors from network
- Simplify stack trace error message since most client info isn't needed and shouldn't leak into `eth` and `server` logs
- Add a Histogram to capture sdkClient and mirrorNode clients responses
- Add a Gauge to track operator account costs to support alerting

**Related issue(s)**:

Fixes #206 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
