### PR TITLE
Align transaction with ethereum execution apis (0.4)

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -780,7 +780,7 @@ export class EthImpl implements Eth {
       blockNumber: EthImpl.numberTo0x(contractResult.block_number),
       chainId: contractResult.chain_id,
       from: contractResult.from.substring(0, 42),
-      gas: contractResult.gas_used,
+      gas: EthImpl.numberTo0x(contractResult.gas_used),
       gasPrice: EthImpl.toNullIfEmptyHex(contractResult.gas_price),
       hash: contractResult.hash.substring(0, 66),
       input: contractResult.function_parameters,
@@ -790,10 +790,10 @@ export class EthImpl implements Eth {
       r: rSig,
       s: sSig,
       to: contractResult.to?.substring(0, 42),
-      transactionIndex: contractResult.transaction_index,
+      transactionIndex: EthImpl.numberTo0x(contractResult.transaction_index),
       type: contractResult.type,
       v: contractResult.v,
-      value: contractResult.amount,
+      value: EthImpl.numberTo0x(contractResult.amount),
     });
   }
 
@@ -1035,7 +1035,7 @@ export class EthImpl implements Eth {
           blockNumber: EthImpl.numberTo0x(contractResultDetails.block_number),
           chainId: contractResultDetails.chain_id,
           from: contractResultDetails.from.substring(0, 42),
-          gas: contractResultDetails.gas_used,
+          gas: EthImpl.numberTo0x(contractResultDetails.gas_used),
           gasPrice: EthImpl.toNullIfEmptyHex(contractResultDetails.gas_price),
           hash: contractResultDetails.hash.substring(0, 66),
           input: contractResultDetails.function_parameters,
@@ -1045,10 +1045,10 @@ export class EthImpl implements Eth {
           r: rSig,
           s: sSig,
           to: contractResultDetails.to.substring(0, 42),
-          transactionIndex: contractResultDetails.transaction_index,
+          transactionIndex: EthImpl.numberTo0x(contractResultDetails.transaction_index),
           type: contractResultDetails.type,
           v: contractResultDetails.v,
-          value: contractResultDetails.amount,
+          value: EthImpl.numberTo0x(contractResultDetails.amount),
         });
       })
       .catch((e: any) => {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1336,7 +1336,7 @@ describe('Eth', async function () {
     "blockNumber": "0x11",
     "chainId": "0x12a",
     "from": "0x0000000000000000000000000000000000001f41",
-    "gas": 123,
+    "gas": "0x7b",
     "gasPrice": "0x4a817c80",
     "hash": defaultTxHash,
     "input": "0x0707",
@@ -1346,10 +1346,10 @@ describe('Eth', async function () {
     "r": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
     "s": "0x24e9c602ac800b983b035700a14b23f78a253ab762deab5dc27e3555a750b354",
     "to": "0x0000000000000000000000000000000000001389",
-    "transactionIndex": 1,
+    "transactionIndex": "0x1",
     "type": 2,
     "v": 1,
-    "value": 2000000000
+    "value": "0x77359400"
   };
 
   const defaultDetailedContractResultByHash = {

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -121,13 +121,13 @@ export default class Assertions {
         expect(relayResponse.blockNumber).to.eq(ethers.utils.hexValue(mirrorNodeResponse.block_number));
         // expect(relayResponse.chainId).to.eq(mirrorNodeResponse.chain_id); // FIXME must not be null!
         expect(relayResponse.from).to.eq(mirrorNodeResponse.from);
-        expect(relayResponse.gas).to.eq(mirrorNodeResponse.gas_used);
+        expect(relayResponse.gas).to.eq(ethers.utils.hexValue(mirrorNodeResponse.gas_used));
         // expect(relayResponse.gasPrice).to.eq(mirrorNodeResponse.gas_price); // FIXME must not be null!
         expect(relayResponse.hash).to.eq(mirrorNodeResponse.hash.slice(0, 66));
         expect(relayResponse.input).to.eq(mirrorNodeResponse.function_parameters);
         expect(relayResponse.to).to.eq(mirrorNodeResponse.to);
-        expect(relayResponse.transactionIndex).to.eq(mirrorNodeResponse.transaction_index);
-        expect(relayResponse.value).to.eq(mirrorNodeResponse.amount);
+        expect(relayResponse.transactionIndex).to.eq(ethers.utils.hexValue(mirrorNodeResponse.transaction_index));
+        expect(relayResponse.value).to.eq(ethers.utils.hexValue(mirrorNodeResponse.amount));
     }
 
     static transactionReceipt = (transactionReceipt, mirrorResult) => {


### PR DESCRIPTION
**Description**:
Cherry-pick #338 to release/0.4

Update transaction response integers to be hexadecimal like ethereum execution apis schema

**Related issue(s)**:

Fixes #338 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
