### PR TITLE
test: Acceptance tests seems inconsistent

### DIFF
--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -1104,23 +1104,23 @@ describe('RPC Server Acceptance Tests', function () {
                     Assertions.feeHistory(res, {
                         resultCount: blockCountNumber,
                         oldestBlock: oldestBlockNumberHex,
-                        chechReward: true
+                        checkReward: true
                     });
-
-                    expect(res.baseFeePerGas[0]).to.equal(datedGasPriceHex);
+                    // We expect all values in the array to be from the mirror node. If there is discrepancy in the blocks, the first value is from the consensus node and it's different from expected.
+                    expect(res.baseFeePerGas[1]).to.equal(datedGasPriceHex);
                     expect(res.baseFeePerGas[res.baseFeePerGas.length - 2]).to.equal(updatedGasPriceHex);
                     expect(res.baseFeePerGas[res.baseFeePerGas.length - 1]).to.equal(updatedGasPriceHex);
                 });
 
                 it('should call eth_feeHistory with newest block > latest', async function () {
                     let latestBlock;
-                    const newestBlockNumber = lastBlockAfterUpdate.number + 10;
-                    const newestBlockNumberHex = ethers.utils.hexValue(newestBlockNumber);
+                    const blocksAhead = 10;
                     try {
                         latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`)).blocks[0];
+                        const newestBlockNumberHex = ethers.utils.hexValue(latestBlock.number + blocksAhead);
                         await relay.call('eth_feeHistory', ['0x1', newestBlockNumberHex, null]);
                     } catch (error) {
-                        Assertions.jsonRpcError(error, predefined.REQUEST_BEYOND_HEAD_BLOCK(newestBlockNumber, latestBlock.number));
+                        Assertions.jsonRpcError(error, predefined.REQUEST_BEYOND_HEAD_BLOCK(latestBlock.number + blocksAhead, latestBlock.number));
                     }
                 });
 


### PR DESCRIPTION
**Description**:
Fixing two tests with these changes. Another one was fixed here https://github.com/hashgraph/hedera-sdk-js/pull/1224. 

Logic behind fix for test: `should call eth_feeHistory with updated fees`
In the before hook, we are feeding default fees to the mirror node. So that we know how many blocks we should take and where to expect those fees. But if there is discrepancy in the blocks, the first element in this array is taken from the consensus node, not from the mirror node. This is the reason sometimes this value in the first index is wrong.

Logic behind fix for test: `should call eth_feeHistory with newest block > latest`
By the time we're requesting the last block, it's already ahead by one. So we were excepting it to be 10 ahead, but it's actually 11 ahead on rare occasions.


**Related issue(s)**:

Fixes #381 

**Notes for reviewer**:
```
  131 passing (4m)

[2022-08-08 12:44:04.670 +0000] INFO (rpc-acceptance-test/44539 on Georgis-MacBook-Pro-3.local): Acceptance Tests spent 532.31120121 ℏ

```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
