### PR TITLE
Add balance precheck to eth_sendRawtransaction

### DIFF
--- a/packages/relay/src/lib/errors.ts
+++ b/packages/relay/src/lib/errors.ts
@@ -76,10 +76,10 @@ export const predefined = {
     code: -32000,
     message: `Request beyond head block: requested ${requested}, head ${latest}`
   }),
-  'UNSUPPORTED_CHAIN_ID': new JsonRpcError({
+  'UNSUPPORTED_CHAIN_ID': (requested: string | number, current: string | number) => new JsonRpcError({
     name: 'ChainId not supported',
     code: -32000,
-    message: 'ChainId not supported'
+    message: `ChainId (${requested}) not supported. The correct chainId is ${current}`
   }),
   'GAS_PRICE_TOO_LOW': new JsonRpcError({
     name: 'Gas price too low',

--- a/packages/relay/src/lib/errors.ts
+++ b/packages/relay/src/lib/errors.ts
@@ -86,4 +86,9 @@ export const predefined = {
     code: -32009,
     message: 'Gas price below configured minimum gas price'
   }),
+  'INSUFFICIENT_ACCOUNT_BALANCE': new JsonRpcError({
+    name: 'Insufficient account balance',
+    code: -32000,
+    message: 'Insufficient funds for transfer'
+  }),
 };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -115,7 +115,7 @@ export class EthImpl implements Eth {
     this.mirrorNodeClient = mirrorNodeClient;
     this.logger = logger;
     this.chain = chain;
-    this.precheck = new Precheck(mirrorNodeClient, logger, chain);
+    this.precheck = new Precheck(mirrorNodeClient, nodeClient, logger, chain);
   }
 
   /**
@@ -633,6 +633,11 @@ export class EthImpl implements Eth {
     const gasPrecheck = this.precheck.gasPrice(transaction, gasPrice);
     if (!gasPrecheck.passes) {
       return gasPrecheck.error;
+    }
+
+    const balancePrecheck = await this.precheck.balance(transaction);
+    if (!balancePrecheck.passes) {
+      return balancePrecheck.error;
     }
 
     const transactionBuffer = Buffer.from(EthImpl.prune0x(transaction), 'hex');

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -622,11 +622,7 @@ export class EthImpl implements Eth {
 
     const chainIdPrecheckRes = this.precheck.chainId(transaction);
     if ( !chainIdPrecheckRes.passes ) {
-      return new JsonRpcError({
-        name: 'ChainId not supported',
-        code: -32000,
-        message: `ChainId (${chainIdPrecheckRes.chainId}) not supported. The correct chainId is ${this.chain}.`
-      });
+      return chainIdPrecheckRes.error;
     }
 
     const gasPrice = await this.getFeeWeibars();

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -763,7 +763,7 @@ export class EthImpl implements Eth {
       nonce: contractResult.nonce,
       r: rSig,
       s: sSig,
-      to: contractResult.to.substring(0, 42),
+      to: contractResult.to?.substring(0, 42),
       transactionIndex: contractResult.transaction_index,
       type: contractResult.type,
       v: contractResult.v,

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -75,7 +75,7 @@ export class Precheck {
 
     return {
       passes,
-      chainId: txChainId
+      error: predefined.UNSUPPORTED_CHAIN_ID(txChainId, this.chain)
     };
   }
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -977,7 +977,7 @@ describe('Eth calls using MirrorNode', async function () {
     Array.from(Array(11).keys()).map(blockNumber => mock.onGet(`blocks/${blockNumber}`).reply(200, {...defaultBlock, number: blockNumber}))
 
     const feeHistory = await ethImpl.feeHistory(200, '0x9', [0]);
-    console.log(feeHistory)
+
     expect(feeHistory).to.exist;
     expect(feeHistory['oldestBlock']).to.equal(`0x0`);
     expect(feeHistory['reward'].length).to.equal(maxResultsCap);

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -22,9 +22,10 @@ import { expect } from 'chai';
 import { Registry } from 'prom-client';
 const registry = new Registry();
 
+import sinon from 'sinon';
 import pino from 'pino';
 import {Precheck} from "../../src/lib/precheck";
-import {MirrorNodeClient} from "../../src/lib/clients";
+import {MirrorNodeClient, SDKClient} from "../../src/lib/clients";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import constants from '../../src/lib/constants';
@@ -55,7 +56,8 @@ describe('Precheck', async function() {
 
         // @ts-ignore
         const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
-        precheck = new Precheck(mirrorNodeInstance, logger, '0x12a');
+        const sdkInstance = sinon.createStubInstance(SDKClient);
+        precheck = new Precheck(mirrorNodeInstance, sdkInstance, logger, '0x12a');
     });
 
     describe('chainId', async function() {

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -65,14 +65,12 @@ describe('Precheck', async function() {
             const result = precheck.chainId(txWithMatchingChainId);
             expect(result).to.exist;
             expect(result.passes).to.eq(true);
-            expect(result.chainId).to.eq('0x12a');
         });
 
         it('should return false for non-matching chainId', async function() {
             const result = precheck.chainId(txWithNonMatchingChainId);
             expect(result).to.exist;
             expect(result.passes).to.eq(false);
-            expect(result.chainId).to.eq('0x0');
         });
     });
 

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -351,6 +351,19 @@ describe('RPC Server Acceptance Tests', function () {
                     expect(balanceChange.toString()).to.eq(ONE_TINYBAR.toString());
                 });
 
+                it('should fail "eth_sendRawTransaction" for legacy EIP 155 transactions (with insufficient balance)', async function () {
+                    const balanceInWeiBars = await servicesNode.getAccountBalanceInWeiBars(accounts[2].accountId)
+
+                    const transaction = {
+                        ...default155TransactionData,
+                        to: mirrorContract.evm_address,
+                        value: balanceInWeiBars,
+                        nonce: await relay.getAccountNonce(accounts[2].address)
+                    };
+                    const signedTx = await accounts[2].wallet.signTransaction(transaction);
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'Insufficient funds for transfer');
+                });
+
                 it('should fail "eth_sendRawTransaction" for Legacy transactions (with no chainId)', async function () {
                     const transaction = {
                         ...defaultLegacyTransactionData,
@@ -390,9 +403,20 @@ describe('RPC Server Acceptance Tests', function () {
                         to: mirrorContract.evm_address,
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
-                    console.log(transaction);
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing('eth_sendRawTransaction', [signedTx], -32009, 'Gas price below configured minimum gas price');
+                });
+
+                it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions (with insufficient balance)', async function () {
+                    const balanceInWeiBars = await servicesNode.getAccountBalanceInWeiBars(accounts[2].accountId)
+                    const transaction = {
+                        ...defaultLegacy2930TransactionData,
+                        value: balanceInWeiBars,
+                        to: mirrorContract.evm_address,
+                        nonce: await relay.getAccountNonce(accounts[2].address)
+                    };
+                    const signedTx = await accounts[2].wallet.signTransaction(transaction);
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'Insufficient funds for transfer');
                 });
 
                 it('should fail "eth_sendRawTransaction" for London transactions (with gas price too low)', async function () {
@@ -405,6 +429,19 @@ describe('RPC Server Acceptance Tests', function () {
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing('eth_sendRawTransaction', [signedTx], -32009, 'Gas price below configured minimum gas price');
+                });
+
+                it('should fail "eth_sendRawTransaction" for London transactions (with insufficient balance)', async function () {
+                    const balanceInWeiBars = await servicesNode.getAccountBalanceInWeiBars(accounts[2].accountId)
+
+                    const transaction = {
+                        ...defaultLondonTransactionData,
+                        value: balanceInWeiBars,
+                        to: mirrorContract.evm_address,
+                        nonce: await relay.getAccountNonce(accounts[2].address)
+                    };
+                    const signedTx = await accounts[2].wallet.signTransaction(transaction);
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'Insufficient funds for transfer');
                 });
 
                 it('should execute "eth_sendRawTransaction" for London transactions', async function () {

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -29,6 +29,7 @@ import {AccountBalanceQuery, ContractFunctionParameters} from '@hashgraph/sdk';
 // local resources
 import parentContractJson from '../contracts/Parent.json';
 import basicContractJson from '../contracts/Basic.json';
+import { predefined } from '../../../relay/src/lib/errors';
 
 describe('RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -318,7 +319,7 @@ describe('RPC Server Acceptance Tests', function () {
                         Assertions.expectedError();
                     }
                     catch(e) {
-                        Assertions.jsonRpcError(e, -32000, 'ChainId (0x3e7) not supported. The correct chainId is 0x12a.');
+                        Assertions.jsonRpcError(e, predefined.UNSUPPORTED_CHAIN_ID(ethers.utils.hexValue(INCORRECT_CHAIN_ID), CHAIN_ID));
                     }
                 });
 
@@ -330,7 +331,7 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32009, 'Gas price below configured minimum gas price');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.GAS_PRICE_TOO_LOW);
                 });
 
                 it('should execute "eth_sendRawTransaction" for legacy EIP 155 transactions', async function () {
@@ -361,7 +362,7 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'Insufficient funds for transfer');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.INSUFFICIENT_ACCOUNT_BALANCE);
                 });
 
                 it('should fail "eth_sendRawTransaction" for Legacy transactions (with no chainId)', async function () {
@@ -371,7 +372,7 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'ChainId (0x0) not supported. The correct chainId is 0x12a.');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.UNSUPPORTED_CHAIN_ID('0x0', CHAIN_ID));
                 });
 
                 it('should fail "eth_sendRawTransaction" for Legacy transactions (with gas price too low)', async function () {
@@ -383,7 +384,7 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32009, 'Gas price below configured minimum gas price');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.GAS_PRICE_TOO_LOW);
                 });
 
                 it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions', async function () {
@@ -404,7 +405,7 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32009, 'Gas price below configured minimum gas price');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.GAS_PRICE_TOO_LOW);
                 });
 
                 it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions (with insufficient balance)', async function () {
@@ -416,7 +417,7 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'Insufficient funds for transfer');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.INSUFFICIENT_ACCOUNT_BALANCE);
                 });
 
                 it('should fail "eth_sendRawTransaction" for London transactions (with gas price too low)', async function () {
@@ -428,7 +429,7 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32009, 'Gas price below configured minimum gas price');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.GAS_PRICE_TOO_LOW);
                 });
 
                 it('should fail "eth_sendRawTransaction" for London transactions (with insufficient balance)', async function () {
@@ -441,7 +442,7 @@ describe('RPC Server Acceptance Tests', function () {
                         nonce: await relay.getAccountNonce(accounts[2].address)
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    await relay.callFailing('eth_sendRawTransaction', [signedTx], -32000, 'Insufficient funds for transfer');
+                    await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.INSUFFICIENT_ACCOUNT_BALANCE);
                 });
 
                 it('should execute "eth_sendRawTransaction" for London transactions', async function () {
@@ -835,7 +836,7 @@ describe('RPC Server Acceptance Tests', function () {
                     latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`)).blocks[0];
                     await relay.call('eth_feeHistory', ['0x1', newestBlockNumberHex, null]);
                 } catch (error) {
-                    Assertions.jsonRpcError(error, -32000, `Request beyond head block: requested ${newestBlockNumber}, head ${latestBlock.number}`);
+                    Assertions.jsonRpcError(error, predefined.REQUEST_BEYOND_HEAD_BLOCK(newestBlockNumber, latestBlock.number));
                 }                
             });
 

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -21,6 +21,7 @@
 import { ethers, providers } from 'ethers';
 import { Logger } from 'pino';
 import Assertions from '../helpers/assertions';
+import { predefined } from '../../../relay/src/lib/errors';
 
 export default class RelayClient {
 
@@ -48,13 +49,13 @@ export default class RelayClient {
      * @param methodName
      * @param params
      */
-    async callFailing(methodName: string, params: any[], expectedCode = -32603, expectedMessage = 'Unknown error invoking RPC') {
+    async callFailing(methodName: string, params: any[], expectedRpcError = predefined.INTERNAL_ERROR) {
         try {
             const res = await this.call(methodName, params);
             this.logger.trace(`[POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`);
             Assertions.expectedError();
         } catch (err) {
-            Assertions.jsonRpcError(err, expectedCode, expectedMessage);
+            Assertions.jsonRpcError(err, expectedRpcError);
         }
     }
 

--- a/packages/server/tests/clients/servicesClient.ts
+++ b/packages/server/tests/clients/servicesClient.ts
@@ -275,6 +275,13 @@ export default class ServicesClient {
         const receipt = await response.getReceipt(this.client);
         this.logger.info(`File ${fileId} updated with status: ${receipt.status.toString()}`);
     }
+
+    async getAccountBalanceInWeiBars(account: string | AccountId) {
+        const balance = await this.executeQuery(new AccountBalanceQuery()
+            .setAccountId(account));
+
+        return ethers.BigNumber.from(balance.hbars.toTinybars().toString()).mul(10 ** 10);
+    }
 }
 
 export class AliasAccount {

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -19,6 +19,7 @@
  */
 import { expect } from 'chai';
 import { ethers } from 'ethers';
+import { JsonRpcError, predefined } from '../../../relay/src/lib/errors';
 import { Utils } from './utils';
 
 export default class Assertions {
@@ -195,15 +196,15 @@ export default class Assertions {
     }
 
     static unknownResponse(err) {
-        Assertions.jsonRpcError(err, -32603, 'Unknown error invoking RPC');
+        Assertions.jsonRpcError(err, predefined.INTERNAL_ERROR);
     }
 
-    static jsonRpcError(err, code, message) {
+    static jsonRpcError(err: any, expectedError: JsonRpcError) {
         expect(err).to.exist;
         expect(err).to.have.property('body');
 
         const parsedError = JSON.parse(err.body);
-        expect(parsedError.error.message).to.be.equal(message);
-        expect(parsedError.error.code).to.be.equal(code);
+        expect(parsedError.error.message).to.be.equal(expectedError.message);
+        expect(parsedError.error.code).to.be.equal(expectedError.code);
     }
 }


### PR DESCRIPTION
**Description**:
* Add balance precheck
* Add optional chaining to `getTransactionByHash` for null value of `contractResult.to` causing "multiple done() method invoked" error in acceptance tests
* Refactor `jsonRpcError` assertion to accept predefined error object

**Related issue(s)**:

Fixes #130 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
