### PR TITLE
268 fix get logs

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -970,22 +970,22 @@ export class EthImpl implements Eth {
     }
     const logs = result.logs;
 
-    // Find all unique contractId and timestamp pairs and for each one make mirror node request
+    // Find unique contract execution timestamp and for each one make mirror node request
     const promises: Promise<any>[] = [];
     const uniquePairs = {};
 
     for (let i = 0; i < logs.length; i++) {
       const log = logs[i];
-      const pair = `${log.contract_id}-${log.timestamp}`;
-      if (uniquePairs[pair] === undefined) {
-        uniquePairs[pair] = [i];
+      const timestamp = `${log.timestamp}`;
+      if (uniquePairs[timestamp] === undefined) {
+        uniquePairs[timestamp] = [i];
         promises.push(this.mirrorNodeClient.getContractResultsDetails(
           log.contract_id,
           log.timestamp
         ));
       }
       else {
-        uniquePairs[pair].push(i);
+        uniquePairs[timestamp].push(i);
       }
     }
 
@@ -994,8 +994,9 @@ export class EthImpl implements Eth {
       const contractsResultsDetails = await Promise.all(promises);
       for (let i = 0; i < contractsResultsDetails.length; i++) {
         const detail = contractsResultsDetails[i];
-        const pair = `${detail.contract_id}-${detail.timestamp}`;
-        const uPair = uniquePairs[pair] || [];
+        // retrieve set of logs for each timestamp
+        const timestamp = `${detail.timestamp}`;
+        const uPair = uniquePairs[timestamp] || [];
         for (let p = 0; p < uPair.length; p++) {
           const logIndex = uPair[p];
           const log = logs[logIndex];

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -121,6 +121,7 @@ describe('Eth calls using MirrorNode', async function () {
   const contractHash3 = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6394';
   const contractAddress2 = '0x000000000000000000000000000000000000055e';
   const contractTimestamp2 = '1653077542.701408897';
+  const contractTimestamp3 = '1653088542.123456789';
   const contractId1 = '0.0.5001';
   const contractId2 = '0.0.5002';
 
@@ -242,7 +243,7 @@ describe('Eth calls using MirrorNode', async function () {
 
   const defaultDetailedContractResults3 = {
     ...defaultDetailedContractResults, ...{
-      'timestamp': contractTimestamp2,
+      'timestamp': contractTimestamp3,
       'block_hash': blockHash3,
       'block_number': blockNumber3,
       'hash': contractHash3,
@@ -300,7 +301,7 @@ describe('Eth calls using MirrorNode', async function () {
         "bloom": logBloom3,
         "contract_id": contractId1,
         "data": "0x",
-        "index": 1,
+        "index": 0,
         "topics": [],
         "root_contract_id": "0.0.34806097",
         "timestamp": contractTimestamp2
@@ -310,10 +311,10 @@ describe('Eth calls using MirrorNode', async function () {
         "bloom": logBloom4,
         "contract_id": contractId2,
         "data": "0x",
-        "index": 1,
+        "index": 0,
         "topics": [],
         "root_contract_id": "0.0.34806097",
-        "timestamp": contractTimestamp2
+        "timestamp": contractTimestamp3
       }
     ]
   };
@@ -853,7 +854,7 @@ describe('Eth calls using MirrorNode', async function () {
       mock.onGet(`contracts/results/logs`).reply(200, defaultLogs);
       mock.onGet(`contracts/${contractId1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResults);
       mock.onGet(`contracts/${contractId1}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults2);
-      mock.onGet(`contracts/${contractId2}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults3);
+      mock.onGet(`contracts/${contractId2}/results/${contractTimestamp3}`).reply(200, defaultDetailedContractResults3);
 
       const result = await ethImpl.getLogs(null, null, null, null, null);
       expect(result).to.exist;

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -708,9 +708,9 @@ describe('RPC Server Acceptance Tests', function () {
 
     function runLocalHederaNetwork() {
         // set env variables for docker images until local-node is updated
-        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.26.2';
-        process.env['HAVEGED_IMAGE_TAG'] = '0.26.2';
-        process.env['MIRROR_IMAGE_TAG'] = '0.58.0';
+        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.26.3';
+        process.env['HAVEGED_IMAGE_TAG'] = '0.26.3';
+        process.env['MIRROR_IMAGE_TAG'] = '0.59.0-rc1';
         logger.trace(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 
         // start local-node


### PR DESCRIPTION
**Description**:
`eth-getLogs` logic was grouping transactions via `contractId-timestamp`.
This resulted in logs getting missed since the contractId of logs from called contracts differ from the caller

- Update `eth_getLogs` call to group log results via timestamp to determine unique executions
- Update integration tests
- Updated acceptance test image versions

**Related issue(s)**:

Fixes #268

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
