### PR TITLE
Align log with execution apis (0.4)

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -825,13 +825,13 @@ export class EthImpl implements Eth {
         return new Log({
           address: log.address,
           blockHash: EthImpl.toHash32(receiptResponse.block_hash),
-          blockNumber: receiptResponse.block_number,
+          blockNumber: EthImpl.numberTo0x(receiptResponse.block_number),
           data: log.data,
-          logIndex: log.index,
+          logIndex: EthImpl.numberTo0x(log.index),
           removed: false,
           topics: log.topics,
           transactionHash: EthImpl.toHash32(receiptResponse.hash),
-          transactionIndex: receiptResponse.transaction_index
+          transactionIndex: EthImpl.numberTo0x(receiptResponse.transaction_index)
         });
       });
 
@@ -1151,13 +1151,13 @@ export class EthImpl implements Eth {
           logs[logIndex] = new Log({
             address: log.address,
             blockHash: EthImpl.toHash32(detail.block_hash),
-            blockNumber: detail.block_number,
+            blockNumber: EthImpl.numberTo0x(detail.block_number),
             data: log.data,
-            logIndex: logIndex,
+            logIndex: EthImpl.numberTo0x(logIndex),
             removed: false,
             topics: log.topics,
             transactionHash: EthImpl.toHash32(detail.hash),
-            transactionIndex: detail.transaction_index
+            transactionIndex: EthImpl.numberTo0x(detail.transaction_index)
           });
         }
       }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -979,15 +979,15 @@ describe('Eth calls using MirrorNode', async function () {
       expect(res.address).to.eq(log.address);
       expect(res.blockHash).to.eq(EthImpl.toHash32(tx.block_hash));
       expect(res.blockHash.length).to.eq(66);
-      expect(res.blockNumber).to.eq(tx.block_number);
+      expect(res.blockNumber).to.eq(EthImpl.numberTo0x(tx.block_number));
       expect(res.data).to.eq(log.data);
-      expect(res.logIndex).to.eq(blockLogIndexOffset + Number(log.index));
+      expect(res.logIndex).to.eq(EthImpl.numberTo0x(blockLogIndexOffset + Number(log.index)));
       expect(res.removed).to.eq(false);
       expect(res.topics).to.exist;
       expect(res.topics).to.deep.eq(log.topics);
       expect(res.transactionHash).to.eq(tx.hash);
       expect(res.transactionHash.length).to.eq(66);
-      expect(res.transactionIndex).to.eq(tx.transaction_index);
+      expect(res.transactionIndex).to.eq(EthImpl.numberTo0x(tx.transaction_index));
     };
 
     const expectLogData1 = (res) => {
@@ -1411,15 +1411,15 @@ describe('Eth', async function () {
     "logs": [{
       "address": "0x0000000000000000000000000000000000001389",
       "blockHash": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
-      "blockNumber": 17,
+      "blockNumber": "0x11",
       "data": "0x0123",
-      "logIndex": 0,
+      "logIndex": "0x0",
       "removed": false,
       "topics": [
         "0x97c1fc0a6ed5551bc831571325e9bdb365d06803100dc20648640ba24ce69750"
       ],
       "transactionHash": "0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392",
-      "transactionIndex": 1
+      "transactionIndex": "0x1"
     }],
     "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
     "status": "0x1",

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -131,7 +131,7 @@ describe('RPC Server Acceptance Tests', function () {
                     expect(logs[i]).to.have.property('logIndex');
 
                     // verify logIndex represents index in block across transactions
-                    expect(logs[i].logIndex).to.equal(Number(i));
+                    expect(logs[i].logIndex).to.equal(ethers.utils.hexValue(Number(i)));
 
                     const key = `${logs[i].transactionHash}---${logs[i].logIndex}`;
                     txIndexLogIndexMapping.push(key);
@@ -156,7 +156,7 @@ describe('RPC Server Acceptance Tests', function () {
 
                 const log4BlockInt = parseInt(log4Block.blockNumber);
                 for (let i in logs) {
-                    expect(logs[i].blockNumber).to.be.greaterThanOrEqual(log4BlockInt);
+                    expect(parseInt(logs[i].blockNumber, 16)).to.be.greaterThanOrEqual(log4BlockInt);
                 }
             });
 
@@ -168,7 +168,7 @@ describe('RPC Server Acceptance Tests', function () {
 
                 const log0BlockInt = parseInt(log0Block.blockNumber);
                 for (let i in logs) {
-                    expect(logs[i].blockNumber).to.be.lessThanOrEqual(log0BlockInt);
+                    expect(parseInt(logs[i].blockNumber, 16)).to.be.lessThanOrEqual(log0BlockInt);
                 }
             });
 
@@ -182,8 +182,8 @@ describe('RPC Server Acceptance Tests', function () {
                 const log0BlockInt = parseInt(log0Block.blockNumber);
                 const log4BlockInt = parseInt(log4Block.blockNumber);
                 for (let i in logs) {
-                    expect(logs[i].blockNumber).to.be.greaterThanOrEqual(log0BlockInt);
-                    expect(logs[i].blockNumber).to.be.lessThanOrEqual(log4BlockInt);
+                    expect(parseInt(logs[i].blockNumber, 16)).to.be.greaterThanOrEqual(log0BlockInt);
+                    expect(parseInt(logs[i].blockNumber, 16)).to.be.lessThanOrEqual(log4BlockInt);
                 }
             });
 


### PR DESCRIPTION
**Description**:
CHerry-pick #337 to release/0.4

Update log response integers to be hexadecimals

**Related issue(s)**:

Fixes #337 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
