### PR TITLE
Align receipt with execution apis

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -837,19 +837,19 @@ export class EthImpl implements Eth {
 
       const receipt = {
         blockHash: EthImpl.toHash32(receiptResponse.block_hash),
-        blockNumber: Number(receiptResponse.block_number),
+        blockNumber: EthImpl.numberTo0x(receiptResponse.block_number),
         from: receiptResponse.from,
         to: receiptResponse.to,
-        cumulativeGasUsed: Number(receiptResponse.block_gas_used),
-        gasUsed: Number(receiptResponse.gas_used),
+        cumulativeGasUsed: EthImpl.numberTo0x(receiptResponse.block_gas_used),
+        gasUsed: EthImpl.numberTo0x(receiptResponse.gas_used),
         contractAddress: createdContract,
         logs: logs,
         logsBloom: receiptResponse.bloom,
         transactionHash: EthImpl.toHash32(receiptResponse.hash),
-        transactionIndex: Number(receiptResponse.transaction_index),
-        effectiveGasPrice: Number.parseInt(effectiveGas) * 10_000_000_000,
+        transactionIndex: EthImpl.numberTo0x(receiptResponse.transaction_index),
+        effectiveGasPrice: EthImpl.numberTo0x(Number.parseInt(effectiveGas) * 10_000_000_000),
         root: receiptResponse.root,
-        status: Number(receiptResponse.status),
+        status: EthImpl.numberTo0x(receiptResponse.status),
       };
 
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -849,7 +849,7 @@ export class EthImpl implements Eth {
         transactionIndex: EthImpl.numberTo0x(receiptResponse.transaction_index),
         effectiveGasPrice: EthImpl.numberTo0x(Number.parseInt(effectiveGas) * 10_000_000_000),
         root: receiptResponse.root,
-        status: EthImpl.numberTo0x(receiptResponse.status),
+        status: receiptResponse.status,
       };
 
 

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -20,6 +20,7 @@
 
 // Used for fake implementation of block history
 import {Status, TransactionRecord} from "@hashgraph/sdk";
+import {EthImpl} from "./eth";
 
 export class Block {
     public readonly timestamp:string = '0x' + new Date().valueOf().toString(16);
@@ -44,7 +45,7 @@ export class Block {
     public readonly totalDifficulty:string = '0x1';
     public readonly transactions:string[] | Transaction[] = [];
     public readonly transactionsRoot:string = '0x0';
-    public readonly uncles:any[] = [];
+    public readonly uncles:string[] = [];
 
     constructor(args?:any) {
         if (args) {
@@ -103,36 +104,36 @@ export class CachedBlock extends Block {
 
 export class Receipt {
     public readonly transactionHash:string;
-    public readonly transactionIndex:number;
+    public readonly transactionIndex:string;
     public readonly blockHash:string;
-    public readonly blockNumber:number;
+    public readonly blockNumber:string;
     public readonly from:string;
     public readonly to:(undefined|string);
-    public readonly cumulativeGasUsed:number;
-    public readonly gasUsed:number;
+    public readonly cumulativeGasUsed:string;
+    public readonly gasUsed:string;
     public readonly contractAddress:(undefined|string);
-    public readonly logs:string[];
+    public readonly logs:Log[];
     public readonly logsBloom:string;
     public readonly root:(undefined|string);
-    public readonly status:(undefined|number);
-    public readonly effectiveGasPrice:(undefined|number);
+    public readonly status:(undefined|string);
+    public readonly effectiveGasPrice:(undefined|string);
 
     constructor(txHash:string, record:TransactionRecord, block:Block) {
-        const gasUsed = record.contractFunctionResult == null ? 0 : record.contractFunctionResult.gasUsed;
+        const gasUsed = EthImpl.numberTo0x(record.contractFunctionResult == null ? 0 : record.contractFunctionResult.gasUsed.toNumber());
         const contractAddress = record.contractFunctionResult == undefined ? undefined : "0x" + record.contractFunctionResult.contractId?.toSolidityAddress();
 
         this.transactionHash = txHash;
-        this.transactionIndex = 0;
-        this.blockNumber = Number(block.number);
+        this.transactionIndex = "0x0";
+        this.blockNumber = block.number;
         this.blockHash = block.hash;
         this.from = '0x';
         // TODO this.to = record.contractFunctionResult?.contractId;
-        this.cumulativeGasUsed = Number(gasUsed);
-        this.gasUsed = Number(gasUsed);
+        this.cumulativeGasUsed = gasUsed;
+        this.gasUsed = gasUsed;
         this.contractAddress = contractAddress;
         this.logs = [];
         this.logsBloom = '';
-        this.status = record.receipt.status == Status.Success ? 1 : 0;
+        this.status = record.receipt.status == Status.Success ? "0x1" : "0x0";
     }
 }
 

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -20,7 +20,6 @@
 
 // Used for fake implementation of block history
 import {Status, TransactionRecord} from "@hashgraph/sdk";
-import {EthImpl} from "./eth";
 
 export class Block {
     public readonly timestamp:string = '0x' + new Date().valueOf().toString(16);
@@ -119,17 +118,17 @@ export class Receipt {
     public readonly effectiveGasPrice:(undefined|string);
 
     constructor(txHash:string, record:TransactionRecord, block:Block) {
-        const gasUsed = EthImpl.numberTo0x(record.contractFunctionResult == null ? 0 : record.contractFunctionResult.gasUsed.toNumber());
+        const gasUsed = record.contractFunctionResult == null ? 0 : record.contractFunctionResult.gasUsed;
         const contractAddress = record.contractFunctionResult == undefined ? undefined : "0x" + record.contractFunctionResult.contractId?.toSolidityAddress();
 
         this.transactionHash = txHash;
-        this.transactionIndex = "0x0";
+        this.transactionIndex = '0x0';
         this.blockNumber = block.number;
         this.blockHash = block.hash;
         this.from = '0x';
         // TODO this.to = record.contractFunctionResult?.contractId;
-        this.cumulativeGasUsed = gasUsed;
-        this.gasUsed = gasUsed;
+        this.cumulativeGasUsed = Number(gasUsed).toString(16);
+        this.gasUsed = Number(gasUsed).toString(16);
         this.contractAddress = contractAddress;
         this.logs = [];
         this.logsBloom = '';

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -224,7 +224,7 @@ describe('Eth calls using MirrorNode', async function () {
       "bloom": logBloom1,
       "contract_id": contractId1,
       "data": "0x",
-      "index": 0,
+      "index": "0x0",
       "topics": defaultLogTopics,
       "root_contract_id": "0.0.34806097",
       "timestamp": contractTimestamp1
@@ -234,7 +234,7 @@ describe('Eth calls using MirrorNode', async function () {
       "bloom": logBloom2,
       "contract_id": contractId1,
       "data": "0x",
-      "index": 1,
+      "index": "0x1",
       "topics": defaultLogTopics,
       "root_contract_id": "0.0.34806097",
       "timestamp": contractTimestamp1
@@ -247,7 +247,7 @@ describe('Eth calls using MirrorNode', async function () {
       "bloom": logBloom3,
       "contract_id": contractId1,
       "data": "0x",
-      "index": 0,
+      "index": "0x0",
       "topics": [],
       "root_contract_id": "0.0.34806097",
       "timestamp": contractTimestamp2
@@ -260,7 +260,7 @@ describe('Eth calls using MirrorNode', async function () {
       "bloom": logBloom4,
       "contract_id": contractId2,
       "data": "0x",
-      "index": 0,
+      "index": "0x0",
       "topics": [],
       "root_contract_id": "0.0.34806097",
       "timestamp": contractTimestamp3
@@ -981,7 +981,7 @@ describe('Eth calls using MirrorNode', async function () {
       expect(res.blockHash.length).to.eq(66);
       expect(res.blockNumber).to.eq(tx.block_number);
       expect(res.data).to.eq(log.data);
-      expect(res.logIndex).to.eq(blockLogIndexOffset + log.index);
+      expect(res.logIndex).to.eq(blockLogIndexOffset + Number(log.index));
       expect(res.removed).to.eq(false);
       expect(res.topics).to.exist;
       expect(res.topics).to.deep.eq(log.topics);
@@ -1333,7 +1333,7 @@ describe('Eth', async function () {
   const defaultTransaction = {
     "accessList": undefined,
     "blockHash": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
-    "blockNumber": 17,
+    "blockNumber": "0x11",
     "chainId": "0x12a",
     "from": "0x0000000000000000000000000000000000001f41",
     "gas": 123,
@@ -1386,7 +1386,7 @@ describe('Eth', async function () {
       "value_read": "0x97c1fc0a6ed5551bc831571325e9bdb365d06803100dc20648640ba24ce69750",
       "value_written": "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925"
     }],
-    "status": 1,
+    "status": "0x1",
     "access_list": "0x",
     "block_gas_used": 50000000,
     "chain_id": "0x12a",
@@ -1402,29 +1402,29 @@ describe('Eth', async function () {
 
   const defaultReceipt = {
     "blockHash": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
-    "blockNumber": defaultDetailedContractResultByHash.block_number,
-    "cumulativeGasUsed": defaultDetailedContractResultByHash.block_gas_used,
-    "effectiveGasPrice": 12500000000000000000,
+    "blockNumber": "0x11",
+    "cumulativeGasUsed": "0x2faf080",
+    "effectiveGasPrice": "0xad78ebc5ac620000",
     "from": "0x0000000000000000000000000000000000001f41",
     "to": "0x0000000000000000000000000000000000001389",
-    "gasUsed": defaultDetailedContractResultByHash.gas_used,
+    "gasUsed": "0x7b",
     "logs": [{
-        "address": "0x0000000000000000000000000000000000001389",
-        "blockHash": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
-        "blockNumber": 17,
-        "data": "0x0123",
-        "logIndex": 0,
-        "removed": false,
-        "topics": [
-          "0x97c1fc0a6ed5551bc831571325e9bdb365d06803100dc20648640ba24ce69750"
-        ],
-        "transactionHash": "0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-        "transactionIndex": 1
+      "address": "0x0000000000000000000000000000000000001389",
+      "blockHash": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
+      "blockNumber": 17,
+      "data": "0x0123",
+      "logIndex": 0,
+      "removed": false,
+      "topics": [
+        "0x97c1fc0a6ed5551bc831571325e9bdb365d06803100dc20648640ba24ce69750"
+      ],
+      "transactionHash": "0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
+      "transactionIndex": 1
     }],
     "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-    "status": defaultDetailedContractResultByHash.status,
+    "status": "0x1",
     "transactionHash": "0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-    "transactionIndex": defaultDetailedContractResultByHash.transaction_index,
+    "transactionIndex": "0x1",
     "contractAddress": "0x0000000000000000000000000000000000001b59",
     "root": undefined
   };
@@ -1597,7 +1597,7 @@ describe('Eth', async function () {
 
       expect(result.accessList).to.eq(defaultTransaction.accessList);
       expect(result.blockHash).to.eq(defaultTransaction.blockHash);
-      expect(result.blockNumber).to.eq(`0x${defaultTransaction.blockNumber.toString(16)}`);
+      expect(result.blockNumber).to.eq(defaultTransaction.blockNumber);
       expect(result.chainId).to.eq(defaultTransaction.chainId);
       expect(result.from).to.eq(defaultTransaction.from);
       expect(result.gas).to.eq(defaultTransaction.gas);
@@ -1631,7 +1631,7 @@ describe('Eth', async function () {
       expect(result).to.exist;
       expect(result.accessList).to.eq(defaultTransaction.accessList);
       expect(result.blockHash).to.eq(defaultTransaction.blockHash);
-      expect(result.blockNumber).to.eq(`0x${defaultTransaction.blockNumber.toString(16)}`);
+      expect(result.blockNumber).to.eq(defaultTransaction.blockNumber);
       expect(result.chainId).to.eq(defaultTransaction.chainId);
       expect(result.from).to.eq(defaultTransaction.from);
       expect(result.gas).to.eq(defaultTransaction.gas);

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -139,13 +139,13 @@ export default class Assertions {
         expect(Number(transactionReceipt.blockNumber)).to.gt(0);
         expect(transactionReceipt.blockNumber).to.eq(ethers.utils.hexValue(mirrorResult.block_number));
 
+        expect(transactionReceipt.cumulativeGasUsed).to.exist;
         expect(Number(transactionReceipt.cumulativeGasUsed)).to.gt(0);
         expect(Number(transactionReceipt.cumulativeGasUsed)).to.eq(mirrorResult.block_gas_used);
-        expect(transactionReceipt.cumulativeGasUsed).to.eq(mirrorResult.block_gas_used);
 
+        expect(transactionReceipt.gasUsed).to.exist;
         expect(Number(transactionReceipt.gasUsed)).to.gt(0);
         expect(Number(transactionReceipt.gasUsed)).to.eq(mirrorResult.gas_used);
-        expect(transactionReceipt.gasUsed).to.eq(mirrorResult.gas_used);
 
         expect(transactionReceipt.logsBloom).to.exist;
         expect(transactionReceipt.logsBloom).to.not.eq('0x0');
@@ -159,7 +159,7 @@ export default class Assertions {
         expect(Number(transactionReceipt.transactionIndex)).to.eq(mirrorResult.transaction_index);
 
         expect(transactionReceipt.effectiveGasPrice).to.exist;
-        expect(transactionReceipt.effectiveGasPrice).to.gt(0);
+        expect(Number(transactionReceipt.effectiveGasPrice)).to.gt(0);
         const effectiveGas = mirrorResult.max_fee_per_gas === undefined || mirrorResult.max_fee_per_gas == '0x'
             ? mirrorResult.gas_price
             : mirrorResult.max_fee_per_gas;

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -136,15 +136,15 @@ export default class Assertions {
         expect(transactionReceipt.blockHash).to.eq(mirrorResult.block_hash.slice(0, 66));
 
         expect(transactionReceipt.blockNumber).to.exist;
-        expect(transactionReceipt.blockNumber).to.gt(0);
-        expect(transactionReceipt.blockNumber).to.eq(mirrorResult.block_number);
+        expect(Number(transactionReceipt.blockNumber)).to.gt(0);
+        expect(transactionReceipt.blockNumber).to.eq(ethers.utils.hexValue(mirrorResult.block_number));
 
-        expect(transactionReceipt.cumulativeGasUsed).to.exist;
-        expect(transactionReceipt.cumulativeGasUsed).to.gt(0);
+        expect(Number(transactionReceipt.cumulativeGasUsed)).to.gt(0);
+        expect(Number(transactionReceipt.cumulativeGasUsed)).to.eq(mirrorResult.block_gas_used);
         expect(transactionReceipt.cumulativeGasUsed).to.eq(mirrorResult.block_gas_used);
 
-        expect(transactionReceipt.gasUsed).to.exist;
-        expect(transactionReceipt.gasUsed).to.gt(0);
+        expect(Number(transactionReceipt.gasUsed)).to.gt(0);
+        expect(Number(transactionReceipt.gasUsed)).to.eq(mirrorResult.gas_used);
         expect(transactionReceipt.gasUsed).to.eq(mirrorResult.gas_used);
 
         expect(transactionReceipt.logsBloom).to.exist;
@@ -156,7 +156,7 @@ export default class Assertions {
         expect(transactionReceipt.transactionHash).to.eq(mirrorResult.hash);
 
         expect(transactionReceipt.transactionIndex).to.exist;
-        expect(transactionReceipt.transactionIndex).to.eq(mirrorResult.transaction_index);
+        expect(Number(transactionReceipt.transactionIndex)).to.eq(mirrorResult.transaction_index);
 
         expect(transactionReceipt.effectiveGasPrice).to.exist;
         expect(transactionReceipt.effectiveGasPrice).to.gt(0);
@@ -167,7 +167,7 @@ export default class Assertions {
         expect(transactionReceipt.effectiveGasPrice).to.eq(mirrorEffectiveGasPrice);
 
         expect(transactionReceipt.status).to.exist;
-        expect(transactionReceipt.status).to.eq(Number(mirrorResult.status));
+        expect(transactionReceipt.status).to.eq(mirrorResult.status);
 
         expect(transactionReceipt.logs).to.exist;
         expect(transactionReceipt.logs.length).to.eq(mirrorResult.logs.length);


### PR DESCRIPTION

**Description**:
Move uints back to hex strings

Signed-off-by: Danno Ferrin <danno.ferrin@hedera.com>

**Related issue(s)**:

Fixes #302

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
