### PR TITLE
Add logic to clear metric from registry before create

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -123,8 +123,11 @@ export class MirrorNodeClient {
         this.logger = logger;
         this.register = register;
 
+        // clear and create metric in registry
+        const metricHistogramName = 'rpc_relay_mirror_response';
+        register.removeSingleMetric(metricHistogramName);
         this.mirrorResponseHistogram = new Histogram({
-            name: 'rpc_relay_mirror_response',
+            name: metricHistogramName,
             help: 'Mirror node response method statusCode latency histogram',
             labelNames: ['method', 'statusCode'],
             registers: [register]
@@ -291,9 +294,9 @@ export class MirrorNodeClient {
         const queryParamObject = {};
         this.setQueryParam(queryParamObject, 'timestamp', timestamp);
         const queryParams = this.getQueryParams(queryParamObject);
-        return this.request(`${MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT}${queryParams}`, 
-        MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT,
-        [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT}${queryParams}`,
+            MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT,
+            [400, 404]);
     }
 
     public async getNetworkFees(timestamp?: string, order?: string) {
@@ -301,9 +304,9 @@ export class MirrorNodeClient {
         this.setQueryParam(queryParamObject, 'timestamp', timestamp);
         this.setQueryParam(queryParamObject, 'order', order);
         const queryParams = this.getQueryParams(queryParamObject);
-        return this.request(`${MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT}${queryParams}`, 
-        MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT,
-        [400, 404]);
+        return this.request(`${MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT}${queryParams}`,
+            MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT,
+            [400, 404]);
     }
 
     private static getContractResultsByAddressPath(address: string) {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -80,15 +80,21 @@ export class SDKClient {
         this.clientMain = clientMain;
         this.logger = logger;
         this.register = register;
+
+        // clear and create metrics in registry
+        const metricHistogramName = 'rpc_relay_consensusnode_response';
+        register.removeSingleMetric(metricHistogramName);
         this.consensusNodeClientHistorgram = new Histogram({
-            name: 'rpc_relay_consensusnode_response',
+            name: metricHistogramName,
             help: 'Relay consensusnode mode type status cost histogram',
             labelNames: ['mode', 'type', 'status'],
             registers: [register]
         });
 
+        const metricGaugeName = 'rpc_relay_operator_balance';
+        register.removeSingleMetric(metricHistogramName);
         this.operatorAccountGauge = new Gauge({
-            name: 'rpc_relay_operator_balance',
+            name: metricGaugeName,
             help: 'Relay operator balance gauge',
             labelNames: ['mode', 'type'],
             registers: [register],

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -48,8 +48,11 @@ const responseSuccessStatusCode = '200';
 const responseInternalErrorCode = '-32603';
 collectDefaultMetrics({ register, prefix: 'rpc_relay_' });
 
+// clear and create metric in registry
+const metricHistogramName = 'rpc_relay_method_response';
+register.removeSingleMetric(metricHistogramName);
 const methodResponseHistogram = new Histogram({
-  name: 'rpc_relay_method_response',
+  name: metricHistogramName,
   help: 'JSON RPC method statusCode latency histogram',
   labelNames: ['method', 'statusCode'],
   registers: [register]


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
In some test suites we recreate client instances causes failures when registering a metric
- Add logic to clear metrics from registry before creating

**Related issue(s)**:

Fixes #228 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
