### PR TITLE
Update balance precheck to  better handle large accounts

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -120,6 +120,11 @@ export class SDKClient {
             .setAccountId(AccountId.fromString(account)), this.clientMain, callerName);
     }
 
+    async getAccountBalanceInTinyBar(account: string, callerName: string): Promise<BigNumber> {
+        const balance = await this.getAccountBalance(account, callerName);
+        return balance.hbars.to(HbarUnit.Tinybar);
+    }
+    
     async getAccountBalanceInWeiBar(account: string, callerName: string): Promise<BigNumber> {
         const balance = await this.getAccountBalance(account, callerName);
         return SDKClient.HbarToWeiBar(balance);

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -105,12 +105,12 @@ export class Precheck {
 
     try {
       const { account }: any = await this.mirrorNodeClient.getAccount(tx.from!);
-      const accountBalance = await this.sdkClient.getAccountBalanceInWeiBar(account, callerName);
+      const tinybars = await this.sdkClient.getAccountBalanceInTinyBar(account, callerName);
 
-      result.passes = ethers.ethers.BigNumber.from(accountBalance.toString()).gte(txTotalValue);
+      result.passes = ethers.ethers.BigNumber.from(tinybars.toString()).mul(constants.TINYBAR_TO_WEIBAR_COEF).gte(txTotalValue);
 
       if (!result.passes) {
-        this.logger.trace('Failed balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, accountBalance=%s)', transaction, txTotalValue, accountBalance);
+        this.logger.trace('Failed balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, accountTinyBarBalance=%s)', transaction, txTotalValue, tinybars);
       }
     } catch (error: any) {
       this.logger.trace('Error on balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, error=%s)', transaction, txTotalValue, error.message);


### PR DESCRIPTION
Signed-off-by: Nana-EC <nana@swirldslabs.com>

**Description**:
Update balance precheck to  better handle large accounts
Involve ethers in calculation

- Add `getAccountBalanceInTinyBar` to sdkClient
- Use ethers to calculate wei, thus avoid to string conversion management causing issue
- Add integration tests

**Related issue(s)**:

Fixes #327 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
