### PR TITLE
Split acceptance tests into separate jobs

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        filter: [ api, erc20, htsprecompile, htsprecompile_v1 ]
+        filter: [ api, erc20, htsprecompile, htsprecompilev1 ]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        filter: [ api, erc20, htsprecompile ]
+        filter: [ api, erc20, htsprecompile, htsprecompile_v1 ]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -8,7 +8,7 @@ on:
     tags: [ v* ]
 
 jobs:
-  acceptance-tests:
+  suite:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -8,8 +8,8 @@ on:
     tags: [ v* ]
 
 jobs:
-  setup-local-hedera:
-    name: Acceptance Tests
+  api-tests:
+    name: API Acceptance Tests
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -38,4 +38,68 @@ jobs:
         run: npx lerna run build
 
       - name: Run acceptance tests
-        run: npm run acceptancetest
+        run: npm run acceptancetest:api
+
+  erc20-rpc-tests:
+    name: ERC 20 Acceptance Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Create .env file
+        run: cp ./packages/server/tests/localAcceptance.env .env
+
+      - name: Lerna Bootstrap
+        run: npm run setup
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Build Typescript
+        run: npx lerna run build
+
+      - name: Run acceptance tests
+        run: npm run acceptancetest:erc20
+
+  htsprecompile-rpc-tests:
+    name: HTS Precompile Acceptance Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Create .env file
+        run: cp ./packages/server/tests/localAcceptance.env .env
+
+      - name: Lerna Bootstrap
+        run: npm run setup
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Build Typescript
+        run: npx lerna run build
+
+      - name: Run acceptance tests
+        run: npm run acceptancetest:htsprecompile

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -8,9 +8,11 @@ on:
     tags: [ v* ]
 
 jobs:
-  api-tests:
-    name: API Acceptance Tests
+  acceptance-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        filter: [ api, erc20, htsprecompile ]
     permissions:
       contents: write
     steps:
@@ -38,68 +40,4 @@ jobs:
         run: npx lerna run build
 
       - name: Run acceptance tests
-        run: npm run acceptancetest:api
-
-  erc20-rpc-tests:
-    name: ERC 20 Acceptance Tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Install packages
-        run: npm ci
-
-      - name: Create .env file
-        run: cp ./packages/server/tests/localAcceptance.env .env
-
-      - name: Lerna Bootstrap
-        run: npm run setup
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Build Typescript
-        run: npx lerna run build
-
-      - name: Run acceptance tests
-        run: npm run acceptancetest:erc20
-
-  htsprecompile-rpc-tests:
-    name: HTS Precompile Acceptance Tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: 16
-
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Install packages
-        run: npm ci
-
-      - name: Create .env file
-        run: cp ./packages/server/tests/localAcceptance.env .env
-
-      - name: Lerna Bootstrap
-        run: npm run setup
-
-      - name: Install pnpm
-        run: npm install -g pnpm
-
-      - name: Build Typescript
-        run: npx lerna run build
-
-      - name: Run acceptance tests
-        run: npm run acceptancetest:htsprecompile
+        run: npm run acceptancetest:${{ matrix.filter }}

