### PR TITLE
Resolve issues with some fields in eth_getBlock

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -924,15 +924,12 @@ export class EthImpl implements Eth {
     const timestampRangeParams = [`gte:${timestampRange.from}`, `lte:${timestampRange.to}`];
     const contractResults = await this.mirrorNodeClient.getContractResults({ timestamp: timestampRangeParams });
     const maxGasLimit = constants.BLOCK_GAS_LIMIT;
+    const gasUsed = blockResponse.gas_used;
 
     if (contractResults === null || contractResults.results === undefined) {
       // contract result not found
       return null;
     }
-
-    // loop over contract function results to calculated aggregated datapoints
-    let gasUsed = 0;
-
 
     // The consensus timestamp of the block, with the nanoseconds part omitted.
     const timestamp = timestampRange.from.substring(0, timestampRange.from.indexOf('.'));
@@ -940,8 +937,6 @@ export class EthImpl implements Eth {
     const transactionHashes: string[] = [];
 
     for (const result of contractResults.results) {
-      gasUsed += result.gas_used;
-
       // depending on stage of contract execution revert the result.to value may be null
       if (!_.isNil(result.to)) {
         const transaction = await this.getTransactionFromContractResult(result.to, result.timestamp);

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -133,7 +133,9 @@ export const defaultBlock = {
     'timestamp': {
         'from': '1651560386.060890949',
         'to': '1651560389.060890949'
-    }
+    },
+    'gas_used': gasUsed1 + gasUsed2,
+    'logs_bloom': '0x'
 };
 export const defaultContractResults = {
     'results': [

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -137,7 +137,7 @@ describe('Eth calls using MirrorNode', async function () {
 
   const defaultBlock = {
     'count': blockTransactionCount,
-    'hapi_version': '0.27.0',
+    'hapi_version': '0.28.1',
     'hash': blockHash,
     'name': '2022-05-03T06_46_26.060890949Z.rcd',
     'number': blockNumber,
@@ -146,7 +146,9 @@ describe('Eth calls using MirrorNode', async function () {
     'timestamp': {
       'from': `${blockTimestamp}.060890949`,
       'to': '1651560389.060890949'
-    }
+    },
+    'gas_used': gasUsed1 + gasUsed2,
+    'logs_bloom': '0x'
   };
 
 
@@ -451,7 +453,7 @@ describe('Eth calls using MirrorNode', async function () {
 
   it('eth_getBlockByNumber with zero transactions', async function () {
     // mirror node request mocks
-    mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
+    mock.onGet(`blocks/${blockNumber}`).reply(200, {...defaultBlock, gas_used: 0});
     mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, { 'results': [] });
     mock.onGet('network/fees').reply(200, defaultNetworkFees);
     const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
@@ -498,7 +500,7 @@ describe('Eth calls using MirrorNode', async function () {
 
   it('eth_getBlockByNumber with block match and contract revert', async function () {
     // mirror node request mocks
-    mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
+    mock.onGet(`blocks/${blockNumber}`).reply(200, {...defaultBlock, gas_used: gasUsed1});
     mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultContractResultsRevert);
     mock.onGet('network/fees').reply(200, defaultNetworkFees);
 
@@ -636,7 +638,7 @@ describe('Eth calls using MirrorNode', async function () {
 
   it('eth_getBlockByHash with block match and contract revert', async function () {
     // mirror node request mocks
-    mock.onGet(`blocks/${blockHash}`).reply(200, defaultBlock);
+    mock.onGet(`blocks/${blockHash}`).reply(200, {...defaultBlock, gas_used: gasUsed1});
     mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, defaultContractResultsRevert);
     mock.onGet('network/fees').reply(200, defaultNetworkFees);
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -54,6 +54,7 @@ const validateHash = (hash: string, len?: number) => {
 };
 
 const verifyBlockConstants = (block: Block) => {
+  expect(block.gasLimit).equal(EthImpl.numberTo0x(15000000));
   expect(block.baseFeePerGas).equal('0x84b6a5c400');
   expect(block.difficulty).equal(EthImpl.zeroHex);
   expect(block.extraData).equal(EthImpl.emptyHex);
@@ -115,7 +116,9 @@ describe('Eth calls using MirrorNode', async function () {
   const gasUsed2 = 800000;
   const maxGasLimit = 250000;
   const maxGasLimitHex = EthImpl.numberTo0x(maxGasLimit);
-  const contractCallData = "0xef641f44"
+  const contractCallData = "0xef641f44";
+  const blockTimestamp = '1651560386';
+  const blockTimestampHex = EthImpl.numberTo0x(Number(blockTimestamp));
   const firstTransactionTimestampSeconds = '1653077547';
   const firstTransactionTimestampSecondsHex = EthImpl.numberTo0x(Number(firstTransactionTimestampSeconds));
   const contractAddress1 = '0x000000000000000000000000000000000000055f';
@@ -141,7 +144,7 @@ describe('Eth calls using MirrorNode', async function () {
     'previous_hash': '0xf7d6481f659c866c35391ee230c374f163642ebf13a5e604e04a95a9ca48a298dc2dfa10f51bcbaab8ae23bc6d662a0b',
     'size': null,
     'timestamp': {
-      'from': '1651560386.060890949',
+      'from': `${blockTimestamp}.060890949`,
       'to': '1651560389.060890949'
     }
   };
@@ -435,10 +438,9 @@ describe('Eth calls using MirrorNode', async function () {
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
     expect(result.gasUsed).equal(totalGasUsed);
-    expect(result.gasLimit).equal(maxGasLimitHex);
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
-    expect(result.timestamp).equal(firstTransactionTimestampSecondsHex);
+    expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(2);
     expect((result.transactions[0] as string)).equal(contractHash1);
     expect((result.transactions[1] as string)).equal(contractHash1);
@@ -459,10 +461,9 @@ describe('Eth calls using MirrorNode', async function () {
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
     expect(result.gasUsed).equal('0x0');
-    expect(result.gasLimit).equal('0x0');
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
-    expect(result.timestamp).equal('0x0');
+    expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(0);
     expect(result.transactionsRoot).equal(EthImpl.ethEmptyTrie);
 
@@ -484,10 +485,9 @@ describe('Eth calls using MirrorNode', async function () {
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
     expect(result.gasUsed).equal(totalGasUsed);
-    expect(result.gasLimit).equal(maxGasLimitHex);
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
-    expect(result.timestamp).equal(firstTransactionTimestampSecondsHex);
+    expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(2);
     expect((result.transactions[0] as Transaction).hash).equal(contractHash1);
     expect((result.transactions[1] as Transaction).hash).equal(contractHash1);
@@ -509,10 +509,9 @@ describe('Eth calls using MirrorNode', async function () {
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
     expect(result.gasUsed).equal(EthImpl.numberTo0x(gasUsed1));
-    expect(result.gasLimit).equal(maxGasLimitHex);
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
-    expect(result.timestamp).equal(firstTransactionTimestampSecondsHex);
+    expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(0);
 
     // verify expected constants
@@ -598,10 +597,9 @@ describe('Eth calls using MirrorNode', async function () {
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
     expect(result.gasUsed).equal(totalGasUsed);
-    expect(result.gasLimit).equal(maxGasLimitHex);
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
-    expect(result.timestamp).equal(firstTransactionTimestampSecondsHex);
+    expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(2);
     expect((result.transactions[0] as string)).equal(contractHash1);
     expect((result.transactions[1] as string)).equal(contractHash1);
@@ -625,10 +623,9 @@ describe('Eth calls using MirrorNode', async function () {
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
     expect(result.gasUsed).equal(totalGasUsed);
-    expect(result.gasLimit).equal(maxGasLimitHex);
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
-    expect(result.timestamp).equal(firstTransactionTimestampSecondsHex);
+    expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(2);
     expect((result.transactions[0] as Transaction).hash).equal(contractHash1);
     expect((result.transactions[1] as Transaction).hash).equal(contractHash1);
@@ -650,10 +647,9 @@ describe('Eth calls using MirrorNode', async function () {
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
     expect(result.gasUsed).equal(EthImpl.numberTo0x(gasUsed1));
-    expect(result.gasLimit).equal(maxGasLimitHex);
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
-    expect(result.timestamp).equal(firstTransactionTimestampSecondsHex);
+    expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(0);
 
     // verify expected constants

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -32,6 +32,7 @@ export default class Assertions {
     static defaultGasPrice = 720_000_000_000;
     static datedGasPrice = 570_000_000_000;
     static updatedGasPrice = 640_000_000_000;
+    static maxBlockGasLimit = 15_000_000;
     static defaultGasUsed = 0.5;
 
     static assertId = (id) => {
@@ -80,6 +81,7 @@ export default class Assertions {
         expect(relayResponse.uncles).to.be.exist;
         expect(relayResponse.uncles.length).to.eq(0);
         expect(relayResponse.logsBloom).to.eq(Assertions.emptyBloom);
+        expect(relayResponse.gasLimit).to.equal(ethers.utils.hexValue(Assertions.maxBlockGasLimit));
 
         // Assert dynamic values
         expect(relayResponse.hash).to.be.equal(mirrorNodeResponse.hash.slice(0, 66));
@@ -100,7 +102,6 @@ export default class Assertions {
             }
         }
 
-        expect(relayResponse.gasLimit).to.equal(ethers.utils.hexValue(maxGasLimit));
         expect(relayResponse.gasUsed).to.equal(ethers.utils.hexValue(gasUsed));
         expect(relayResponse.timestamp).to.equal(ethers.utils.hexValue(Number(timestamp)));
 

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -89,22 +89,8 @@ export default class Assertions {
         expect(relayResponse.transactions.length).to.equal(mirrorTransactions.length);
         expect(relayResponse.parentHash).to.equal(mirrorNodeResponse.previous_hash.slice(0, 66));
         expect(relayResponse.size).to.equal(ethers.utils.hexValue(mirrorNodeResponse.size | 0));
-
-        let maxGasLimit = 0;
-        let gasUsed = 0;
-        let timestamp = 0;
-
-        for (const result of mirrorTransactions) {
-            maxGasLimit = result.gas_limit > maxGasLimit ? result.gas_limit : maxGasLimit;
-            gasUsed += result.gas_used;
-            if (timestamp === 0) {
-                timestamp = result.timestamp.substring(0, result.timestamp.indexOf('.'));
-            }
-        }
-
-        expect(relayResponse.gasUsed).to.equal(ethers.utils.hexValue(gasUsed));
-        expect(relayResponse.timestamp).to.equal(ethers.utils.hexValue(Number(timestamp)));
-
+        expect(relayResponse.gasUsed).to.equal(ethers.utils.hexValue(mirrorNodeResponse.gas_used));
+        expect(relayResponse.timestamp).to.equal(ethers.utils.hexValue(Number(mirrorNodeResponse.timestamp.from.split('.')[0])));
         if (relayResponse.transactions.length) {
             expect(relayResponse.transactionsRoot).to.equal(mirrorNodeResponse.hash.slice(0, 66));
         }


### PR DESCRIPTION
**Description**:
Fix issues with values returned from `getBlocks`: `timestamp` and `gasLimit`.
- Changes `timestamp` logic to be always the start of the period, returned by the mirror node at `/api/v1/blocks/:hashOrNumber`
- Changes `gasLimit` to be hardcoded as 15000000
- Returns the `gas_used` field from `/api/v1/blocks/:hashOrNumber` as `gasUsed` instead of calculating the gas sum of all contract results in the block.

**Related issue(s)**:

Fixes an issue, described in a comment in [414#issuecomment-1207980112](https://github.com/hashgraph/hedera-json-rpc-relay/issues/414#issuecomment-1207980112)

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
