### PR TITLE
readme updated with new instructions for installing the helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,15 @@ Where the `result` value matches the .env `CHAIN_ID` configuration value or the 
 
 ### Helm Chart
 
-In this repo there is a `helm-chart` directory that contains the configurations to deploy Hedera's json-rpc relay to a K8s cluster.
-To get started install the helm chart:
+This repos `helm-chart` directory that contains the configurations to deploy Hedera's json-rpc relay to a K8s cluster.  These same configurations are also available via helm repo.
+To install the helm chart first install the helm repo:
 ```
-helm install hedera-json-rpc-relay ./helm-chart --debug
+helm repo add hedera-json-rpc-relay https://hashgraph.github.io/hedera-json-rpc-relay/charts
+helm repo update
+```
+now install the helm chart:
+```
+helm install [RELEASE_NAME] hedera-json-rpc-relay/hedera-json-rpc-relay -f /path/to/values.yaml
 ```
 
 To see the values that have been deployed:

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Where the `result` value matches the .env `CHAIN_ID` configuration value or the 
 
 ### Helm Chart
 
-This repos `helm-chart` directory that contains the configurations to deploy Hedera's json-rpc relay to a K8s cluster.  These same configurations are also available via helm repo.
-To install the helm chart first install the helm repo:
+This repos `helm-chart` directory contains the templates and values to deploy Hedera's json-rpc relay to a K8s cluster.  This directory is packaged and distributed via helm repo.
+To get started, first install the helm repo:
 ```
 helm repo add hedera-json-rpc-relay https://hashgraph.github.io/hedera-json-rpc-relay/charts
 helm repo update


### PR DESCRIPTION
Readme update to use the helm repo instead of the existing helm-charts directory.  Helm repo allows for multiple versions to be stored.
