### PR TITLE
Query mirror node for deployed_bytecode in eth_getCode

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -487,10 +487,16 @@ export class EthImpl implements Eth {
     }
 
     try {
-      const bytecode = await this.sdkClient.getContractByteCode(0, 0, address, EthImpl.ethGetCode);
-      return EthImpl.prepend0x(Buffer.from(bytecode).toString('hex'));
+      const contract = await this.mirrorNodeClient.getContract(address);
+      if (contract && contract.runtime_bytecode && contract.runtime_bytecode !== EthImpl.emptyHex) {
+        return contract.runtime_bytecode;
+      }
+      else {
+        const bytecode = await this.sdkClient.getContractByteCode(0, 0, address, EthImpl.ethGetCode);
+        return EthImpl.prepend0x(Buffer.from(bytecode).toString('hex'));
+      }
     } catch (e: any) {
-      if(e instanceof SDKClientError) {      
+      if(e instanceof SDKClientError) {
         // handle INVALID_CONTRACT_ID
         if (e.isInvalidContractId()) {
           this.logger.debug('Unable to find code for contract %s in block "%s", returning 0x0, err code: %s', address, blockNumber, e.statusCode);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -989,7 +989,7 @@ describe('Eth calls using MirrorNode', async function () {
       expect(resCached).to.equal(EthImpl.emptyHex);
     });
 
-    it('should return the deployed_bytecode from the mirror node', async () => {
+    it('should return the runtime_bytecode from the mirror node', async () => {
       mock.onGet(`contracts/${contractAddress1}`).reply(200, defaultContract);
       sdkClientStub.getContractByteCode.returns(Buffer.from(deployedBytecode.replace('0x', ''), 'hex'));
 
@@ -1000,18 +1000,16 @@ describe('Eth calls using MirrorNode', async function () {
     it('should return the bytecode from SDK if Mirror Node returns 404', async () => {
       mock.onGet(`contracts/${contractAddress1}`).reply(404, defaultContract);
       sdkClientStub.getContractByteCode.returns(Buffer.from(deployedBytecode.replace('0x', ''), 'hex'));
-
       const res = await ethImpl.getCode(contractAddress1, null);
       expect(res).to.equal(deployedBytecode);
     });
 
-    it('should return the bytecode from SDK if Mirror Node returns empty deployed_bytecode', async () => {
+    it('should return the bytecode from SDK if Mirror Node returns empty runtime_bytecode', async () => {
       mock.onGet(`contracts/${contractAddress1}`).reply(404, {
         ...defaultContract,
-        deployed_bytecode: '0x'
-      }, );
+        runtime_bytecode: EthImpl.emptyHex
+      });
       sdkClientStub.getContractByteCode.returns(Buffer.from(deployedBytecode.replace('0x', ''), 'hex'));
-
       const res = await ethImpl.getCode(contractAddress1, null);
       expect(res).to.equal(deployedBytecode);
     });

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -118,7 +118,7 @@ describe('RPC Server Acceptance Tests', function () {
         // set env variables for docker images until local-node is updated
         process.env['NETWORK_NODE_IMAGE_TAG'] = '0.27.4';
         process.env['HAVEGED_IMAGE_TAG'] = '0.27.4';
-        process.env['MIRROR_IMAGE_TAG'] = '0.60.0';
+        process.env['MIRROR_IMAGE_TAG'] = '0.62.0-rc1';
         logger.trace(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 
         // start local-node


### PR DESCRIPTION
**Description**:
`eth_getCode` makes a request to the mirror node. In the case of an empty result (`0x`) or if the contract has not yet been propagated to the mirror node the bytecode is retrieved from consensus.

**Related issue(s)**:

Fixes #27 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