--- a/dapp-example/src/components/ContractInteractions.js
+++ b/dapp-example/src/components/ContractInteractions.js
@@ -27,7 +27,7 @@ const ContractInteractions = ({ signer, isConnected, chain, address }) => {
             setDeployContractMsg('Loading...');
 
             const contractFactory = new ethers.ContractFactory(Greeter.abi, Greeter.bytecode, signer);
-            const contract = await contractFactory.deploy('initial_msg');
+            const contract = await contractFactory.deploy('initial_msg', { gasLimit: 500000 });
             const receipt = await contract.deployTransaction.wait();
             setContractAddress(receipt.contractAddress);
 

--- a/dapp-example/src/components/ContractInteractions.js
+++ b/dapp-example/src/components/ContractInteractions.js
@@ -27,7 +27,7 @@ const ContractInteractions = ({ signer, isConnected, chain, address }) => {
             setDeployContractMsg('Loading...');
 
             const contractFactory = new ethers.ContractFactory(Greeter.abi, Greeter.bytecode, signer);
-            const contract = await contractFactory.deploy('initial_msg', { gasLimit: 500000 });
+            const contract = await contractFactory.deploy('initial_msg');
             const receipt = await contract.deployTransaction.wait();
             setContractAddress(receipt.contractAddress);
 

--- a/dapp-example/tests/e2e/index.spec.js
+++ b/dapp-example/tests/e2e/index.spec.js
@@ -29,7 +29,6 @@ describe('Test Core Hedera User Scenarios', function() {
     // deploy the contract
     cy.get('#btnDeployContract').should('not.be.disabled').click();
     cy.confirmMetamaskTransaction();
-    cy.waitUntil(() => cy.get('#btnDeployContract').should('not.be.disabled'));
 
     // test a view call
     cy.get('#btnReadGreeting').should('not.be.disabled').click();

--- a/dapp-example/tests/support/bootstrap.js
+++ b/dapp-example/tests/support/bootstrap.js
@@ -112,6 +112,8 @@ const transferHTSToken = async function(accountId, tokenId) {
 };
 
 (async () => {
+  //wait for 10 sec, to be sure that local node is loaded, before trying to create accounts
+  await new Promise(r => setTimeout(r, 10000));
   let mainPrivateKeyString = process.env.PRIVATE_KEY;
   if (mainPrivateKeyString === '') {
     mainPrivateKeyString = HederaSDK.PrivateKey.generateECDSA().toStringRaw()

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     },
     "scripts": {
         "acceptancetest": "ts-mocha packages/server/tests/acceptance/index.spec.ts --exit",
+        "acceptancetest:api": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api' --exit",
+        "acceptancetest:erc20": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@erc20' --exit",
+        "acceptancetest:htsprecompile": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@htsprecompile' --exit",
         "acceptancetest:release": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@release' --exit",
         "build": "npx lerna run build",
         "build-and-test": "npx lerna run build && npx lerna run test",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "acceptancetest:api": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api' --exit",
         "acceptancetest:erc20": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@erc20' --exit",
         "acceptancetest:htsprecompile": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@htsprecompile' --exit",
+        "acceptancetest:htsprecompilev1": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@htsprecompilev1' --exit",
         "acceptancetest:release": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@release' --exit",
         "build": "npx lerna run build",
         "build-and-test": "npx lerna run build && npx lerna run test",

--- a/packages/server/tests/acceptance/erc20.spec.ts
+++ b/packages/server/tests/acceptance/erc20.spec.ts
@@ -31,7 +31,7 @@ import {Utils} from '../helpers/utils';
 import { EthImpl } from "@hashgraph/json-rpc-relay/src/lib/eth";
 
 
-describe('ERC20 Acceptance Tests', async function () {
+describe('@erc20 Acceptance Tests', async function () {
     this.timeout(240 * 1000); // 240 seconds
     const {servicesNode, relay} = global;
 

--- a/packages/server/tests/acceptance/htsPrecompile.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile.spec.ts
@@ -31,7 +31,7 @@ import ERC20MockJson from '../contracts/ERC20Mock.json';
 import BaseHTSJson from '../contracts/BaseHTS.json';
 
 
-describe('HTS Precompile Acceptance Tests', async function () {
+describe('@htsprecompile Acceptance Tests', async function () {
   this.timeout(240 * 1000); // 240 seconds
   const { servicesNode, mirrorNode, relay } = global;
 

--- a/packages/server/tests/acceptance/htsPrecompile.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile.spec.ts
@@ -675,7 +675,7 @@ describe('@htsprecompile Acceptance Tests', async function () {
       expect(updateExpiryInfoResponseCode).to.equal(TX_SUCCESS_CODE);
       expect(getExpiryInfoResponseCode).to.equal(TX_SUCCESS_CODE);
       expect(tokenExpiryInfoAfter.autoRenewPeriod).to.equal(expiryInfo.autoRenewPeriod);
-      expect(newRenewAccountEvmAddress).to.equal(expectedRenewAddress);
+      expect(newRenewAccountEvmAddress.toUpperCase()).to.equal(expectedRenewAddress);
 
       //use close to with delta 200 seconds, because we don't know the exact second it was set to expiry
       expect(tokenExpiryInfoAfter.second).to.be.closeTo(epoch, 200);

--- a/packages/server/tests/acceptance/htsPrecompile.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile.spec.ts
@@ -628,12 +628,12 @@ describe('@htsprecompile Acceptance Tests', async function () {
       const tokenExpiryInfoAfter = (await getTokenExpiryInfoTxAfter.wait()).events.filter(e => e.event === 'TokenExpiryInfo')[0].args.expiryInfo;
 
       const newRenewAccountEvmAddress = await mirrorNodeAddressReq(tokenExpiryInfoAfter.autoRenewAccount);
-      const expectedRenewAddress = `0x${BaseHTSContractAddress.substring(2).toUpperCase()}`;
+      const expectedRenewAddress = `0x${BaseHTSContractAddress.substring(2)}`;
 
       expect(updateExpiryInfoResponseCode).to.equal(TX_SUCCESS_CODE);
       expect(getExpiryInfoResponseCode).to.equal(TX_SUCCESS_CODE);
       expect(tokenExpiryInfoAfter.autoRenewPeriod).to.equal(expiryInfo.autoRenewPeriod);
-      expect(newRenewAccountEvmAddress).to.equal(expectedRenewAddress);
+      expect(newRenewAccountEvmAddress.toLowerCase()).to.equal(expectedRenewAddress.toLowerCase());
 
       //use close to with delta 200 seconds, because we don't know the exact second it was set to expiry
       expect(tokenExpiryInfoAfter.second).to.be.closeTo(epoch, 200);
@@ -670,12 +670,12 @@ describe('@htsprecompile Acceptance Tests', async function () {
       const tokenExpiryInfoAfter = (await getTokenExpiryInfoTxAfter.wait()).events.filter(e => e.event === 'TokenExpiryInfo')[0].args.expiryInfo;
 
       const newRenewAccountEvmAddress = await mirrorNodeAddressReq(tokenExpiryInfoAfter.autoRenewAccount);
-      const expectedRenewAddress = `0x${BaseHTSContractAddress.substring(2).toUpperCase()}`;
+      const expectedRenewAddress = `0x${BaseHTSContractAddress.substring(2)}`;
 
       expect(updateExpiryInfoResponseCode).to.equal(TX_SUCCESS_CODE);
       expect(getExpiryInfoResponseCode).to.equal(TX_SUCCESS_CODE);
       expect(tokenExpiryInfoAfter.autoRenewPeriod).to.equal(expiryInfo.autoRenewPeriod);
-      expect(newRenewAccountEvmAddress.toUpperCase()).to.equal(expectedRenewAddress);
+      expect(newRenewAccountEvmAddress.toLowerCase()).to.equal(expectedRenewAddress.toLowerCase());
 
       //use close to with delta 200 seconds, because we don't know the exact second it was set to expiry
       expect(tokenExpiryInfoAfter.second).to.be.closeTo(epoch, 200);

--- a/packages/server/tests/acceptance/htsPrecompile_v1.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile_v1.spec.ts
@@ -26,11 +26,10 @@ chai.use(solidity);
 
 import { AliasAccount } from '../clients/servicesClient';
 import { ethers } from 'ethers';
-import ERC20MockJson from '../contracts/contracts_v1/ERC20Mock.json';
 import BaseHTSJson from '../contracts/contracts_v1/BaseHTS.json';
 
 
-describe('HTS Precompile V1 Acceptance Tests', async function () {
+describe('@htsprecompilev1 HTS Precompile V1 Acceptance Tests', async function () {
   this.timeout(240 * 1000); // 240 seconds
   const { servicesNode, relay } = global;
 

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -33,7 +33,7 @@ import logsContractJson from '../contracts/Logs.json';
 import { predefined } from '../../../relay/src/lib/errors/JsonRpcError';
 import { EthImpl } from '@hashgraph/json-rpc-relay/src/lib/eth';
 
-describe('RPC Server Acceptance Tests', function () {
+describe('@api RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
 
     const accounts: AliasAccount[] = [];

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -31,7 +31,7 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
     // shell.exec(`sed -i '' 's/      STREAM_EXTENSION: "rcd"/      STREAM_EXTENSION: "rcd.gz"/' node_modules/@hashgraph/hedera-local/docker-compose.yml`);
     
     console.log('Start local node');
-    shell.exec(`hedera start --d`);
+    shell.exec(`hedera start -d`);
     console.log('Hedera Hashgraph local node env started');
   }
 

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -31,7 +31,7 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
     // shell.exec(`sed -i '' 's/      STREAM_EXTENSION: "rcd"/      STREAM_EXTENSION: "rcd.gz"/' node_modules/@hashgraph/hedera-local/docker-compose.yml`);
     
     console.log('Start local node');
-    shell.exec(`hedera start --h localhost --d`);
+    shell.exec(`hedera start --d`);
     console.log('Hedera Hashgraph local node env started');
   }
 

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -31,7 +31,7 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
     // shell.exec(`sed -i '' 's/      STREAM_EXTENSION: "rcd"/      STREAM_EXTENSION: "rcd.gz"/' node_modules/@hashgraph/hedera-local/docker-compose.yml`);
     
     console.log('Start local node');
-    shell.exec(`hedera start -d`);
+    shell.exec(`hedera start --h localhost --d`);
     console.log('Hedera Hashgraph local node env started');
   }
 


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
- Split acceptance tests into separate jobs
- Add a timeout to ensure local-node has started up first

**Related issue(s)**:

Fixes #514 
Fixes #520

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
