### PR TITLE
add tests for update token info

### DIFF
--- a/packages/server/tests/contracts/HederaTokenService.sol
+++ b/packages/server/tests/contracts/HederaTokenService.sol
@@ -408,6 +408,16 @@ abstract contract HederaTokenService is HederaResponseCodes {
         (responseCode, defaultKycStatus) = success ? abi.decode(result, (int32, bool)) : (HederaResponseCodes.UNKNOWN, false);
     }
 
+    /// Operation to update token info
+    /// @param token The token address
+    /// @param tokenInfo The hedera token info to update token with
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function updateTokenInfo(address token, IHederaTokenService.HederaToken memory tokenInfo) internal returns (int responseCode) {
+        (bool success, bytes memory result) = precompileAddress.call(
+            abi.encodeWithSelector(IHederaTokenService.updateTokenInfo.selector, token, tokenInfo));
+        responseCode = success ? abi.decode(result, (int32)) : HederaResponseCodes.UNKNOWN;
+    }
+
     /**********************
      * ABI v1 calls       *
      **********************/

--- a/packages/server/tests/contracts/IHederaTokenService.sol
+++ b/packages/server/tests/contracts/IHederaTokenService.sol
@@ -463,6 +463,14 @@ interface IHederaTokenService {
     external
     returns (int64 responseCode, FixedFee[] memory fixedFees, FractionalFee[] memory fractionalFees, RoyaltyFee[] memory royaltyFees);
 
+    /// Operation to update token info
+    /// @param token The token address
+    /// @param tokenInfo The hedera token info to update token with
+    /// @return responseCode The response code for the status of the request. SUCCESS is 22.
+    function updateTokenInfo(address token, HederaToken memory tokenInfo)
+    external
+    returns (int responseCode);
+
     /**********************
      * ABIV1 calls        *
      **********************/


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:
Add tests for updateToken.  

The tests cannot be executed as they depend on completion of the following pr in services: https://github.com/hashgraph/hedera-services/pull/3738

Updated HederaTokenService.sol and IHederaTokenService.sol to add call for performing the update.  The corresponding .json files have not yet been updated awaiting completion of the pr referenced above. 

**Related issue(s)**:

Fixes #410 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
