### PR TITLE
Improve acceptance tests run against remote instances

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -142,7 +142,7 @@ export class MirrorNodeClient {
         try {
             const response = await this.client.get(path);
             ms = Date.now() - start;
-            this.logger.debug(`Mirror Node Response: [GET] ${path} ${response.status} ${ms} ms`);
+            this.logger.debug(`[GET] ${path} ${response.status} ${ms} ms`);
             this.mirrorResponseHistogram.labels(pathLabel, response.status).observe(ms);
             return response.data;
         } catch (error: any) {
@@ -156,12 +156,12 @@ export class MirrorNodeClient {
     handleError(error: any, path: string, allowedErrorStatuses?: number[]) {
         if (allowedErrorStatuses && allowedErrorStatuses.length) {
             if (error.response && allowedErrorStatuses.indexOf(error.response.status) !== -1) {
-                this.logger.debug(`Mirror Node Response: [GET] ${path} ${error.response.status} status`);
+                this.logger.debug(`[GET] ${path} ${error.response.status} status`);
                 return null;
             }
         }
 
-        this.logger.error(new Error(error.message), `Mirror Node Response: [GET] ${path} ${error.response.status} status`);
+        this.logger.error(new Error(error.message), `[GET] ${path} ${error.response.status} status`);
         throw predefined.INTERNAL_ERROR;
     }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -92,7 +92,7 @@ export class SDKClient {
         });
 
         const metricGaugeName = 'rpc_relay_operator_balance';
-        register.removeSingleMetric(metricHistogramName);
+        register.removeSingleMetric(metricGaugeName);
         this.operatorAccountGauge = new Gauge({
             name: metricGaugeName,
             help: 'Relay operator balance gauge',

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -119,7 +119,7 @@ export class RelayImpl implements Relay {
       default: {
         if (process.env.OPERATOR_ID_MAIN && process.env.OPERATOR_KEY_MAIN) {
           client = client.setOperator(
-            AccountId.fromString(process.env.OPERATOR_ID_MAIN),
+            AccountId.fromString(process.env.OPERATOR_ID_MAIN.trim()),
             PrivateKey.fromString(process.env.OPERATOR_KEY_MAIN)
           );
         }

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -32,7 +32,7 @@ import RelayClient from '../clients/relayClient';
 import app from '../../dist/server';
 import Assertions from '../helpers/assertions';
 import { Utils } from '../helpers/utils';
-import { AccountBalanceQuery, ContractFunctionParameters } from '@hashgraph/sdk';
+import { AccountBalanceQuery, ContractFunctionParameters, Hbar } from '@hashgraph/sdk';
 
 const testLogger = pino({
     name: 'hedera-json-rpc-relay',
@@ -61,6 +61,7 @@ let mirrorContract;
 let mirrorContractDetails;
 let mirrorPrimaryAccount;
 let mirrorSecondaryAccount;
+let startOperatorBalance: Hbar;
 
 const USE_LOCAL_NODE = process.env.LOCAL_NODE || 'true';
 const CHAIN_ID = process.env.CHAIN_ID || 0;
@@ -80,17 +81,26 @@ const NON_EXISTING_BLOCK_HASH = '0x555555555555555555555555555555555555555555555
 const NON_EXISTING_BLOCK_NUMBER = 99999999;
 const NON_EXISTING_INDEX = 999999;
 
-describe('RPC Server Acceptance Tests', function() {
+describe('RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
 
     const accounts: AliasAccount[] = [];
 
     let relayServer; // Relay Server
-    const servicesNode = new ServicesClient(NETWORK, OPERATOR_ID, OPERATOR_KEY, logger.child({ name: `services-client` }));
-    const mirrorNode = new MirrorClient(MIRROR_NODE_URL, logger.child({ name: `mirror-node-client` }));
-    const relay = new RelayClient(RELAY_URL, logger.child({ name: `relay-client` }));
+    const servicesNode = new ServicesClient(NETWORK, OPERATOR_ID, OPERATOR_KEY, logger.child({ name: `acctest-services-client` }));
+    const mirrorNode = new MirrorClient(MIRROR_NODE_URL, logger.child({ name: `acctest-mirror-node-client` }));
+    const relay = new RelayClient(RELAY_URL, logger.child({ name: `acctest-relay-client` }));
+    this.beforeAll(async () => {
+        // configuration details
+        logger.info('Acceptance Tests Configurations successfully loaded');
+        logger.info(`LOCAL_NODE: ${process.env.LOCAL_NODE}`);
+        logger.info(`CHAIN_ID: ${process.env.CHAIN_ID}`);
+        logger.info(`HEDERA_NETWORK: ${process.env.HEDERA_NETWORK}`);
+        logger.info(`OPERATOR_ID_MAIN: ${process.env.OPERATOR_ID_MAIN}`);
+        logger.info(`MIRROR_NODE_URL: ${process.env.MIRROR_NODE_URL}`);
+        logger.info(`E2E_RELAY_HOST: ${process.env.E2E_RELAY_HOST}`);
+        startOperatorBalance = await servicesNode.getOperatorBalance();
 
-    before(async () => {
 
         if (USE_LOCAL_NODE === 'true') {
             runLocalHederaNetwork();
@@ -100,7 +110,7 @@ describe('RPC Server Acceptance Tests', function() {
             runLocalRelay();
         }
 
-        accounts[0] = await servicesNode.createAliasAccount();
+        accounts[0] = await servicesNode.createAliasAccount(20);
         accounts[1] = await servicesNode.createAliasAccount();
         accounts[2] = await servicesNode.createAliasAccount(20);
         contractId = await accounts[0].client.createParentContract(parentContractJson);
@@ -125,11 +135,17 @@ describe('RPC Server Acceptance Tests', function() {
         mirrorSecondaryAccount = (await mirrorNode.get(`accounts?account.id=${accounts[1].accountId}`)).accounts[0];
     });
 
+    this.afterAll(async () => {
+        const endOperatorBalance = await servicesNode.getOperatorBalance();
+        const cost = startOperatorBalance.toTinybars().subtract(endOperatorBalance.toTinybars());
+        logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
+    });
+
     describe('Block related RPC calls', () => {
 
         let mirrorBlock;
         let mirrorContractResults;
-        let mirrorTransactions : any[] = [];
+        let mirrorTransactions: any[] = [];
 
         before(async () => {
             mirrorBlock = (await mirrorNode.get(`/blocks?block.number=${mirrorContractDetails.block_number}`)).blocks[0];
@@ -138,82 +154,82 @@ describe('RPC Server Acceptance Tests', function() {
 
             for (let i = 0; i < mirrorContractResults.length; i++) {
                 const res = mirrorContractResults[i];
-                mirrorTransactions.push( (await mirrorNode.get(`/contracts/${res.contract_id}/results/${res.timestamp}`)) );
+                mirrorTransactions.push((await mirrorNode.get(`/contracts/${res.contract_id}/results/${res.timestamp}`)));
             }
 
         });
 
-        it('should execute "eth_getBlockByHash", hydrated transactions not specified', async function() {
+        it('should execute "eth_getBlockByHash", hydrated transactions not specified', async function () {
             const blockResult = await relay.call('eth_getBlockByHash', [mirrorBlock.hash]);
             Assertions.block(blockResult, mirrorBlock, mirrorTransactions, false);
         });
 
-        it('should execute "eth_getBlockByHash", hydrated transactions = false', async function() {
+        it('should execute "eth_getBlockByHash", hydrated transactions = false', async function () {
             const blockResult = await relay.call('eth_getBlockByHash', [mirrorBlock.hash, false]);
             Assertions.block(blockResult, mirrorBlock, mirrorTransactions, false);
         });
 
-        it('should execute "eth_getBlockByHash", hydrated transactions = true', async function() {
+        it('should execute "eth_getBlockByHash", hydrated transactions = true', async function () {
             const blockResult = await relay.call('eth_getBlockByHash', [mirrorBlock.hash, true]);
             Assertions.block(blockResult, mirrorBlock, mirrorTransactions, true);
         });
 
-        it('should execute "eth_getBlockByHash" for non-existing block hash and hydrated transactions = false', async function() {
+        it('should execute "eth_getBlockByHash" for non-existing block hash and hydrated transactions = false', async function () {
             const blockResult = await relay.call('eth_getBlockByHash', [NON_EXISTING_BLOCK_HASH, false]);
             expect(blockResult).to.be.null;
         });
 
-        it('should execute "eth_getBlockByHash" for non-existing block hash and hydrated transactions = true', async function() {
+        it('should execute "eth_getBlockByHash" for non-existing block hash and hydrated transactions = true', async function () {
             const blockResult = await relay.call('eth_getBlockByHash', [NON_EXISTING_BLOCK_HASH, true]);
             expect(blockResult).to.be.null;
         });
 
-        it('should execute "eth_getBlockByNumber", hydrated transactions not specified', async function() {
+        it('should execute "eth_getBlockByNumber", hydrated transactions not specified', async function () {
             const blockResult = await relay.call('eth_getBlockByNumber', [mirrorBlock.number]);
             Assertions.block(blockResult, mirrorBlock, mirrorTransactions, false);
         });
 
-        it('should execute "eth_getBlockByNumber", hydrated transactions = false', async function() {
+        it('should execute "eth_getBlockByNumber", hydrated transactions = false', async function () {
             const blockResult = await relay.call('eth_getBlockByNumber', [mirrorBlock.number, false]);
             Assertions.block(blockResult, mirrorBlock, mirrorTransactions, false);
         });
 
-        it('should execute "eth_getBlockByNumber", hydrated transactions = true', async function() {
+        it('should execute "eth_getBlockByNumber", hydrated transactions = true', async function () {
             const blockResult = await relay.call('eth_getBlockByNumber', [mirrorBlock.number, true]);
             Assertions.block(blockResult, mirrorBlock, mirrorTransactions, true);
         });
 
-        it('should execute "eth_getBlockByNumber" for non existing block number and hydrated transactions = true', async function() {
+        it('should execute "eth_getBlockByNumber" for non existing block number and hydrated transactions = true', async function () {
             const blockResult = await relay.call('eth_getBlockByNumber', [NON_EXISTING_BLOCK_NUMBER, true]);
             expect(blockResult).to.be.null;
         });
 
-        it('should execute "eth_getBlockByNumber" for non existing block number and hydrated transactions = false', async function() {
+        it('should execute "eth_getBlockByNumber" for non existing block number and hydrated transactions = false', async function () {
             const blockResult = await relay.call('eth_getBlockByNumber', [NON_EXISTING_BLOCK_NUMBER, false]);
             expect(blockResult).to.be.null;
         });
 
-        it('should execute "eth_getBlockTransactionCountByHash"', async function() {
+        it('should execute "eth_getBlockTransactionCountByHash"', async function () {
             const res = await relay.call('eth_getBlockTransactionCountByHash', [mirrorBlock.hash]);
             expect(res).to.be.equal(mirrorBlock.count);
         });
 
-        it('should execute "eth_getBlockTransactionCountByHash" for non-existing block hash', async function() {
+        it('should execute "eth_getBlockTransactionCountByHash" for non-existing block hash', async function () {
             const res = await relay.call('eth_getBlockTransactionCountByHash', [NON_EXISTING_BLOCK_HASH]);
             expect(res).to.be.null;
         });
 
-        it('should execute "eth_getBlockTransactionCountByNumber"', async function() {
+        it('should execute "eth_getBlockTransactionCountByNumber"', async function () {
             const res = await relay.call('eth_getBlockTransactionCountByNumber', [mirrorBlock.number]);
             expect(res).to.be.equal(mirrorBlock.count);
         });
 
-        it('should execute "eth_getBlockTransactionCountByNumber" for non-existing block number', async function() {
+        it('should execute "eth_getBlockTransactionCountByNumber" for non-existing block number', async function () {
             const res = await relay.call('eth_getBlockTransactionCountByNumber', [NON_EXISTING_BLOCK_NUMBER]);
             expect(res).to.be.null;
         });
 
-        it('should execute "eth_blockNumber"', async function() {
+        it('should execute "eth_blockNumber"', async function () {
 
             const mirrorBlocks = await mirrorNode.get(`blocks`);
             expect(mirrorBlocks).to.have.property('blocks');
@@ -234,8 +250,8 @@ describe('RPC Server Acceptance Tests', function() {
 
         const defaultLegacyTransactionData = {
             value: ONE_TINYBAR,
-            gasPrice: 720000000000,
-            gasLimit: 3000000
+            gasPrice: 7200000000000,
+            gasLimit: 30000000
         };
 
         const default155TransactionData = {
@@ -246,8 +262,8 @@ describe('RPC Server Acceptance Tests', function() {
         const defaultLondonTransactionData = {
             value: ONE_TINYBAR,
             chainId: Number(CHAIN_ID),
-            maxPriorityFeePerGas: 720000000000,
-            maxFeePerGas: 720000000000,
+            maxPriorityFeePerGas: 7200000000000,
+            maxFeePerGas: 7200000000000,
             gasLimit: 300000,
             type: 2
         };
@@ -255,45 +271,45 @@ describe('RPC Server Acceptance Tests', function() {
         const defaultLegacy2930TransactionData = {
             value: ONE_TINYBAR,
             chainId: Number(CHAIN_ID),
-            gasPrice: 720000000000,
-            gasLimit: 3000000,
+            gasPrice: 7200000000000,
+            gasLimit: 30000000,
             type: 1
         };
 
-        it('should execute "eth_getTransactionByBlockHashAndIndex"', async function() {
+        it('should execute "eth_getTransactionByBlockHashAndIndex"', async function () {
             const response = await relay.call('eth_getTransactionByBlockHashAndIndex',
                 [mirrorContractDetails.block_hash, mirrorContractDetails.transaction_index]);
             Assertions.transaction(response, mirrorContractDetails);
         });
 
-        it('should execute "eth_getTransactionByBlockHashAndIndex" for invalid block hash', async function() {
+        it('should execute "eth_getTransactionByBlockHashAndIndex" for invalid block hash', async function () {
             const response = await relay.call('eth_getTransactionByBlockHashAndIndex',
                 [NON_EXISTING_BLOCK_HASH, mirrorContractDetails.transaction_index]);
             expect(response).to.be.null;
         });
 
-        it('should execute "eth_getTransactionByBlockHashAndIndex" for invalid index', async function() {
+        it('should execute "eth_getTransactionByBlockHashAndIndex" for invalid index', async function () {
             const response = await relay.call('eth_getTransactionByBlockHashAndIndex',
                 [mirrorContractDetails.block_hash, NON_EXISTING_INDEX]);
             expect(response).to.be.null;
         });
 
-        it('should execute "eth_getTransactionByBlockNumberAndIndex"', async function() {
+        it('should execute "eth_getTransactionByBlockNumberAndIndex"', async function () {
             const response = await relay.call('eth_getTransactionByBlockNumberAndIndex', [mirrorContractDetails.block_number, mirrorContractDetails.transaction_index]);
             Assertions.transaction(response, mirrorContractDetails);
         });
 
-        it('should execute "eth_getTransactionByBlockNumberAndIndex" for invalid index', async function() {
+        it('should execute "eth_getTransactionByBlockNumberAndIndex" for invalid index', async function () {
             const response = await relay.call('eth_getTransactionByBlockNumberAndIndex', [mirrorContractDetails.block_number, NON_EXISTING_INDEX]);
             expect(response).to.be.null;
         });
 
-        it('should execute "eth_getTransactionByBlockNumberAndIndex" for non-exising block number', async function() {
+        it('should execute "eth_getTransactionByBlockNumberAndIndex" for non-exising block number', async function () {
             const response = await relay.call('eth_getTransactionByBlockNumberAndIndex', [NON_EXISTING_BLOCK_NUMBER, mirrorContractDetails.transaction_index]);
             expect(response).to.be.null;
         });
 
-        it('should execute "eth_getTransactionReceipt" for hash of legacy transaction', async function() {
+        it('should execute "eth_getTransactionReceipt" for hash of legacy transaction', async function () {
             const transaction = {
                 ...default155TransactionData,
                 to: mirrorContract.evm_address,
@@ -310,7 +326,7 @@ describe('RPC Server Acceptance Tests', function() {
             Assertions.transactionReceipt(res, mirrorResult);
         });
 
-        it('should execute "eth_getTransactionReceipt" for hash of London transaction', async function() {
+        it('should execute "eth_getTransactionReceipt" for hash of London transaction', async function () {
             const transaction = {
                 ...defaultLondonTransactionData,
                 to: mirrorContract.evm_address,
@@ -327,12 +343,12 @@ describe('RPC Server Acceptance Tests', function() {
             Assertions.transactionReceipt(res, mirrorResult);
         });
 
-        it('should execute "eth_getTransactionReceipt" for non-existing hash', async function() {
+        it('should execute "eth_getTransactionReceipt" for non-existing hash', async function () {
             const res = await relay.call('eth_getTransactionReceipt', [NON_EXISTING_TX_HASH]);
             expect(res).to.be.null;
         });
 
-        it('should execute "eth_sendRawTransaction" for legacy EIP 155 transactions', async function() {
+        it('should execute "eth_sendRawTransaction" for legacy EIP 155 transactions', async function () {
             const receiverInitialBalance = await relay.getBalance(mirrorContract.evm_address);
             const transaction = {
                 ...defaultLondonTransactionData,
@@ -350,7 +366,7 @@ describe('RPC Server Acceptance Tests', function() {
             expect(balanceChange.toString()).to.eq(ONE_TINYBAR.toString());
         });
 
-        it('should fail "eth_sendRawTransaction" for Legacy transactions (with no chainId)', async function() {
+        it('should fail "eth_sendRawTransaction" for Legacy transactions (with no chainId)', async function () {
             const transaction = {
                 ...defaultLegacyTransactionData,
                 to: mirrorContract.evm_address,
@@ -361,7 +377,7 @@ describe('RPC Server Acceptance Tests', function() {
             await relay.callFailing('eth_sendRawTransaction', [signedTx]);
         });
 
-        it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions', async function() {
+        it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions', async function () {
             const transaction = {
                 ...defaultLegacy2930TransactionData,
                 to: mirrorContract.evm_address,
@@ -371,7 +387,7 @@ describe('RPC Server Acceptance Tests', function() {
             await relay.callFailing('eth_sendRawTransaction', [signedTx]);
         });
 
-        it('should execute "eth_sendRawTransaction" for London transactions', async function() {
+        it('should execute "eth_sendRawTransaction" for London transactions', async function () {
             const receiverInitialBalance = await relay.getBalance(mirrorContract.evm_address);
 
             const transaction = {
@@ -390,37 +406,37 @@ describe('RPC Server Acceptance Tests', function() {
             expect(balanceChange.toString()).to.eq(ONE_TINYBAR.toString());
         });
 
-        it('should execute "eth_getTransactionCount" primary', async function() {
+        it('should execute "eth_getTransactionCount" primary', async function () {
             const res = await relay.call('eth_getTransactionCount', [mirrorPrimaryAccount.evm_address, mirrorContractDetails.block_number]);
             expect(res).to.be.equal('0x0');
         });
 
-        it('should execute "eth_getTransactionCount" secondary', async function() {
+        it('should execute "eth_getTransactionCount" secondary', async function () {
             const res = await relay.call('eth_getTransactionCount', [mirrorSecondaryAccount.evm_address, mirrorContractDetails.block_number]);
             expect(res).to.be.equal('0x0');
         });
 
-        it('should execute "eth_getTransactionCount" contract', async function() {
+        it('should execute "eth_getTransactionCount" contract', async function () {
             const res = await relay.call('eth_getTransactionCount', [mirrorContract.evm_address, mirrorContractDetails.block_number]);
             expect(res).to.be.equal('0x1');
         });
 
-        it('should execute "eth_getTransactionCount" for account with id converted to evm_address', async function() {
+        it('should execute "eth_getTransactionCount" for account with id converted to evm_address', async function () {
             const res = await relay.call('eth_getTransactionCount', [Utils.idToEvmAddress(mirrorPrimaryAccount.account), mirrorContractDetails.block_number]);
             expect(res).to.be.equal('0x0');
         });
 
-        it('should execute "eth_getTransactionCount" contract with id converted to evm_address', async function() {
+        it('should execute "eth_getTransactionCount" contract with id converted to evm_address', async function () {
             const res = await relay.call('eth_getTransactionCount', [Utils.idToEvmAddress(contractId.toString()), mirrorContractDetails.block_number]);
             expect(res).to.be.equal('0x1');
         });
 
-        it('should execute "eth_getTransactionCount" for non-existing address', async function() {
+        it('should execute "eth_getTransactionCount" for non-existing address', async function () {
             const res = await relay.call('eth_getTransactionCount', [NON_EXISTING_ADDRESS, mirrorContractDetails.block_number]);
             expect(res).to.be.equal('0x0');
         });
 
-        it('should execute "eth_getTransactionCount" for account with non-zero nonce', async function() {
+        it('should execute "eth_getTransactionCount" for account with non-zero nonce', async function () {
             const account = await servicesNode.createAliasAccount();
             // Wait for account creation to propagate
             await mirrorNode.get(`/accounts/${account.accountId}`);
@@ -440,7 +456,7 @@ describe('RPC Server Acceptance Tests', function() {
             expect(res).to.be.equal('0x1');
         });
 
-        it('should execute "eth_getTransactionByHash" for existing transaction', async function() {
+        it('should execute "eth_getTransactionByHash" for existing transaction', async function () {
             const transaction = {
                 ...defaultLondonTransactionData,
                 to: mirrorContract.evm_address,
@@ -454,25 +470,25 @@ describe('RPC Server Acceptance Tests', function() {
             Assertions.transaction(res, mirrorTransaction);
         });
 
-        it('should execute "eth_getTransactionByHash" for non-existing transaction and return null', async function() {
+        it('should execute "eth_getTransactionByHash" for non-existing transaction and return null', async function () {
             const res = await relay.call('eth_getTransactionByHash', [NON_EXISTING_TX_HASH]);
             expect(res).to.be.null;
         });
     });
 
-    it('should execute "eth_estimateGas"', async function() {
+    it('should execute "eth_estimateGas"', async function () {
         const res = await relay.call('eth_estimateGas', []);
         expect(res).to.contain('0x');
         expect(res).to.not.be.equal('0x');
         expect(res).to.not.be.equal('0x0');
     });
 
-    it('should execute "eth_gasPrice"', async function() {
+    it('should execute "eth_gasPrice"', async function () {
         const res = await relay.call('eth_gasPrice', []);
         expect(res).to.be.equal('0xa7a3582000');
     });
 
-    it('should execute "eth_getBalance" for newly created account with 10 HBAR', async function() {
+    it('should execute "eth_getBalance" for newly created account with 10 HBAR', async function () {
         const account = await servicesNode.createAliasAccount(10);
         // Wait for account creation to propagate
         await mirrorNode.get(`/accounts/${account.accountId}`);
@@ -484,17 +500,17 @@ describe('RPC Server Acceptance Tests', function() {
         expect(res).to.eq(ethers.utils.hexValue(balanceInWeiBars));
     });
 
-    it('should execute "eth_getBalance" for non-existing address', async function() {
+    it('should execute "eth_getBalance" for non-existing address', async function () {
         const res = await relay.call('eth_getBalance', [NON_EXISTING_ADDRESS, 'latest']);
         expect(res).to.eq('0x0');
     });
 
-    it('should execute "eth_getBalance" for contract', async function() {
+    it('should execute "eth_getBalance" for contract', async function () {
         const res = await relay.call('eth_getBalance', [Utils.idToEvmAddress(contractId.toString()), 'latest']);
         expect(res).to.eq(ethers.utils.hexValue(ONE_WEIBAR));
     });
 
-    it('should execute "eth_getBalance" for contract with id converted to evm_address', async function() {
+    it('should execute "eth_getBalance" for contract with id converted to evm_address', async function () {
         const res = await relay.call('eth_getBalance', [Utils.idToEvmAddress(contractId.toString()), 'latest']);
         expect(res).to.eq(ethers.utils.hexValue(ONE_WEIBAR));
     });
@@ -506,77 +522,77 @@ describe('RPC Server Acceptance Tests', function() {
             mirrorBlock = (await mirrorNode.get(`/blocks?block.number=${mirrorContractDetails.block_number}`)).blocks[0];
         });
 
-        it('should execute "eth_chainId"', async function() {
+        it('should execute "eth_chainId"', async function () {
             const res = await relay.call('eth_chainId', [null]);
             expect(res).to.be.equal(CHAIN_ID);
         });
 
-        it('should execute "net_listening"', async function() {
+        it('should execute "net_listening"', async function () {
             const res = await relay.call('net_listening', []);
             expect(res).to.be.equal('false');
         });
 
-        it('should execute "net_version"', async function() {
+        it('should execute "net_version"', async function () {
             const res = await relay.call('net_version', []);
             expect(res).to.be.equal(CHAIN_ID);
         });
 
-        it('should execute "eth_getUncleByBlockHashAndIndex"', async function() {
+        it('should execute "eth_getUncleByBlockHashAndIndex"', async function () {
             const res = await relay.call('eth_getUncleByBlockHashAndIndex', [mirrorBlock.hash, 0]);
             expect(res).to.be.null;
         });
 
-        it('should execute "eth_getUncleByBlockHashAndIndex" for non-existing block hash and index=0', async function() {
+        it('should execute "eth_getUncleByBlockHashAndIndex" for non-existing block hash and index=0', async function () {
             const res = await relay.call('eth_getUncleByBlockHashAndIndex', [NON_EXISTING_BLOCK_HASH, 0]);
             expect(res).to.be.null;
         });
 
-        it('should execute "eth_getUncleByBlockNumberAndIndex"', async function() {
+        it('should execute "eth_getUncleByBlockNumberAndIndex"', async function () {
             const res = await relay.call('eth_getUncleByBlockNumberAndIndex', [mirrorBlock.number, 0]);
             expect(res).to.be.null;
         });
 
-        it('should execute "eth_getUncleByBlockNumberAndIndex" for non-existing block number and index=0', async function() {
+        it('should execute "eth_getUncleByBlockNumberAndIndex" for non-existing block number and index=0', async function () {
             const res = await relay.call('eth_getUncleByBlockNumberAndIndex', [NON_EXISTING_BLOCK_NUMBER, 0]);
             expect(res).to.be.null;
         });
 
-        it('should execute "eth_getUncleCountByBlockHash"', async function() {
+        it('should execute "eth_getUncleCountByBlockHash"', async function () {
             const res = await relay.call('eth_getUncleCountByBlockHash', []);
             expect(res).to.be.equal('0x0');
         });
 
-        it('should execute "eth_getUncleCountByBlockNumber"', async function() {
+        it('should execute "eth_getUncleCountByBlockNumber"', async function () {
             const res = await relay.call('eth_getUncleCountByBlockNumber', []);
             expect(res).to.be.equal('0x0');
         });
 
-        it('should return empty on "eth_accounts"', async function() {
+        it('should return empty on "eth_accounts"', async function () {
             const res = await relay.call('eth_accounts', []);
             expect(res).to.deep.equal([]);
         });
 
-        it('should execute "eth_hashrate"', async function() {
+        it('should execute "eth_hashrate"', async function () {
             const res = await relay.call('eth_hashrate', []);
             expect(res).to.be.equal('0x0');
         });
 
-        it('should execute "eth_mining"', async function() {
+        it('should execute "eth_mining"', async function () {
             const res = await relay.call('eth_mining', []);
             expect(res).to.be.equal(false);
         });
 
-        it('should execute "eth_submitWork"', async function() {
+        it('should execute "eth_submitWork"', async function () {
             const res = await relay.call('eth_submitWork', []);
             expect(res).to.be.equal(false);
         });
 
-        it('should execute "eth_syncing"', async function() {
+        it('should execute "eth_syncing"', async function () {
             const res = await relay.call('eth_syncing', []);
             expect(res).to.be.equal(false);
         });
 
-        it('should execute "web3_client_version"', async function() {
+        it('should execute "web3_client_version"', async function () {
             const res = await relay.call('web3_client_version', []);
             expect(res).to.contain('relay/');
         });
@@ -585,31 +601,31 @@ describe('RPC Server Acceptance Tests', function() {
 
     describe('Unsupported RPC Endpoints', () => {
 
-        it('should not support "eth_submitHashrate"', async function() {
+        it('should not support "eth_submitHashrate"', async function () {
             await relay.callUnsupported('eth_submitHashrate', []);
         });
 
-        it('should not support "eth_getWork"', async function() {
+        it('should not support "eth_getWork"', async function () {
             await relay.callUnsupported('eth_getWork', []);
         });
 
-        it('should not support "eth_coinbase"', async function() {
+        it('should not support "eth_coinbase"', async function () {
             await relay.callUnsupported('eth_coinbase', []);
         });
 
-        it('should not support "eth_sendTransaction"', async function() {
+        it('should not support "eth_sendTransaction"', async function () {
             await relay.callUnsupported('eth_sendTransaction', []);
         });
 
-        it('should not support "eth_protocolVersion"', async function() {
+        it('should not support "eth_protocolVersion"', async function () {
             await relay.callUnsupported('eth_protocolVersion', []);
         });
 
-        it('should not support "eth_sign"', async function() {
+        it('should not support "eth_sign"', async function () {
             await relay.callUnsupported('eth_sign', []);
         });
 
-        it('should not support "eth_signTransaction"', async function() {
+        it('should not support "eth_signTransaction"', async function () {
             await relay.callUnsupported('eth_signTransaction', []);
         });
     });
@@ -654,7 +670,7 @@ describe('RPC Server Acceptance Tests', function() {
         });
     });
 
-    after(function() {
+    after(function () {
         if (USE_LOCAL_NODE === 'true') {
             // stop local-node
             logger.info('Shutdown local node');

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -90,6 +90,7 @@ describe('RPC Server Acceptance Tests', function () {
     const servicesNode = new ServicesClient(NETWORK, OPERATOR_ID, OPERATOR_KEY, logger.child({ name: `acctest-services-client` }));
     const mirrorNode = new MirrorClient(MIRROR_NODE_URL, logger.child({ name: `acctest-mirror-node-client` }));
     const relay = new RelayClient(RELAY_URL, logger.child({ name: `acctest-relay-client` }));
+    
     this.beforeAll(async () => {
         // configuration details
         logger.info('Acceptance Tests Configurations successfully loaded');
@@ -99,7 +100,6 @@ describe('RPC Server Acceptance Tests', function () {
         logger.info(`OPERATOR_ID_MAIN: ${process.env.OPERATOR_ID_MAIN}`);
         logger.info(`MIRROR_NODE_URL: ${process.env.MIRROR_NODE_URL}`);
         logger.info(`E2E_RELAY_HOST: ${process.env.E2E_RELAY_HOST}`);
-        startOperatorBalance = await servicesNode.getOperatorBalance();
 
 
         if (USE_LOCAL_NODE === 'true') {
@@ -109,6 +109,9 @@ describe('RPC Server Acceptance Tests', function () {
         if (RELAY_URL === LOCAL_RELAY_URL) {
             runLocalRelay();
         }
+
+        // cache start balance
+        startOperatorBalance = await servicesNode.getOperatorBalance();
 
         accounts[0] = await servicesNode.createAliasAccount(20);
         accounts[1] = await servicesNode.createAliasAccount();
@@ -664,7 +667,7 @@ describe('RPC Server Acceptance Tests', function () {
         });
     });
 
-    this.afterAll(async () => {
+    this.afterAll(async () =>  {
         if (USE_LOCAL_NODE === 'true') {
             // stop local-node
             logger.info('Shutdown local node');

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -668,6 +668,10 @@ describe('RPC Server Acceptance Tests', function () {
     });
 
     this.afterAll(async () =>  {
+        const endOperatorBalance = await servicesNode.getOperatorBalance();
+        const cost = startOperatorBalance.toTinybars().subtract(endOperatorBalance.toTinybars());
+        logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
+
         if (USE_LOCAL_NODE === 'true') {
             // stop local-node
             logger.info('Shutdown local node');
@@ -679,10 +683,6 @@ describe('RPC Server Acceptance Tests', function () {
         if (relayServer !== undefined) {
             relayServer.close();
         }
-
-        const endOperatorBalance = await servicesNode.getOperatorBalance();
-        const cost = startOperatorBalance.toTinybars().subtract(endOperatorBalance.toTinybars());
-        logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
     });
 
     function runLocalHederaNetwork() {

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -142,7 +142,7 @@ describe('RPC Server Acceptance Tests', function () {
 
         let mirrorBlock;
         let mirrorContractResults;
-        let mirrorTransactions: any[] = [];
+        const mirrorTransactions: any[] = [];
 
         before(async () => {
             mirrorBlock = (await mirrorNode.get(`/blocks?block.number=${mirrorContractDetails.block_number}`)).blocks[0];
@@ -244,11 +244,12 @@ describe('RPC Server Acceptance Tests', function () {
     });
 
     describe('Transaction related RPC Calls', () => {
-
+        const defaultGasPrice = 720_000_000_000;
+        const defaultGasLimit = 3_000_000;
         const defaultLegacyTransactionData = {
             value: ONE_TINYBAR,
-            gasPrice: 7200000000000,
-            gasLimit: 30000000
+            gasPrice: defaultGasPrice,
+            gasLimit: defaultGasLimit
         };
 
         const default155TransactionData = {
@@ -259,17 +260,17 @@ describe('RPC Server Acceptance Tests', function () {
         const defaultLondonTransactionData = {
             value: ONE_TINYBAR,
             chainId: Number(CHAIN_ID),
-            maxPriorityFeePerGas: 7200000000000,
-            maxFeePerGas: 7200000000000,
-            gasLimit: 300000,
+            maxPriorityFeePerGas: defaultGasPrice,
+            maxFeePerGas: defaultGasPrice,
+            gasLimit: defaultGasLimit,
             type: 2
         };
 
         const defaultLegacy2930TransactionData = {
             value: ONE_TINYBAR,
             chainId: Number(CHAIN_ID),
-            gasPrice: 7200000000000,
-            gasLimit: 30000000,
+            gasPrice: defaultGasPrice,
+            gasLimit: defaultGasLimit,
             type: 1
         };
 

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -135,12 +135,6 @@ describe('RPC Server Acceptance Tests', function () {
         mirrorSecondaryAccount = (await mirrorNode.get(`accounts?account.id=${accounts[1].accountId}`)).accounts[0];
     });
 
-    this.afterAll(async () => {
-        const endOperatorBalance = await servicesNode.getOperatorBalance();
-        const cost = startOperatorBalance.toTinybars().subtract(endOperatorBalance.toTinybars());
-        logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
-    });
-
     describe('Block related RPC calls', () => {
 
         let mirrorBlock;
@@ -670,7 +664,7 @@ describe('RPC Server Acceptance Tests', function () {
         });
     });
 
-    after(function () {
+    this.afterAll(async () => {
         if (USE_LOCAL_NODE === 'true') {
             // stop local-node
             logger.info('Shutdown local node');
@@ -682,6 +676,10 @@ describe('RPC Server Acceptance Tests', function () {
         if (relayServer !== undefined) {
             relayServer.close();
         }
+
+        const endOperatorBalance = await servicesNode.getOperatorBalance();
+        const cost = startOperatorBalance.toTinybars().subtract(endOperatorBalance.toTinybars());
+        logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
     });
 
     function runLocalHederaNetwork() {

--- a/packages/server/tests/clients/mirrorClient.ts
+++ b/packages/server/tests/clients/mirrorClient.ts
@@ -52,7 +52,8 @@ export default class MirrorClient {
 
                 // if retry condition is not specified, by default idempotent requests are retried
                 return error?.response?.status === 400 || error?.response?.status === 404;
-            }
+            },
+            shouldResetTimeout: true,
         });
 
         this.client = mirrorNodeClient;

--- a/packages/server/tests/clients/servicesClient.ts
+++ b/packages/server/tests/clients/servicesClient.ts
@@ -254,6 +254,12 @@ export default class ServicesClient {
         return this.client.operatorAccountId || AccountId.fromString('0.0.0');
     }
 
+    async getOperatorBalance(): Promise<Hbar> {
+        const accountBalance = await (new AccountBalanceQuery()
+            .setAccountId(this.client.operatorAccountId!))
+            .execute(this.client);
+        return accountBalance.hbars;
+    }
 }
 
 export class AliasAccount {


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Improve acceptance test runs
- Update `rpc.spect.ts`
  - differentiate logs
  - increase account1 balance to afford other transactions
  - log configurations
  - display test expense
- Shorten client logs
- Fix missed metric removal logic
- Trim `OPERATOR_ID_MAIN`
- Add timeout reset on mirror client
- add operator balance check


**Related issue(s)**:

Fixes #243 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
