### PR TITLE
Helm chart chain id fix

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+          - name: CHAIN_ID
+            value: {{ .Values.config.CHAIN_ID | squote }}        
           - name: HEDERA_NETWORK
             valueFrom:
               secretKeyRef:
@@ -63,12 +65,6 @@ spec:
               secretKeyRef:
                 name: {{ include "json-rpc-relay.fullname" . }}
                 key: OPERATOR_KEY_ETH_SENDRAWTRANSACTION
-                optional: true
-          - name: CHAIN_ID
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "json-rpc-relay.fullname" . }}
-                key: CHAIN_ID
                 optional: true
           - name: MIRROR_NODE_URL
             valueFrom:

--- a/helm-chart/templates/secret.yaml
+++ b/helm-chart/templates/secret.yaml
@@ -10,7 +10,6 @@ data:
   OPERATOR_KEY_MAIN: {{ .Values.config.OPERATOR_KEY_MAIN | b64enc }}
   OPERATOR_ID_ETH_SENDRAWTRANSACTION: {{ .Values.config.OPERATOR_ID_ETH_SENDRAWTRANSACTION | default (printf "%q" "") }}
   OPERATOR_KEY_ETH_SENDRAWTRANSACTION: {{ .Values.config.OPERATOR_KEY_ETH_SENDRAWTRANSACTION | default (printf "%q" "") }}
-  CHAIN_ID: {{ printf "%s" .Values.config.CHAIN_ID | default (printf "%q" "") |b64enc }}
   MIRROR_NODE_URL: {{ .Values.config.MIRROR_NODE_URL | b64enc }}
   LOCAL_NODE: {{ .Values.config.LOCAL_NODE | quote | b64enc }}
   SERVER_PORT: {{ .Values.config.SERVER_PORT | quote | b64enc }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -89,6 +89,7 @@ config:
   OPERATOR_KEY_MAIN: ""
   OPERATOR_ID_ETH_SENDRAWTRANSACTION: ""
   OPERATOR_KEY_ETH_SENDRAWTRANSACTION: ""
+  # This value should be in decimal, not hexadecimal format.
   CHAIN_ID: ""
   MIRROR_NODE_URL: ""
   LOG_LEVEL: ""


### PR DESCRIPTION
**Description**:
Cleanup the way CHAIN_ID is set and transported into the k8s deployments.  Hex numbers are often converted (or attempted to be converted) and this makes the code return 0xNaN as the CHAIN_ID.  Moving away from setting this in a k8s secret because there is less conversion/encoding.

Fixes #300 