### PR TITLE
Fix nonce zerohexbytes regression

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -850,7 +850,7 @@ export class EthImpl implements Eth {
       logsBloom: EthImpl.emptyBloom, //TODO calculate full block boom in mirror node
       miner: EthImpl.zeroAddressHex,
       mixHash: EthImpl.zeroHex32Byte,
-      nonce: EthImpl.zeroHex,
+      nonce: EthImpl.zeroHex8Byte,
       number: EthImpl.numberTo0x(blockResponse.number),
       parentHash: blockResponse.previous_hash.substring(0, 66),
       receiptsRoot: EthImpl.zeroHex32Byte,

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -58,7 +58,7 @@ const verifyBlockConstants = (block: Block) => {
   expect(block.extraData).equal(EthImpl.emptyHex);
   expect(block.miner).equal(EthImpl.zeroAddressHex);
   expect(block.mixHash).equal(EthImpl.zeroHex32Byte);
-  expect(block.nonce).equal(EthImpl.zeroHex);
+  expect(block.nonce).equal(EthImpl.zeroHex8Byte);
   expect(block.receiptsRoot).equal(EthImpl.zeroHex32Byte);
   expect(block.sha3Uncles).equal(EthImpl.emptyArrayHex);
   expect(block.stateRoot).equal(EthImpl.zeroHex32Byte);

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -24,6 +24,7 @@ import { Utils } from './utils';
 export default class Assertions {
     static emptyHex = '0x';
     static zeroHex32Byte = '0x0000000000000000000000000000000000000000000000000000000000000000';
+    static zeroHex8Byte = '0x0000000000000000';
     static emptyArrayHex = '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347';
     static emptyBloom = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
     static ethEmptyTrie = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421';
@@ -60,7 +61,7 @@ export default class Assertions {
         expect(relayResponse.extraData).to.be.equal(Assertions.emptyHex);
         expect(relayResponse.miner).to.be.equal(ethers.constants.AddressZero);
         expect(relayResponse.mixHash).to.be.equal(Assertions.zeroHex32Byte);
-        expect(relayResponse.nonce).to.be.equal(ethers.utils.hexValue(0));
+        expect(relayResponse.nonce).to.be.equal(Assertions.zeroHex8Byte);
         expect(relayResponse.receiptsRoot).to.be.equal(Assertions.zeroHex32Byte);
         expect(relayResponse.sha3Uncles).to.be.equal(Assertions.emptyArrayHex);
         expect(relayResponse.stateRoot).to.be.equal(Assertions.zeroHex32Byte);


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
There was a regression that lost the use of the `EthImpl.zeroHex8Byte`
Restore this
- Update `eth.ts` to use `EthImpl.zeroHex8Byte`
- Update `eth.spec.ts` to use `EthImpl.zeroHex8Byte`

**Related issue(s)**:

Fixes #149 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
