### PR TITLE
Fix block root properties default hash formats

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -46,6 +46,7 @@ export class EthImpl implements Eth {
   static emptyHex = '0x';
   static zeroHex = '0x0';
   static zeroHex8Byte = '0x0000000000000000';
+  static zeroHex32Byte = '0x0000000000000000000000000000000000000000000000000000000000000000';
   static emptyArrayHex = '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347';
   static zeroAddressHex = '0x0000000000000000000000000000000000000000';
   static emptyBloom = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
@@ -848,15 +849,15 @@ export class EthImpl implements Eth {
       hash: blockHash,
       logsBloom: EthImpl.emptyBloom, //TODO calculate full block boom in mirror node
       miner: EthImpl.zeroAddressHex,
-      mixHash: EthImpl.emptyHex,
+      mixHash: EthImpl.zeroHex32Byte,
       nonce: EthImpl.zeroHex,
       number: EthImpl.numberTo0x(blockResponse.number),
       parentHash: blockResponse.previous_hash.substring(0, 66),
-      receiptsRoot: EthImpl.zeroHex,
+      receiptsRoot: EthImpl.zeroHex32Byte,
       timestamp: EthImpl.numberTo0x(Number(timestamp)),
       sha3Uncles: EthImpl.emptyArrayHex,
       size: EthImpl.numberTo0x(blockResponse.size | 0),
-      stateRoot: EthImpl.zeroHex,
+      stateRoot: EthImpl.zeroHex32Byte,
       totalDifficulty: EthImpl.zeroHex,
       transactions: transactionArray,
       transactionsRoot: transactionArray.length == 0 ? EthImpl.ethEmptyTrie : blockHash,

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -57,11 +57,11 @@ const verifyBlockConstants = (block: Block) => {
   expect(block.difficulty).equal(EthImpl.zeroHex);
   expect(block.extraData).equal(EthImpl.emptyHex);
   expect(block.miner).equal(EthImpl.zeroAddressHex);
-  expect(block.mixHash).equal(EthImpl.emptyHex);
+  expect(block.mixHash).equal(EthImpl.zeroHex32Byte);
   expect(block.nonce).equal(EthImpl.zeroHex);
-  expect(block.receiptsRoot).equal(EthImpl.zeroHex);
+  expect(block.receiptsRoot).equal(EthImpl.zeroHex32Byte);
   expect(block.sha3Uncles).equal(EthImpl.emptyArrayHex);
-  expect(block.stateRoot).equal(EthImpl.zeroHex);
+  expect(block.stateRoot).equal(EthImpl.zeroHex32Byte);
   expect(block.totalDifficulty).equal(EthImpl.zeroHex);
   expect(block.uncles).to.deep.equal([]);
 };

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -23,6 +23,7 @@ import { Utils } from './utils';
 
 export default class Assertions {
     static emptyHex = '0x';
+    static zeroHex32Byte = '0x0000000000000000000000000000000000000000000000000000000000000000';
     static emptyArrayHex = '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347';
     static emptyBloom = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
     static ethEmptyTrie = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421';
@@ -58,11 +59,11 @@ export default class Assertions {
         expect(relayResponse.difficulty).to.be.equal(ethers.utils.hexValue(0));
         expect(relayResponse.extraData).to.be.equal(Assertions.emptyHex);
         expect(relayResponse.miner).to.be.equal(ethers.constants.AddressZero);
-        expect(relayResponse.mixHash).to.be.equal(Assertions.emptyHex);
+        expect(relayResponse.mixHash).to.be.equal(Assertions.zeroHex32Byte);
         expect(relayResponse.nonce).to.be.equal(ethers.utils.hexValue(0));
-        expect(relayResponse.receiptsRoot).to.be.equal(ethers.utils.hexValue(0));
+        expect(relayResponse.receiptsRoot).to.be.equal(Assertions.zeroHex32Byte);
         expect(relayResponse.sha3Uncles).to.be.equal(Assertions.emptyArrayHex);
-        expect(relayResponse.stateRoot).to.be.equal(ethers.utils.hexValue(0));
+        expect(relayResponse.stateRoot).to.be.equal(Assertions.zeroHex32Byte);
         expect(relayResponse.totalDifficulty).to.be.equal(ethers.utils.hexValue(0));
         expect(relayResponse.uncles).to.be.exist;
         expect(relayResponse.uncles.length).to.eq(0);


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
`block.mixHash`, `block.receiptsRoot` and `block.stateRoot` should return hexes of 32byte formats
- Update `eth.ts` to use 32 bytes format
- Update `eth.spec.ts` to use 32 bytes format
- Updated `assertions`  to use 32 bytes format

**Related issue(s)**:

Fixes #256 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
