### PR TITLE
Health checks svc annotations

### DIFF
--- a/helm-chart/environments/minikube.yaml
+++ b/helm-chart/environments/minikube.yaml
@@ -6,8 +6,8 @@ config:
   CHAIN_ID: ""
   MIRROR_NODE_URL: ""
   LOG_LEVEL: ""
-  hosted:
-    HEDERA_NETWORK: previewnet
+  local:
+    HEDERA_NETWORK: {"127.0.01:50211":"0.0.3"}
   OPERATOR_ID_MAIN: ""
   OPERATOR_KEY_MAIN: ""
   OPERATOR_ID_ETH_SENDRAWTRANSACTION: ""

--- a/helm-chart/environments/minikube.yaml
+++ b/helm-chart/environments/minikube.yaml
@@ -6,10 +6,8 @@ config:
   CHAIN_ID: ""
   MIRROR_NODE_URL: ""
   LOG_LEVEL: ""
-  local:
-    HEDERA_NETWORK: {"127.0.01:50211":"0.0.3"}
-
-secret:
+  hosted:
+    HEDERA_NETWORK: previewnet
   OPERATOR_ID_MAIN: ""
   OPERATOR_KEY_MAIN: ""
   OPERATOR_ID_ETH_SENDRAWTRANSACTION: ""

--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -6,7 +6,7 @@ metadata:
     app:  {{ template "json-rpc-relay.name" . }}
     {{ include "json-rpc-relay.labels" . | nindent 4 }}
 data:
