### PR TITLE
Support 'from' in 'eth_call' (0.4)

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -194,7 +194,7 @@ export class SDKClient {
           .setEthereumData(transactionBuffer), callerName);
     }
 
-    async submitContractCallQuery(to: string, data: string, gas: number, callerName: string): Promise<ContractFunctionResult> {
+    async submitContractCallQuery(to: string, data: string, gas: number, from: string, callerName: string): Promise<ContractFunctionResult> {
         const contract = SDKClient.prune0x(to);
         const contractId = contract.startsWith("00000000000")
             ? ContractId.fromSolidityAddress(contract)
@@ -207,6 +207,10 @@ export class SDKClient {
         // data is optional and can be omitted in which case fallback function will be employed
         if (data) {
             contractCallQuery.setFunctionParameters(Buffer.from(SDKClient.prune0x(data), 'hex'));
+        }
+
+        if (from) {
+            contractCallQuery.setSenderAccountId(AccountId.fromEvmAddress(0,0, from))
         }
 
         if (this.clientMain.operatorAccountId !== null) {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -738,10 +738,10 @@ export class EthImpl implements Eth {
           gas = call.gas;
         }
       }
-
+      
       // Execute the call and get the response
-      this.logger.debug('Making eth_call on contract %o with gas %d and call data "%s"', call.to, gas, call.data);
-      const contractCallResponse = await this.sdkClient.submitContractCallQuery(call.to, call.data, gas, EthImpl.ethCall);
+      this.logger.debug('Making eth_call on contract %o with gas %d and call data "%s" from "%s"', call.to, gas, call.data, call.from);
+      const contractCallResponse = await this.sdkClient.submitContractCallQuery(call.to, call.data, gas, call.from, EthImpl.ethCall);
 
       // FIXME Is this right? Maybe so?
       return EthImpl.prepend0x(Buffer.from(contractCallResponse.asBytes()).toString('hex'));

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -37,7 +37,6 @@ import pino from 'pino';
 import { Block, Transaction } from '../../src/lib/model';
 import constants from '../../src/lib/constants';
 import { SDKClient } from '../../src/lib/clients';
-import { TextEncoder } from 'util';
 const logger = pino();
 const registry = new Registry();
 const Relay = new RelayImpl(logger, registry);
@@ -115,6 +114,7 @@ describe('Eth calls using MirrorNode', async function () {
   const gasUsed2 = 800000;
   const maxGasLimit = 250000;
   const maxGasLimitHex = EthImpl.numberTo0x(maxGasLimit);
+  const contractCallData = "0xef641f44"
   const firstTransactionTimestampSeconds = '1653077547';
   const firstTransactionTimestampSecondsHex = EthImpl.numberTo0x(Number(firstTransactionTimestampSeconds));
   const contractAddress1 = '0x000000000000000000000000000000000000055f';
@@ -1317,6 +1317,81 @@ describe('Eth calls using MirrorNode', async function () {
     } catch (error: any) {
       expect(error.message).to.equal('Error encountered estimating the gas price');
     }
+  });
+
+  describe('eth_call', async function () {
+    it('eth_call with no gas', async function () {
+      sdkClientStub.submitContractCallQuery.returns({
+            asBytes: function () {
+              return Uint8Array.of(0)
+            }
+          }
+      );
+
+      const result = await ethImpl.call({
+        "from": contractAddress1,
+        "to": contractAddress2,
+        "data": contractCallData,
+      }, 'latest')
+
+      sinon.assert.calledWith(sdkClientStub.submitContractCallQuery, contractAddress2, contractCallData, 400_000, contractAddress1, 'eth_call');
+      expect(result).to.equal("0x00")
+    });
+
+    it('eth_call with no data', async function () {
+      sdkClientStub.submitContractCallQuery.returns({
+            asBytes: function () {
+              return Uint8Array.of(0)
+            }
+          }
+      );
+
+      var result = await ethImpl.call({
+        "from": contractAddress1,
+        "to": contractAddress2,
+        "gas": maxGasLimitHex
+      }, 'latest')
+
+      sinon.assert.calledWith(sdkClientStub.submitContractCallQuery, contractAddress2, undefined, maxGasLimit, contractAddress1, 'eth_call');
+      expect(result).to.equal("0x00")
+    });
+
+    it('eth_call with no from address', async function () {
+      sdkClientStub.submitContractCallQuery.returns({
+            asBytes: function () {
+              return Uint8Array.of(0)
+            }
+          }
+      );
+
+      const result = await ethImpl.call({
+        "to": contractAddress2,
+        "data": contractCallData,
+        "gas": maxGasLimitHex
+      }, 'latest')
+
+      sinon.assert.calledWith(sdkClientStub.submitContractCallQuery, contractAddress2, contractCallData, maxGasLimit, undefined, 'eth_call');
+      expect(result).to.equal("0x00")
+    });
+
+    it('eth_call with all fields', async function () {
+      sdkClientStub.submitContractCallQuery.returns({
+            asBytes: function () {
+              return Uint8Array.of(0)
+            }
+          }
+      );
+
+      const result = await ethImpl.call({
+        "from": contractAddress1,
+        "to": contractAddress2,
+        "data": contractCallData,
+        "gas": maxGasLimitHex
+      }, 'latest')
+
+      sinon.assert.calledWith(sdkClientStub.submitContractCallQuery, contractAddress2, contractCallData, maxGasLimit, contractAddress1, 'eth_call');
+      expect(result).to.equal("0x00")
+    });
   });
 });
 


### PR DESCRIPTION
* 

**Description**:
Cherry pick #375 

When a from value is in the eth_call params, set it to the senderId.


**Related issue(s)**:

Fixes #373 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
