### PR TITLE
return 0x instead of 0x0 for non existing contract addresses given to…

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -494,8 +494,8 @@ export class EthImpl implements Eth {
         // handle INVALID_CONTRACT_ID
         if (e.isInvalidContractId()) {
           this.logger.debug('Unable to find code for contract %s in block "%s", returning 0x0, err code: %s', address, blockNumber, e.statusCode);
-          cache.set(cachedLabel, '0x', constants.CACHE_TTL.ONE_HOUR);
-          return '0x';
+          cache.set(cachedLabel, EthImpl.emptyHex, constants.CACHE_TTL.ONE_HOUR);
+          return EthImpl.emptyHex;
         }
         this.logger.error(e, 'Error raised during getCode for address %s, err code: %s', address, e.statusCode);
       } else {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -494,8 +494,8 @@ export class EthImpl implements Eth {
         // handle INVALID_CONTRACT_ID
         if (e.isInvalidContractId()) {
           this.logger.debug('Unable to find code for contract %s in block "%s", returning 0x0, err code: %s', address, blockNumber, e.statusCode);
-          cache.set(cachedLabel, '0x0', constants.CACHE_TTL.ONE_HOUR);
-          return '0x0';
+          cache.set(cachedLabel, '0x', constants.CACHE_TTL.ONE_HOUR);
+          return '0x';
         }
         this.logger.error(e, 'Error raised during getCode for address %s, err code: %s', address, e.statusCode);
       } else {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -958,8 +958,8 @@ describe('Eth calls using MirrorNode', async function () {
       const resNoCache = await ethImpl.getCode(contractAddress1, null);
       const resCached = await ethImpl.getCode(contractAddress1, null);
       sinon.assert.calledOnce(sdkClientStub.getContractByteCode);
-      expect(resNoCache).to.equal(EthImpl.zeroHex);
-      expect(resCached).to.equal(EthImpl.zeroHex);
+      expect(resNoCache).to.equal(EthImpl.emptyHex);
+      expect(resCached).to.equal(EthImpl.emptyHex);
     });
 
     it('should return the bytecode', async () => {

--- a/packages/server/tests/acceptance/erc20.spec.ts
+++ b/packages/server/tests/acceptance/erc20.spec.ts
@@ -28,6 +28,7 @@ import { ethers, BigNumber } from 'ethers';
 import ERC20MockJson from '../contracts/ERC20Mock.json';
 import Assertions from '../helpers/assertions';
 import {Utils} from '../helpers/utils';
+import { EthImpl } from "@hashgraph/json-rpc-relay/src/lib/eth";
 
 
 describe('ERC20 Acceptance Tests', async function () {
@@ -50,7 +51,7 @@ describe('ERC20 Acceptance Tests', async function () {
 
     const testTitles = [
         {testName: ERC20, expectedBytecode: ERC20MockJson.deployedBytecode},
-        {testName: HTS, expectedBytecode: '0x'}
+        {testName: HTS, expectedBytecode: EthImpl.emptyHex}
     ];
 
     before(async () => {

--- a/packages/server/tests/acceptance/erc20.spec.ts
+++ b/packages/server/tests/acceptance/erc20.spec.ts
@@ -50,7 +50,7 @@ describe('ERC20 Acceptance Tests', async function () {
 
     const testTitles = [
         {testName: ERC20, expectedBytecode: ERC20MockJson.deployedBytecode},
-        {testName: HTS, expectedBytecode: '0x0'}
+        {testName: HTS, expectedBytecode: '0x'}
     ];
 
     before(async () => {

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -989,19 +989,19 @@ describe('RPC Server Acceptance Tests', function () {
 
                 it('should return 0x0 for non-existing contract on eth_getCode', async function () {
                     const res = await relay.call('eth_getCode', [NON_EXISTING_ADDRESS]);
-                    expect(res).to.eq('0x0');
+                    expect(res).to.eq('0x');
                 });
 
                 it('should return 0x0 for account evm_address on eth_getCode', async function () {
                     const evmAddress = Utils.idToEvmAddress(accounts[2].accountId.toString());
                     const res = await relay.call('eth_getCode', [evmAddress]);
-                    expect(res).to.eq('0x0');
+                    expect(res).to.eq('0x');
                 });
 
                 it('should return 0x0 for account alias on eth_getCode', async function () {
                     const alias = Utils.idToEvmAddress(accounts[2].accountId.toString());
                     const res = await relay.call('eth_getCode', [alias]);
-                    expect(res).to.eq('0x0');
+                    expect(res).to.eq('0x');
                 });
             });
 

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -31,6 +31,7 @@ import parentContractJson from '../contracts/Parent.json';
 import basicContractJson from '../contracts/Basic.json';
 import logsContractJson from '../contracts/Logs.json';
 import { predefined } from '../../../relay/src/lib/errors/JsonRpcError';
+import { EthImpl } from '@hashgraph/json-rpc-relay/src/lib/eth';
 
 describe('RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -989,19 +990,19 @@ describe('RPC Server Acceptance Tests', function () {
 
                 it('should return 0x0 for non-existing contract on eth_getCode', async function () {
                     const res = await relay.call('eth_getCode', [NON_EXISTING_ADDRESS]);
-                    expect(res).to.eq('0x');
+                    expect(res).to.eq(EthImpl.emptyHex);
                 });
 
                 it('should return 0x0 for account evm_address on eth_getCode', async function () {
                     const evmAddress = Utils.idToEvmAddress(accounts[2].accountId.toString());
                     const res = await relay.call('eth_getCode', [evmAddress]);
-                    expect(res).to.eq('0x');
+                    expect(res).to.eq(EthImpl.emptyHex);
                 });
 
                 it('should return 0x0 for account alias on eth_getCode', async function () {
                     const alias = Utils.idToEvmAddress(accounts[2].accountId.toString());
                     const res = await relay.call('eth_getCode', [alias]);
-                    expect(res).to.eq('0x');
+                    expect(res).to.eq(EthImpl.emptyHex);
                 });
             });
 


### PR DESCRIPTION
… eth_getCode

Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:
In order to be more consistent with other relays, return 0x instead of 0x0 when sending a non existing contract address to the eth_getCode call.

Modified code in the error condition when we are given an invalid contract.

**Related issue(s)**:

Fixes #394 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