-{{- if .Values.config.local.HEDERA_NETWORK }}
+{{- if and .Values.config.local .Values.config.local.HEDERA_NETWORK }}
   HEDERA_NETWORK: {{ .Values.config.local.HEDERA_NETWORK | toJson }}
 {{- else if .Values.config.hosted.HEDERA_NETWORK }}
   HEDERA_NETWORK: {{ .Values.config.hosted.HEDERA_NETWORK }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -95,11 +95,11 @@ spec:
             name: {{ .Values.ports.name  }}
         livenessProbe:
           httpGet:
-            path: /
+            path: /health/liveness
             port: jsonrpcrelay
         readinessProbe:
           httpGet:
-            path: /
+            path: /health/readiness
             port: jsonrpcrelay                      
         resources: 
           {{- toYaml .Values.resources | indent 12 }}

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -93,14 +93,14 @@ spec:
         ports:
           - containerPort: {{ .Values.ports.containerPort }}
             name: {{ .Values.ports.name  }}
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: jsonrpcrelay
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: jsonrpcrelay                      
+        livenessProbe:
+          httpGet:
+            path: /
+            port: jsonrpcrelay
+        readinessProbe:
+          httpGet:
+            path: /
+            port: jsonrpcrelay                      
         resources: 
           {{- toYaml .Values.resources | indent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm-chart/templates/service.yaml
+++ b/helm-chart/templates/service.yaml
@@ -4,6 +4,14 @@ metadata:
   name: {{ include "json-rpc-relay.fullname" . }}
   labels:
     {{- include "json-rpc-relay.labels" . | nindent 4 }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | nindent 4 }}
+{{- end }}
+{{- if .Values.service.annontations_JSON }}
+  annotations:
+{{ .Values.service.annontations_JSON | toJson | nindent 4 }}
+{{- end }}  
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -37,6 +37,8 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 7546
+  annotations: {}
+  annotations_JSON: {}
 
 ingress:
   enabled: false
@@ -90,12 +92,12 @@ config:
   LOG_LEVEL: ""
   # Use config.local.HEDERA_NETWORK when running against a locally hosted hedera network
   # local:
-    # config.local.HEDERA_NETWORK should configured as a json set - {"$IPv4_ADDR_1:$PORT_1":"$ACCOUNT_ID_1","$IPv4_ADDR_2:$PORT_2":"$ACCOUNT_ID_2"}
-    # HEDERA_NETWORK: {"127.0.01:50211":"0.0.3"}
+  #   config.local.HEDERA_NETWORK should configured as a json set - {"$IPv4_ADDR_1:$PORT_1":"$ACCOUNT_ID_1","$IPv4_ADDR_2:$PORT_2":"$ACCOUNT_ID_2"}
+  #   HEDERA_NETWORK: {"127.0.01:50211":"0.0.3"}
+  #   HEDERA_NETWORK: ""
   # Use config.hosted.HEDERA_NETWORK when running against a hosted Hedera network.  Valid options are `previewnet`, `testnet`, and `mainnet`  
   # hosted:
   #   HEDERA_NETWORK: ""
-secret:
   OPERATOR_ID_MAIN: ""
   OPERATOR_KEY_MAIN: ""
   OPERATOR_ID_ETH_SENDRAWTRANSACTION: ""


### PR DESCRIPTION
**Description**:


This PR
* Adds support for YAML and JSON annotations on the service
* Includes readiness and liveness probes to the deployment
* Updates to the configmap `config.HEDERA_NETWORK` logic and coinciding values.yaml comments
* Removed top-level `secrets.` from value.yaml, this was not ever being called or used

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
```
Deployment templating:
---
# Source: hedera-json-rpc-relay/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-hedera-json-rpc-relay
  labels:
    app:  hedera-json-rpc-relay

    helm.sh/chart: hedera-json-rpc-relay-0.7.0-SNAPSHOT
    app.kubernetes.io/name: hedera-json-rpc-relay
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.7.0-SNAPSHOT"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: hedera-json-rpc-relay
      app.kubernetes.io/instance: test
  template:
    metadata:
      labels:
        app:  hedera-json-rpc-relay
        app.kubernetes.io/name: hedera-json-rpc-relay
        app.kubernetes.io/instance: test
    spec:
      imagePullSecrets:
        - name: ghcr-registry-auth
      serviceAccountName: test-hedera-json-rpc-relay
      securityContext:
        {}
      containers:
      - name: hedera-json-rpc-relay
        image: "ghcr.io/hashgraph/hedera-json-rpc-relay:0.7.0-SNAPSHOT"
        imagePullPolicy: Always
        env:
          - name: CHAIN_ID
            value: ''
          - name: CHAIN_ID
            valueFrom:
              configMapKeyRef:
                name: test-hedera-json-rpc-relay
                key: CHAIN_ID
                optional: true
          - name: HEDERA_NETWORK
            valueFrom:
              configMapKeyRef:
                name: test-hedera-json-rpc-relay
                key: HEDERA_NETWORK
                optional: false
          - name: OPERATOR_ID_ETH_SENDRAWTRANSACTION
            valueFrom:
              secretKeyRef:
                name: test-hedera-json-rpc-relay
                key: OPERATOR_ID_ETH_SENDRAWTRANSACTION
                optional: true
          - name: OPERATOR_KEY_ETH_SENDRAWTRANSACTION
            valueFrom:
              secretKeyRef:
                name: test-hedera-json-rpc-relay
                key: OPERATOR_KEY_ETH_SENDRAWTRANSACTION
                optional: true
          - name: MIRROR_NODE_URL
            valueFrom:
              configMapKeyRef:
                name: test-hedera-json-rpc-relay
                key: MIRROR_NODE_URL
                optional: false
          - name: LOCAL_NODE
            valueFrom:
              configMapKeyRef:
                name: test-hedera-json-rpc-relay
                key: LOCAL_NODE
                optional: false
          - name: SERVER_PORT
            valueFrom:
              configMapKeyRef:
                name: test-hedera-json-rpc-relay
                key: SERVER_PORT
                optional: false
          - name: OPERATOR_ID_MAIN
            valueFrom:
              secretKeyRef:
                name: test-hedera-json-rpc-relay
                key: OPERATOR_ID_MAIN
                optional: false
          - name: OPERATOR_KEY_MAIN
            valueFrom:
              secretKeyRef:
                name: test-hedera-json-rpc-relay
                key: OPERATOR_KEY_MAIN
                optional: false
        ports:
          - containerPort: 7546
            name: jsonrpcrelay
        livenessProbe:
          httpGet:
            path: /
            port: jsonrpcrelay
        readinessProbe:
          httpGet:
            path: /
            port: jsonrpcrelay
        resources:            {}
```


**Checklist**

- [x] Documented (Code comments, README, etc.)

