### PR TITLE
Ensure acceptance tests run on previewnet/testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ E2E_RELAY_HOST=http://127.0.0.1:7546
 
 The following table highlights some initial configuration values to consider
 
-| Config      | Default | Description           |
-| ------------|-------|-----------------------|
-| `CHAIN_ID`  | `0x12a` | The netowrk chain id. Local and previewnet envs should use `0x12a`. Mainnet and Testnet should use `0x127` and `0x128` respectively |
+| Config      | Default | Description                                                                                                                                       |
+| ------------|-------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `CHAIN_ID`  | `0x12a` | The netowrk chain id. Local and previewnet envs should use `0x12a`. Mainnet, Testnet and Previewnet should use `0x127`, `0x128` and `0x129` respectively |
 
 > **_NOTE:_** Acceptance tests can be pointed at a remote location. In this case be sure to appropriately update these values to point away from your local host and to valid deployed services.
 

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -31,7 +31,7 @@ import pino from 'pino';
 const logger = pino();
 
 describe('MirrorNodeClient', async function () {
-  this.timeout(10000);
+  this.timeout(20000);
 
   // mock axios
   const instance = axios.create({
@@ -40,7 +40,7 @@ describe('MirrorNodeClient', async function () {
     headers: {
       'Content-Type': 'application/json'
     },
-    timeout: 10 * 1000
+    timeout: 20 * 1000
   });
   const mock = new MockAdapter(instance);
   const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), instance);

--- a/packages/server/tests/acceptance/erc20.spec.ts
+++ b/packages/server/tests/acceptance/erc20.spec.ts
@@ -55,8 +55,8 @@ describe('ERC20 Acceptance Tests', async function () {
 
     before(async () => {
         accounts[0] = await servicesNode.createAliasAccount(30, relay.provider);
-        accounts[1] = await servicesNode.createAliasAccount(10, relay.provider);
-        accounts[2] = await servicesNode.createAliasAccount(10, relay.provider);
+        accounts[1] = await servicesNode.createAliasAccount(20, relay.provider);
+        accounts[2] = await servicesNode.createAliasAccount(20, relay.provider);
 
         initialHolder = accounts[0].address;
         recipient = accounts[1].address;

--- a/packages/server/tests/acceptance/erc20.spec.ts
+++ b/packages/server/tests/acceptance/erc20.spec.ts
@@ -55,8 +55,8 @@ describe('ERC20 Acceptance Tests', async function () {
 
     before(async () => {
         accounts[0] = await servicesNode.createAliasAccount(30, relay.provider);
-        accounts[1] = await servicesNode.createAliasAccount(20, relay.provider);
-        accounts[2] = await servicesNode.createAliasAccount(20, relay.provider);
+        accounts[1] = await servicesNode.createAliasAccount(15, relay.provider);
+        accounts[2] = await servicesNode.createAliasAccount(15, relay.provider);
 
         initialHolder = accounts[0].address;
         recipient = accounts[1].address;

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -1068,18 +1068,6 @@ describe('RPC Server Acceptance Tests', function () {
             });
         });
 
-        describe('eth_feeHistory', () => {
-            it('should call eth_feeHistory', async function () {
-                const res = await relay.call('eth_feeHistory', ['0x1', 'latest', null]);
-                expect(res.baseFeePerGas).to.exist.to.be.an('Array');
-                expect(res.baseFeePerGas.length).to.be.gt(0);
-                expect(res.gasUsedRatio).to.exist.to.be.an('Array');
-                expect(res.gasUsedRatio.length).to.be.gt(0);
-                expect(res.oldestBlock).to.exist;
-                expect(Number(res.oldestBlock)).to.be.gt(0);
-            });
-        });
-
         // Only run the following tests against a local node since they only work with the genesis account
         if (process.env.LOCAL_NODE && process.env.LOCAL_NODE !== 'false') {
             describe('Gas Price related RPC endpoints', () => {
@@ -1139,5 +1127,17 @@ describe('RPC Server Acceptance Tests', function () {
                 });
             });
         }
+
+        describe('eth_feeHistory', () => {
+            it('should call eth_feeHistory', async function () {
+                const res = await relay.call('eth_feeHistory', ['0x1', 'latest', null]);
+                expect(res.baseFeePerGas).to.exist.to.be.an('Array');
+                expect(res.baseFeePerGas.length).to.be.gt(0);
+                expect(res.gasUsedRatio).to.exist.to.be.an('Array');
+                expect(res.gasUsedRatio.length).to.be.gt(0);
+                expect(res.oldestBlock).to.exist;
+                expect(Number(res.oldestBlock)).to.be.gt(0);
+            });
+        });
     });
 });

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -67,14 +67,15 @@ describe('RPC Server Acceptance Tests', function () {
     const FEE_SCHEDULE_FILE_ID = "0.0.111";
     const FEE_SCHEDULE_FILE_CONTENT_DEFAULT = "0a280a0a08541a061a04408888340a0a08061a061a0440889d2d0a0a08071a061a0440b0b63c120208011200"; // Eth gas = 853000
     const FEE_SCHEDULE_FILE_CONTENT_UPDATED = "0a280a0a08541a061a0440a8953a0a0a08061a061a0440889d2d0a0a08071a061a0440b0b63c120208011200"; // Eth gas = 953000
+    const publicNetworks = ['previewnet', 'testnet', 'mainnet'];
 
     describe('RPC Server Acceptance Tests', function () {
         this.timeout(240 * 1000); // 240 seconds
 
         this.beforeAll(async () => {
-            accounts[0] = await servicesNode.createAliasAccount();
-            accounts[1] = await servicesNode.createAliasAccount();
-            accounts[2] = await servicesNode.createAliasAccount(20);
+            accounts[0] = await servicesNode.createAliasAccount(20);
+            accounts[1] = await servicesNode.createAliasAccount(20);
+            accounts[2] = await servicesNode.createAliasAccount(50);
             contractId = await accounts[0].client.createParentContract(parentContractJson);
 
             const params = new ContractFunctionParameters().addUint256(1);
@@ -406,8 +407,10 @@ describe('RPC Server Acceptance Tests', function () {
                     const transaction = {
                         ...default155TransactionData,
                         to: mirrorContract.evm_address,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        gasPrice: await relay.gasPrice()
                     };
+
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const legacyTxHash = await relay.sendRawTransaction(signedTx);
                     // Since the transactionId is not available in this context
@@ -420,11 +423,15 @@ describe('RPC Server Acceptance Tests', function () {
                 });
 
                 it('should execute "eth_getTransactionReceipt" for hash of London transaction', async function () {
+                    const gasPrice = await relay.gasPrice();
                     const transaction = {
                         ...defaultLondonTransactionData,
                         to: mirrorContract.evm_address,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        maxFeePerGas: gasPrice,
+                        maxPriorityFeePerGas: gasPrice
                     };
+
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const transactionHash = await relay.sendRawTransaction(signedTx);
                     // Since the transactionId is not available in this context
@@ -463,7 +470,8 @@ describe('RPC Server Acceptance Tests', function () {
                     const transaction = {
                         ...default155TransactionData,
                         to: mirrorContract.evm_address,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        gasPrice: await relay.gasPrice()
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const transactionHash = await relay.sendRawTransaction(signedTx);
@@ -483,7 +491,8 @@ describe('RPC Server Acceptance Tests', function () {
                         ...default155TransactionData,
                         to: mirrorContract.evm_address,
                         value: balanceInWeiBars,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        gasPrice: await relay.gasPrice()
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.INSUFFICIENT_ACCOUNT_BALANCE);
@@ -493,7 +502,8 @@ describe('RPC Server Acceptance Tests', function () {
                     const transaction = {
                         ...defaultLegacyTransactionData,
                         to: mirrorContract.evm_address,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        gasPrice: await relay.gasPrice()
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.UNSUPPORTED_CHAIN_ID('0x0', CHAIN_ID));
@@ -515,7 +525,8 @@ describe('RPC Server Acceptance Tests', function () {
                     const transaction = {
                         ...defaultLegacy2930TransactionData,
                         to: mirrorContract.evm_address,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        gasPrice: await relay.gasPrice()
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing('eth_sendRawTransaction', [signedTx]);
@@ -538,7 +549,8 @@ describe('RPC Server Acceptance Tests', function () {
                         ...defaultLegacy2930TransactionData,
                         value: balanceInWeiBars,
                         to: mirrorContract.evm_address,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        gasPrice: await relay.gasPrice()
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.INSUFFICIENT_ACCOUNT_BALANCE);
@@ -558,12 +570,15 @@ describe('RPC Server Acceptance Tests', function () {
 
                 it('should fail "eth_sendRawTransaction" for London transactions (with insufficient balance)', async function () {
                     const balanceInWeiBars = await servicesNode.getAccountBalanceInWeiBars(accounts[2].accountId);
+                    const gasPrice = await relay.gasPrice();
 
                     const transaction = {
                         ...defaultLondonTransactionData,
                         value: balanceInWeiBars,
                         to: mirrorContract.evm_address,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        maxPriorityFeePerGas: gasPrice,
+                        maxFeePerGas: gasPrice,
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing('eth_sendRawTransaction', [signedTx], predefined.INSUFFICIENT_ACCOUNT_BALANCE);
@@ -571,11 +586,14 @@ describe('RPC Server Acceptance Tests', function () {
 
                 it('should execute "eth_sendRawTransaction" for London transactions', async function () {
                     const receiverInitialBalance = await relay.getBalance(mirrorContract.evm_address);
+                    const gasPrice = await relay.gasPrice();
 
                     const transaction = {
                         ...defaultLondonTransactionData,
                         to: mirrorContract.evm_address,
-                        nonce: await relay.getAccountNonce(accounts[2].address)
+                        nonce: await relay.getAccountNonce(accounts[2].address),
+                        maxPriorityFeePerGas: gasPrice,
+                        maxFeePerGas: gasPrice,
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const transactionHash = await relay.call('eth_sendRawTransaction', [signedTx]);
@@ -589,12 +607,14 @@ describe('RPC Server Acceptance Tests', function () {
                 });
 
                 it('should execute "eth_sendRawTransaction" and deploy a large contract', async function() {
+                    const gasPrice = await relay.gasPrice();
+
                     const transaction = {
                         type: 2,
                         chainId: Number(CHAIN_ID),
                         nonce: await relay.getAccountNonce(accounts[2].address),
-                        maxPriorityFeePerGas: Assertions.defaultGasPrice,
-                        maxFeePerGas: Assertions.defaultGasPrice,
+                        maxPriorityFeePerGas: gasPrice,
+                        maxFeePerGas: gasPrice,
                         gasLimit: defaultGasLimit,
                         data: '0x' + '00'.repeat(5121),
                     };
@@ -622,7 +642,7 @@ describe('RPC Server Acceptance Tests', function () {
                             Assertions.expectedError();
                         }
                         catch(e) {
-                            Assertions.jsonRpcError(e, predefined.UNSUPPORTED_CHAIN_ID('0x3e7', '0x12a'));
+                            Assertions.jsonRpcError(e, predefined.UNSUPPORTED_CHAIN_ID('0x3e7', CHAIN_ID));
                         }
                     });
 
@@ -631,8 +651,10 @@ describe('RPC Server Acceptance Tests', function () {
                             ...default155TransactionData,
                             to: mirrorContract.evm_address,
                             nonce: await relay.getAccountNonce(accounts[2].address),
-                            gasLimit: 100
+                            gasLimit: 100,
+                            gasPrice: await relay.gasPrice()
                         };
+
                         const signedTx = await accounts[2].wallet.signTransaction(transaction);
                         try {
                             await relay.sendRawTransaction(signedTx);
@@ -648,8 +670,10 @@ describe('RPC Server Acceptance Tests', function () {
                             ...default155TransactionData,
                             to: mirrorContract.evm_address,
                             nonce: await relay.getAccountNonce(accounts[2].address),
-                            gasLimit: 999999999
+                            gasLimit: 999999999,
+                            gasPrice: await relay.gasPrice()
                         };
+
                         const signedTx = await accounts[2].wallet.signTransaction(transaction);
                         try {
                             await relay.sendRawTransaction(signedTx);
@@ -785,7 +809,12 @@ describe('RPC Server Acceptance Tests', function () {
             it('should call eth_gasPrice', async function () {
                 const res = await relay.call('eth_gasPrice', []);
                 expect(res).to.exist;
-                expect(res).to.equal(ethers.utils.hexValue(Assertions.defaultGasPrice));
+                if (process.env.LOCAL_NODE) {
+                    expect(res).be.equal(ethers.utils.hexValue(Assertions.defaultGasPrice));
+                }
+                else {
+                    expect(Number(res)).to.be.gt(0);
+                }
             });
 
             it('should execute "eth_getBalance" for newly created account with 10 HBAR', async function () {
@@ -1039,57 +1068,64 @@ describe('RPC Server Acceptance Tests', function () {
             });
         });
 
-        describe('Gas Price related RPC endpoints', () => {
-            let lastBlockBeforeUpdate;
-            let lastBlockAfterUpdate;
+        // Only run the following tests against a local node since they only work with the genesis account
+        if (process.env.LOCAL_NODE) {
+            describe('Gas Price related RPC endpoints', () => {
+                let lastBlockBeforeUpdate;
+                let lastBlockAfterUpdate;
 
-            before(async () => {
-                await servicesNode.updateFileContent(FEE_SCHEDULE_FILE_ID, FEE_SCHEDULE_FILE_CONTENT_DEFAULT);
-                await servicesNode.updateFileContent(EXCHANGE_RATE_FILE_ID, EXCHANGE_RATE_FILE_CONTENT_DEFAULT);
-                lastBlockBeforeUpdate = (await mirrorNode.get(`/blocks?limit=1&order=desc`)).blocks[0];
-                await new Promise(resolve => setTimeout(resolve, 4000));
-                await servicesNode.updateFileContent(FEE_SCHEDULE_FILE_ID, FEE_SCHEDULE_FILE_CONTENT_UPDATED);
-                await new Promise(resolve => setTimeout(resolve, 4000));
-                lastBlockAfterUpdate = (await mirrorNode.get(`/blocks?limit=1&order=desc`)).blocks[0];
+                before(async () => {
+                    await servicesNode.updateFileContent(FEE_SCHEDULE_FILE_ID, FEE_SCHEDULE_FILE_CONTENT_DEFAULT);
+                    await servicesNode.updateFileContent(EXCHANGE_RATE_FILE_ID, EXCHANGE_RATE_FILE_CONTENT_DEFAULT);
+                    lastBlockBeforeUpdate = (await mirrorNode.get(`/blocks?limit=1&order=desc`)).blocks[0];
+                    await new Promise(resolve => setTimeout(resolve, 4000));
+                    await servicesNode.updateFileContent(FEE_SCHEDULE_FILE_ID, FEE_SCHEDULE_FILE_CONTENT_UPDATED);
+                    await new Promise(resolve => setTimeout(resolve, 4000));
+                    lastBlockAfterUpdate = (await mirrorNode.get(`/blocks?limit=1&order=desc`)).blocks[0];
+                });
+
+                it('should call eth_feeHistory with updated fees', async function () {
+                    const blockCountNumber = lastBlockAfterUpdate.number - lastBlockBeforeUpdate.number;
+                    const blockCountHex = ethers.utils.hexValue(blockCountNumber);
+                    const datedGasPriceHex = ethers.utils.hexValue(Assertions.datedGasPrice);
+                    const updatedGasPriceHex = ethers.utils.hexValue(Assertions.updatedGasPrice);
+                    const newestBlockNumberHex = ethers.utils.hexValue(lastBlockAfterUpdate.number);
+                    const oldestBlockNumberHex = ethers.utils.hexValue(lastBlockAfterUpdate.number - blockCountNumber + 1);
+
+                    const res = await relay.call('eth_feeHistory', [blockCountHex, newestBlockNumberHex, [0]]);
+
+                    Assertions.feeHistory(res, {
+                        resultCount: blockCountNumber,
+                        oldestBlock: oldestBlockNumberHex,
+                        chechReward: true
+                    });
+
+                    expect(res.baseFeePerGas[0]).to.equal(datedGasPriceHex);
+                    expect(res.baseFeePerGas[res.baseFeePerGas.length - 2]).to.equal(updatedGasPriceHex);
+                    expect(res.baseFeePerGas[res.baseFeePerGas.length - 1]).to.equal(updatedGasPriceHex);
+                });
+
+                it('should call eth_feeHistory with newest block > latest', async function () {
+                    let latestBlock;
+                    const newestBlockNumber = lastBlockAfterUpdate.number + 10;
+                    const newestBlockNumberHex = ethers.utils.hexValue(newestBlockNumber);
+                    try {
+                        latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`)).blocks[0];
+                        await relay.call('eth_feeHistory', ['0x1', newestBlockNumberHex, null]);
+                    } catch (error) {
+                        Assertions.jsonRpcError(error, predefined.REQUEST_BEYOND_HEAD_BLOCK(newestBlockNumber, latestBlock.number));
+                    }
+                });
+
+                it('should call eth_feeHistory with zero block count', async function () {
+                    const res = await relay.call('eth_feeHistory', ['0x0', 'latest', null]);
+
+                    expect(res.reward).to.not.exist;
+                    expect(res.baseFeePerGas).to.not.exist;
+                    expect(res.gasUsedRatio).to.equal(null);
+                    expect(res.oldestBlock).to.equal('0x0');
+                });
             });
-
-            it('should call eth_feeHistory with updated fees', async function () {
-                const blockCountNumber = lastBlockAfterUpdate.number - lastBlockBeforeUpdate.number;
-                const blockCountHex = ethers.utils.hexValue(blockCountNumber);
-                const datedGasPriceHex = ethers.utils.hexValue(Assertions.datedGasPrice);
-                const updatedGasPriceHex = ethers.utils.hexValue(Assertions.updatedGasPrice);
-                const newestBlockNumberHex = ethers.utils.hexValue(lastBlockAfterUpdate.number);
-                const oldestBlockNumberHex = ethers.utils.hexValue(lastBlockAfterUpdate.number - blockCountNumber + 1);
-
-                const res = await relay.call('eth_feeHistory', [blockCountHex, newestBlockNumberHex, [0]]);
-
-                Assertions.feeHistory(res, { resultCount: blockCountNumber, oldestBlock: oldestBlockNumberHex, chechReward: true });
-
-                expect(res.baseFeePerGas[0]).to.equal(datedGasPriceHex);
-                expect(res.baseFeePerGas[res.baseFeePerGas.length - 2]).to.equal(updatedGasPriceHex);
-                expect(res.baseFeePerGas[res.baseFeePerGas.length - 1]).to.equal(updatedGasPriceHex);
-            });
-
-            it('should call eth_feeHistory with newest block > latest', async function () {
-                let latestBlock;
-                const newestBlockNumber = lastBlockAfterUpdate.number + 10;
-                const newestBlockNumberHex = ethers.utils.hexValue(newestBlockNumber);
-                try {
-                    latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`)).blocks[0];
-                    await relay.call('eth_feeHistory', ['0x1', newestBlockNumberHex, null]);
-                } catch (error) {
-                    Assertions.jsonRpcError(error, predefined.REQUEST_BEYOND_HEAD_BLOCK(newestBlockNumber, latestBlock.number));
-                }
-            });
-
-            it('should call eth_feeHistory with zero block count', async function () {
-                const res = await relay.call('eth_feeHistory', ['0x0', 'latest', null]);
-
-                expect(res.reward).to.not.exist;
-                expect(res.baseFeePerGas).to.not.exist;
-                expect(res.gasUsedRatio).to.equal(null);
-                expect(res.oldestBlock).to.equal('0x0');
-            });
-        });
+        }
     });
 });

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -73,9 +73,9 @@ describe('RPC Server Acceptance Tests', function () {
         this.timeout(240 * 1000); // 240 seconds
 
         this.beforeAll(async () => {
-            accounts[0] = await servicesNode.createAliasAccount(20);
-            accounts[1] = await servicesNode.createAliasAccount(20);
-            accounts[2] = await servicesNode.createAliasAccount(50);
+            accounts[0] = await servicesNode.createAliasAccount(15);
+            accounts[1] = await servicesNode.createAliasAccount(15);
+            accounts[2] = await servicesNode.createAliasAccount(30);
             contractId = await accounts[0].client.createParentContract(parentContractJson);
 
             const params = new ContractFunctionParameters().addUint256(1);

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -809,7 +809,7 @@ describe('RPC Server Acceptance Tests', function () {
             it('should call eth_gasPrice', async function () {
                 const res = await relay.call('eth_gasPrice', []);
                 expect(res).to.exist;
-                if (process.env.LOCAL_NODE) {
+                if (process.env.LOCAL_NODE && process.env.LOCAL_NODE !== 'false') {
                     expect(res).be.equal(ethers.utils.hexValue(Assertions.defaultGasPrice));
                 }
                 else {
@@ -1069,7 +1069,7 @@ describe('RPC Server Acceptance Tests', function () {
         });
 
         // Only run the following tests against a local node since they only work with the genesis account
-        if (process.env.LOCAL_NODE) {
+        if (process.env.LOCAL_NODE && process.env.LOCAL_NODE !== 'false') {
             describe('Gas Price related RPC endpoints', () => {
                 let lastBlockBeforeUpdate;
                 let lastBlockAfterUpdate;

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -1068,6 +1068,18 @@ describe('RPC Server Acceptance Tests', function () {
             });
         });
 
+        describe('eth_feeHistory', () => {
+            it('should call eth_feeHistory', async function () {
+                const res = await relay.call('eth_feeHistory', ['0x1', 'latest', null]);
+                expect(res.baseFeePerGas).to.exist.to.be.an('Array');
+                expect(res.baseFeePerGas.length).to.be.gt(0);
+                expect(res.gasUsedRatio).to.exist.to.be.an('Array');
+                expect(res.gasUsedRatio.length).to.be.gt(0);
+                expect(res.oldestBlock).to.exist;
+                expect(Number(res.oldestBlock)).to.be.gt(0);
+            });
+        });
+
         // Only run the following tests against a local node since they only work with the genesis account
         if (process.env.LOCAL_NODE && process.env.LOCAL_NODE !== 'false') {
             describe('Gas Price related RPC endpoints', () => {

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -107,4 +107,10 @@ export default class RelayClient {
         return this.provider.send('eth_sendRawTransaction', [signedTx]);
     };
 
+    /**
+     * Returns the result of eth_gasPrice as a Number.
+     */
+    async gasPrice(): Promise<number> {
+        return Number(await this.call('eth_gasPrice', []));
+    }
 }

--- a/packages/server/tests/clients/servicesClient.ts
+++ b/packages/server/tests/clients/servicesClient.ts
@@ -313,7 +313,15 @@ export default class ServicesClient {
         const expiration = new Date();
         expiration.setDate(expiration.getDate() + 30);
 
-        const htsClient = Client.forNetwork(JSON.parse(this.network));
+        let network = this.network;
+        try {
+            network = JSON.parse(this.network);
+        }
+        catch(e) {
+            // network config is a string and not a valid JSON
+        }
+
+        const htsClient = Client.forNetwork(network);
         htsClient.setOperator(AccountId.fromString(args.treasuryAccountId), args.adminPrivateKey);
 
         const tokenCreate = await (await new TokenCreateTransaction()

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -61,7 +61,7 @@ export default class Assertions {
         // Assert static values
         expect(relayResponse.baseFeePerGas).to.exist;
 
-        if (process.env.LOCAL_NODE) {
+        if (process.env.LOCAL_NODE && process.env.LOCAL_NODE !== 'false') {
             expect(relayResponse.baseFeePerGas).to.be.equal(ethers.utils.hexValue(this.defaultGasPrice));
         }
         else {

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -18,7 +18,7 @@
  *
  */
 import { expect } from 'chai';
-import { ethers } from 'ethers';
+import { ethers, BigNumber } from 'ethers';
 import { JsonRpcError, predefined } from '../../../relay/src/lib/errors';
 import { Utils } from './utils';
 
@@ -59,7 +59,15 @@ export default class Assertions {
      */
     public static block(relayResponse, mirrorNodeResponse, mirrorTransactions, hydratedTransactions = false) {
         // Assert static values
-        expect(relayResponse.baseFeePerGas).to.be.equal(ethers.utils.hexValue(this.defaultGasPrice));
+        expect(relayResponse.baseFeePerGas).to.exist;
+
+        if (process.env.LOCAL_NODE) {
+            expect(relayResponse.baseFeePerGas).to.be.equal(ethers.utils.hexValue(this.defaultGasPrice));
+        }
+        else {
+            expect(Number(relayResponse.baseFeePerGas)).to.be.gt(0);
+        }
+
         expect(relayResponse.difficulty).to.be.equal(ethers.utils.hexValue(0));
         expect(relayResponse.extraData).to.be.equal(Assertions.emptyHex);
         expect(relayResponse.miner).to.be.equal(ethers.constants.AddressZero);
@@ -125,7 +133,9 @@ export default class Assertions {
         // expect(relayResponse.gasPrice).to.eq(mirrorNodeResponse.gas_price); // FIXME must not be null!
         expect(relayResponse.hash).to.eq(mirrorNodeResponse.hash.slice(0, 66));
         expect(relayResponse.input).to.eq(mirrorNodeResponse.function_parameters);
-        expect(relayResponse.to).to.eq(mirrorNodeResponse.to);
+        if (relayResponse.to || mirrorNodeResponse.to) {
+            expect(relayResponse.to).to.eq(mirrorNodeResponse.to);
+        }
         expect(relayResponse.transactionIndex).to.eq(mirrorNodeResponse.transaction_index);
         expect(relayResponse.value).to.eq(mirrorNodeResponse.amount);
     }
@@ -164,7 +174,7 @@ export default class Assertions {
             ? mirrorResult.gas_price
             : mirrorResult.max_fee_per_gas;
         const mirrorEffectiveGasPrice = Utils.tinyBarsToWeibars(effectiveGas);
-        expect(transactionReceipt.effectiveGasPrice).to.eq(mirrorEffectiveGasPrice);
+        expect(BigNumber.from(transactionReceipt.effectiveGasPrice).toString()).to.eq(mirrorEffectiveGasPrice.toString());
 
         expect(transactionReceipt.status).to.exist;
         expect(transactionReceipt.status).to.eq(mirrorResult.status);


### PR DESCRIPTION
Signed-off-by: Ivo Yankov <ivo@devlabs.bg>

**Description**:
Adjust the acceptance tests so that they run consistently against Testnet and Previewnet.
Some tests were failing with error `-32009: Gas price too low` due to a higher gas price on the public networks than the default hardcoded one that is used when testing against the local node.

When testing against Previewnet it turned out that the `chainId` value in the README was incorrect.

**Related issue(s)**:

Fixes #340 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
