### PR TITLE
Ensure transactionHash and blockHash are hash32

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -793,19 +793,19 @@ export class EthImpl implements Eth {
       const logs = receiptResponse.logs.map(log => {
         return new Log({
           address: log.address,
-          blockHash: receiptResponse.block_hash.substring(0, 66),
+          blockHash: EthImpl.toHash32(receiptResponse.block_hash),
           blockNumber: receiptResponse.block_number,
           data: log.data,
           logIndex: log.index,
           removed: false,
           topics: log.topics,
-          transactionHash: receiptResponse.hash,
+          transactionHash: EthImpl.toHash32(receiptResponse.hash),
           transactionIndex: receiptResponse.transaction_index
         });
       });
 
       const receipt = {
-        blockHash: receiptResponse.block_hash.substring(0, 66),
+        blockHash: EthImpl.toHash32(receiptResponse.block_hash),
         blockNumber: EthImpl.numberTo0x(receiptResponse.block_number),
         from: receiptResponse.from,
         to: receiptResponse.to,
@@ -814,7 +814,7 @@ export class EthImpl implements Eth {
         contractAddress: createdContract,
         logs: logs,
         logsBloom: receiptResponse.bloom,
-        transactionHash: receiptResponse.hash,
+        transactionHash: EthImpl.toHash32(receiptResponse.hash),
         transactionIndex: EthImpl.numberTo0x(receiptResponse.transaction_index),
         effectiveGasPrice: EthImpl.numberTo0x(Number.parseInt(effectiveGas) * 10_000_000_000),
         root: receiptResponse.root,
@@ -970,6 +970,10 @@ export class EthImpl implements Eth {
     return block.count;
   }
 
+  private static toHash32(value: string): string {
+    return value.substring(0, 66);
+  }
+
   private getTransactionFromContractResults(contractResults: any) {
     if (contractResults.results === undefined) {
       // contract result not found
@@ -1098,13 +1102,13 @@ export class EthImpl implements Eth {
           const log = logs[logIndex];
           logs[logIndex] = new Log({
             address: log.address,
-            blockHash: detail.block_hash.substring(0, 66),
+            blockHash: EthImpl.toHash32(detail.block_hash),
             blockNumber: detail.block_number,
             data: log.data,
             logIndex: log.index,
             removed: false,
             topics: log.topics,
-            transactionHash: detail.hash,
+            transactionHash: EthImpl.toHash32(detail.hash),
             transactionIndex: detail.transaction_index
           });
         }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -807,6 +807,7 @@ describe('Eth calls using MirrorNode', async function () {
     const expectLogData = (res, log, tx) => {
       expect(res.address).to.eq(log.address);
       expect(res.blockHash).to.eq(tx.block_hash.substring(0, 66));
+      expect(res.blockHash.length).to.eq(66);
       expect(res.blockNumber).to.eq(tx.block_number);
       expect(res.data).to.eq(log.data);
       expect(res.logIndex).to.eq(log.index);
@@ -814,6 +815,7 @@ describe('Eth calls using MirrorNode', async function () {
       expect(res.topics).to.exist;
       expect(res.topics).to.deep.eq(log.topics);
       expect(res.transactionHash).to.eq(tx.hash);
+      expect(res.transactionHash.length).to.eq(66);
       expect(res.transactionIndex).to.eq(tx.transaction_index);
     };
 


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Update `transactionHash` and `blockHash` to be hash32 compliant

**Related issue(s)**:

Fixes #289 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
