### PR TITLE
ChainId precheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ SERVER_PORT=7546
 E2E_RELAY_HOST=http://127.0.0.1:7546
 ```
 
+The following table highlights some initial configuration values to consider
+
+| Config      | Default | Description           |
+| ------------|-------|-----------------------|
+| `CHAIN_ID`  | `0x12a` | The netowrk chain id. Local and previewnet envs should use `0x12a`. Mainnet and Testnet should use `0x127` and `0x128` respectively |
+
 > **_NOTE:_** Acceptance tests can be pointed at a remote location. In this case be sure to appropriately update these values to point away from your local host and to valid deployed services.
 
 #### Run

--- a/packages/relay/src/lib/errors.ts
+++ b/packages/relay/src/lib/errors.ts
@@ -70,5 +70,10 @@ export const predefined = {
     name: 'Incorrect nonce',
     code: -32006,
     message: 'Incorrect nonce'
+  }),
+  'UNSUPPORTED_CHAIN_ID': new JsonRpcError({
+    name: 'ChainId not supported',
+    code: -32000,
+    message: 'ChainId not supported'
   })
 };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -555,15 +555,10 @@ export class EthImpl implements Eth {
     this.logger.trace('sendRawTransaction(transaction=%s)', transaction);
     await this.precheck.nonce(transaction);
 
-    this.logger.trace('Performing chainId precheck for sendRawTransaction(transaction=%s)', transaction);
-
-    const precheckRes = this.precheck.chainId(transaction);
-    this.logger.debug(precheckRes.toString());
-    if ( !precheckRes ) {
-      this.logger.trace('FAILED chainId precheck for sendRawTransaction(transaction=%s)', transaction);
+    if ( !this.precheck.chainId(transaction) ) {
+      this.logger.trace('Failed chainId precheck for sendRawTransaction(transaction=%s)', transaction);
       return predefined.UNSUPPORTED_CHAIN_ID;
     }
-    this.logger.trace('SUCCEEDED chainId precheck for sendRawTransaction(transaction=%s)', transaction);
 
     const transactionBuffer = Buffer.from(EthImpl.prune0x(transaction), 'hex');
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -113,7 +113,7 @@ export class EthImpl implements Eth {
     this.mirrorNodeClient = mirrorNodeClient;
     this.logger = logger;
     this.chain = chain;
-    this.precheck = new Precheck(mirrorNodeClient, chain);
+    this.precheck = new Precheck(mirrorNodeClient, logger, chain);
   }
 
   /**
@@ -555,9 +555,13 @@ export class EthImpl implements Eth {
     this.logger.trace('sendRawTransaction(transaction=%s)', transaction);
     await this.precheck.nonce(transaction);
 
-    if ( !this.precheck.chainId(transaction) ) {
-      this.logger.trace('Failed chainId precheck for sendRawTransaction(transaction=%s)', transaction);
-      return predefined.UNSUPPORTED_CHAIN_ID;
+    const chainIdPrecheckRes = this.precheck.chainId(transaction);
+    if ( !chainIdPrecheckRes.passes ) {
+      return new JsonRpcError({
+        name: 'ChainId not supported',
+        code: -32000,
+        message: `ChainId (${chainIdPrecheckRes.chainId}) not supported. The correct chainId is ${this.chain}.`
+      });
     }
 
     const transactionBuffer = Buffer.from(EthImpl.prune0x(transaction), 'hex');

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -62,7 +62,6 @@ export class Precheck {
 
   chainId(transaction: string) {
     const tx = ethers.utils.parseTransaction(transaction);
-    if (!tx.chainId) return true;
     const txChainId = EthImpl.prepend0x(Number(tx.chainId).toString(16));
     return txChainId === this.chain;
   }

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -21,12 +21,15 @@
 import * as ethers from 'ethers';
 import { predefined } from './errors';
 import { MirrorNodeClient } from './clients';
+import {EthImpl} from "./eth";
 
 export class Precheck {
   private mirrorNodeClient: MirrorNodeClient;
+  private chain: string;
 
-  constructor(mirrorNodeClient: MirrorNodeClient) {
+  constructor(mirrorNodeClient: MirrorNodeClient, chainId: string) {
     this.mirrorNodeClient = mirrorNodeClient;
+    this.chain = chainId;
   }
 
   /**
@@ -55,5 +58,12 @@ export class Precheck {
     if (accountInfo && accountInfo.ethereum_nonce > tx.nonce) {
       throw predefined.NONCE_TOO_LOW;
     }
+  }
+
+  chainId(transaction: string) {
+    const tx = ethers.utils.parseTransaction(transaction);
+    if (!tx.chainId) return true;
+    const txChainId = EthImpl.prepend0x(Number(tx.chainId).toString(16));
+    return txChainId === this.chain;
   }
 }

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -53,7 +53,7 @@ describe('Precheck', async function() {
 
         // @ts-ignore
         const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
-        precheck = new Precheck(mirrorNodeInstance, '0x12a');
+        precheck = new Precheck(mirrorNodeInstance, logger, '0x12a');
     });
 
     describe('chainId', async function() {

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -59,12 +59,16 @@ describe('Precheck', async function() {
     describe('chainId', async function() {
         it('should return true for matching chainId', async function() {
             const result = precheck.chainId(txWithMatchingChainId);
-            expect(result).to.eq(true);
+            expect(result).to.exist;
+            expect(result.passes).to.eq(true);
+            expect(result.chainId).to.eq('0x12a');
         });
 
         it('should return false for non-matching chainId', async function() {
             const result = precheck.chainId(txWithNonMatchingChainId);
-            expect(result).to.eq(false);
+            expect(result).to.exist;
+            expect(result.passes).to.eq(false);
+            expect(result.chainId).to.eq('0x0');
         });
     });
 });

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -1,0 +1,70 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { expect } from 'chai';
+import { Registry } from 'prom-client';
+const registry = new Registry();
+
+import pino from 'pino';
+import {Precheck} from "../../src/lib/precheck";
+import {MirrorNodeClient} from "../../src/lib/clients";
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+const logger = pino();
+
+describe('Precheck', async function() {
+
+    const txWithMatchingChainId = '0x02f87482012a0485a7a358200085a7a3582000832dc6c09400000000000000000000000000000000000003f78502540be40080c001a006f4cd8e6f84b76a05a5c1542a08682c928108ef7163d9c1bf1f3b636b1cd1fba032097cbf2dda17a2dcc40f62c97964d9d930cdce2e8a9df9a8ba023cda28e4ad';
+    const txWithNonMatchingChainId = '0xf86a0385a7a3582000832dc6c09400000000000000000000000000000000000003f78502540be400801ca06750e92db52fa708e27f94f27e0cfb7f5800f9b657180bb2e94c1520cfb1fb6da01bec6045068b6db38b55017bb8b50166699384bc1791fd8331febab0cf629a2a';
+
+    let precheck: Precheck;
+    let mock: MockAdapter;
+
+    this.beforeAll(() => {
+        // mock axios
+        const instance = axios.create({
+            baseURL: 'https://localhost:5551/api/v1',
+            responseType: 'json' as const,
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            timeout: 10 * 1000
+        });
+
+        // @ts-ignore
+        mock = new MockAdapter(instance, { onNoMatch: "throwException" });
+
+        // @ts-ignore
+        const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
+        precheck = new Precheck(mirrorNodeInstance, '0x12a');
+    });
+
+    describe('chainId', async function() {
+        it('should return true for matching chainId', async function() {
+            const result = precheck.chainId(txWithMatchingChainId);
+            expect(result).to.eq(true);
+        });
+
+        it('should return false for non-matching chainId', async function() {
+            const result = precheck.chainId(txWithNonMatchingChainId);
+            expect(result).to.eq(false);
+        });
+    });
+});

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -310,7 +310,7 @@ describe('RPC Server Acceptance Tests', function () {
                         Assertions.expectedError();
                     }
                     catch(e) {
-                        Assertions.jsonRpcError(e, -32000, 'ChainId not supported');
+                        Assertions.jsonRpcError(e, -32000, 'ChainId (0x3e7) not supported. The correct chainId is 0x12a.');
                     }
                 });
 
@@ -340,7 +340,7 @@ describe('RPC Server Acceptance Tests', function () {
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     // FIXME We should not be failing with INTERNAL ERROR but rather user friendly error
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'ChainId not supported');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'ChainId (0x0) not supported. The correct chainId is 0x12a.');
                 });
 
                 it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions', async function () {

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -339,7 +339,6 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    // FIXME We should not be failing with INTERNAL ERROR but rather user friendly error
                     await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'ChainId (0x0) not supported. The correct chainId is 0x12a.');
                 });
 

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -340,7 +340,7 @@ describe('RPC Server Acceptance Tests', function () {
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     // FIXME We should not be failing with INTERNAL ERROR but rather user friendly error
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx]);
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'ChainId not supported');
                 });
 
                 it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions', async function () {

--- a/packages/server/tests/clients/mirrorClient.ts
+++ b/packages/server/tests/clients/mirrorClient.ts
@@ -49,7 +49,7 @@ export default class MirrorClient {
             },
             retryCondition: (error) => {
                 if (error?.response?.status === 404) {
-                    this.logger.debug(`Request failed`);
+                    this.logger.info(`${error.message}: ${error.response.config.baseURL}${error.response.config.url}`);
                 }
                 else {
                     this.logger.error(error, `Request failed`);

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -48,13 +48,13 @@ export default class RelayClient {
      * @param methodName
      * @param params
      */
-    async callFailing(methodName: string, params: any[]) {
+    async callFailing(methodName: string, params: any[], expectedCode = -32603, expectedMessage = 'Unknown error invoking RPC') {
         try {
             const res = await this.call(methodName, params);
             this.logger.trace(`[POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`);
             Assertions.expectedError();
         } catch (err) {
-            Assertions.unknownResponse(err);
+            Assertions.jsonRpcError(err, expectedCode, expectedMessage);
         }
     }
 

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -176,8 +176,15 @@ export default class Assertions {
     };
 
     static unknownResponse(err) {
+        Assertions.jsonRpcError(err, -32603, 'Unknown error invoking RPC');
+    }
+
+    static jsonRpcError(err, code, message) {
+        expect(err).to.exist;
+        expect(err).to.have.property('body');
+
         const parsedError = JSON.parse(err.body);
-        expect(parsedError.error.message).to.be.equal('Unknown error invoking RPC');
-        expect(parsedError.error.code).to.be.equal(-32603);
+        expect(parsedError.error.message).to.be.equal(message);
+        expect(parsedError.error.code).to.be.equal(code);
     }
 }


### PR DESCRIPTION
**Description**:
Adds a precheck for `chainId` in `eth_sendRawTransaction`. If the `chainId` in the submitted transaction is different than the one specified in the relay environment an error is thrown: `-32000: ChainId not supported`

**Related issue(s)**:

Fixes #:
https://github.com/hashgraph/hedera-json-rpc-relay/issues/129

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
