### PR TITLE
Document the blockHash filter for eth_getLogs

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -1318,6 +1318,10 @@
                         "title": "to block",
                         "$ref": "#/components/schemas/uint"
                     },
+                    "blockHash": {
+                        "title": "Block hash",
+                        "$ref": "#/components/schemas/hash32"
+                    },
                     "address": {
                         "title": "Address(es)",
                         "oneOf": [


### PR DESCRIPTION
**Description**:
Adds the `blockHash` filter for eth_getLogs in `openrpc.json`

**Related issue(s)**:

Fixes #376 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
