### PR TITLE
add trace id to error response messages

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -18,12 +18,13 @@
  *
  */
 
+const REQUEST_ID_STRING = `Request ID: `;
 export class JsonRpcError {
   public code: number;
   public message: string;
   public name: string;
 
-  constructor(args: { name: string, code: number, message: string }) {
+  constructor(args: { name: string, code: number, message: string }, requestId?: string) {
     this.code = args.code;
     this.name = args.name;
     this.message = args.message;

--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -27,7 +27,7 @@ export class JsonRpcError {
   constructor(args: { name: string, code: number, message: string }, requestId?: string) {
     this.code = args.code;
     this.name = args.name;
-    this.message = args.message;
+    this.message = requestId ? `[${REQUEST_ID_STRING}${requestId}] ` + args.message : args.message;
   }
 }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -148,7 +148,8 @@ const logAndHandleResponse = async (methodName, methodFunction) => {
     logger.info(`${messagePrefix} ${status} ${ms} ms `);
     if (response instanceof JsonRpcError) {
       return new JsonRpcError({name: response.name, code: response.code, message:`${requestIdPrefix} ` + response.message});
-    } return response;
+    } 
+    return response;
   } catch (e: any) {
     ms = Date.now() - start;
     methodResponseHistogram.labels(methodName, responseInternalErrorCode).observe(ms);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -147,7 +147,8 @@ const logAndHandleResponse = async (methodName, methodFunction) => {
     methodResponseHistogram.labels(methodName, status).observe(ms);
     logger.info(`${messagePrefix} ${status} ${ms} ms `);
     if (response instanceof JsonRpcError) {
-      return new JsonRpcError({name: response.name, code: response.code, message:`${requestIdPrefix} ` + response.message});
+      logger.error(`returning error to sender: ${requestIdPrefix} ${response.message}`)
+      return new JsonRpcError({name: response.name, code: response.code, message: response.message}, requestId);
     } 
     return response;
   } catch (e: any) {
@@ -165,7 +166,8 @@ const logAndHandleResponse = async (methodName, methodFunction) => {
       error = e;
     }
 
-    return new JsonRpcError({name: error.name, code: error.code, message:`${requestIdPrefix} ` + error.message});
+    logger.error(`returning error to sender: ${requestIdPrefix} ${error.message}`)
+    return new JsonRpcError({name: error.name, code: error.code, message:error.message}, requestId);
   }
 };
 

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -44,7 +44,7 @@ export default class Assertions {
 
     static unsupportedResponse = (resp: any) => {
         expect(resp.error.code).to.eq(-32601);
-        expect(resp.error.message).to.eq('Unsupported JSON-RPC method');
+        expect(resp.error.message.endsWith('Unsupported JSON-RPC method')).to.be.true;
     };
 
     static expectedError = () => {
@@ -201,7 +201,7 @@ export default class Assertions {
         expect(err).to.have.property('body');
 
         const parsedError = JSON.parse(err.body);
-        expect(parsedError.error.message).to.be.equal(expectedError.message);
+        expect(parsedError.error.message.endsWith(expectedError.message)).to.be.true;
         expect(parsedError.error.code).to.be.equal(expectedError.code);
     }
 

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -350,7 +350,7 @@ class BaseTest {
     expect(response.data.error).to.have.property('code');
     expect(response.data.error.code).to.be.equal(code);
     expect(response.data.error).to.have.property('message');
-    expect(response.data.error.message).to.be.equal(message);
+    expect(response.data.error.message.endsWith(message)).to.be.true;
     if (name) {
       expect(response.data.error).to.have.property('name');
       expect(response.data.error.name).to.be.equal(name);

--- a/packages/server/tests/postman.json
+++ b/packages/server/tests/postman.json
@@ -604,7 +604,7 @@
 							"    var response = pm.response.json();",
 							"    pm.expect(response.error.code).to.equal(-32601);",
 							"    pm.expect(response.error.name).to.equal(\"Method not found\");",
-							"    pm.expect(response.error.message).to.equal(\"Unsupported JSON-RPC method\");",
+							"    pm.expect(response.error.message.endsWith(\"Unsupported JSON-RPC method\")).to.be.true;",
 							"    pm.expect(response.id).to.equal(\"test_id\");",
 							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
 							"});",


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:
Add trace id to error response messages.  
There is no obvious place to return the trace id when the call is successful without changing the schema.

**Related issue(s)**:

Fixes #431 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
