### PR TITLE
Improve MirrorNodeClient 500 handling

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -70,7 +70,7 @@ export class MirrorNodeClient {
         DESC: 'desc'
     };
 
-    private static httpCodeInternalServerError = 500;
+    private static badGatewayHttpStatusCode = 502;
 
     /**
      * The logger used for logging all output from this class.
@@ -149,7 +149,7 @@ export class MirrorNodeClient {
             return response.data;
         } catch (error: any) {
             ms = Date.now() - start;
-            const effectiveStatusCode = error.response !== undefined ? error.response.status : MirrorNodeClient.httpCodeInternalServerError;            
+            const effectiveStatusCode = error.response !== undefined ? error.response.status : MirrorNodeClient.badGatewayHttpStatusCode;            
             this.mirrorResponseHistogram.labels(pathLabel, effectiveStatusCode).observe(ms);
             this.handleError(error, path, effectiveStatusCode, allowedErrorStatuses);
         }
@@ -159,7 +159,7 @@ export class MirrorNodeClient {
     handleError(error: any, path: string, effectiveStatusCode: number, allowedErrorStatuses?: number[]) {
         if (allowedErrorStatuses && allowedErrorStatuses.length) {
             if (error.response && allowedErrorStatuses.indexOf(effectiveStatusCode) !== -1) {
-                this.logger.debug(`[GET] ${path} ${error.response.status} status`);
+                this.logger.debug(`[GET] ${path} ${effectiveStatusCode} status`);
                 return null;
             }
         }

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -70,7 +70,7 @@ export class MirrorNodeClient {
         DESC: 'desc'
     };
 
-    private static badGatewayHttpStatusCode = 502;
+    private static unknownServerErrorHttpStatusCode = 567;
 
     /**
      * The logger used for logging all output from this class.
@@ -149,7 +149,7 @@ export class MirrorNodeClient {
             return response.data;
         } catch (error: any) {
             ms = Date.now() - start;
-            const effectiveStatusCode = error.response !== undefined ? error.response.status : MirrorNodeClient.badGatewayHttpStatusCode;            
+            const effectiveStatusCode = error.response !== undefined ? error.response.status : MirrorNodeClient.unknownServerErrorHttpStatusCode;            
             this.mirrorResponseHistogram.labels(pathLabel, effectiveStatusCode).observe(ms);
             this.handleError(error, path, effectiveStatusCode, allowedErrorStatuses);
         }


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Improve 500 response handling
- Update `MirrorNodeClient` to check for valid error response and handle absence

**Related issue(s)**:

Fixes #261 

**Notes for reviewer**:
Flow now correctly displays
```
err: {
  "type": "Error",
  "message": "connect ECONNREFUSED 127.0.0.1:5551",
  "stack":
      Error: connect ECONNREFUSED 127.0.0.1:5551
          at MirrorNodeClient.handleError (.../hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:106:27)
          at MirrorNodeClient.<anonymous> (.../hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:94:22)
          at Generator.throw (<anonymous>)
          at rejected (.../hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:25:65)
          at processTicksAndRejections (node:internal/process/task_queues:96:5)
}

[POST] eth_blockNumber: -32603 6 msESC[39m
code: -32603
message: "Unknown error invoking RPC"
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
