### PR TITLE
Helm testdrive cleanup

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: hedera-json-rpc-relay
 description: Helm chart deployment of the hashgraph/hedera-json-rpc-relay
 type: application
-version: 0.8.0-SNAPSHOT
-appVersion: "0.8.0-SNAPSHOT"
+version: 0.1.1
+appVersion: "0.7.0"
 home: https://github.com/hashgraph/hedera-json-rpc-relay

--- a/helm-chart/templates/configmap.yaml
+++ b/helm-chart/templates/configmap.yaml
@@ -13,7 +13,6 @@ data:
 {{- else }}
   HEDERA_NETWORK: {{ required "A valid HEDERA_NETWORK must be present in either .Values.config.local.HEDERA_NETWORK or .Values.config.hosted.HEDERA_NETWORK " (or .Values.config.local.HEDERA_NETWORK .Values.config.hosted.HEDERA_NETWORK) }}
 {{- end }}
-  CHAIN_ID: {{ .valu}} 
   MIRROR_NODE_URL: {{ .Values.config.MIRROR_NODE_URL  }}
   LOCAL_NODE: {{ .Values.config.LOCAL_NODE }}
   SERVER_PORT: {{ .Values.config.SERVER_PORT }}

--- a/helm-chart/templates/service.yaml
+++ b/helm-chart/templates/service.yaml
@@ -8,9 +8,12 @@ metadata:
   annotations:
 {{ toYaml .Values.service.annotations | nindent 4 }}
 {{- end }}
-{{- if .Values.service.annontations_JSON }}
+# This addes support for an NEG setup where the key is a string but the value is JSON
+{{- if .Values.service.annotations_NEG }}
   annotations:
-{{ .Values.service.annontations_JSON | toJson | nindent 4 }}
+{{- range  $key, $value := .Values.service.annotations_NEG }}
+    {{ $key }}: {{ toJson $value }}
+{{- end }}      
 {{- end }}  
 spec:
   type: {{ .Values.service.type }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -38,7 +38,7 @@ service:
   type: ClusterIP
   port: 7546
   annotations: {}
-  annotations_JSON: {}
+  annotations_NEG: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
**Description**:
Removed annotations JSON support in favor of annotation [NEG](https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing) support.  Removed an duplicate and incorrect CHAIN_ID config in the configmap.


**Notes for reviewer**:
Templated these changes using `helm template test ./helm-chart --debug`

```
---
# Source: hedera-json-rpc-relay/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: integration-json-rpc-relay
  labels:
    app:  integration-json-rpc-relay

    helm.sh/chart: hedera-json-rpc-relay-0.1.1
    app.kubernetes.io/name: integration-json-rpc-relay
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.7.0"
    app.kubernetes.io/managed-by: Helm
data:
  HEDERA_NETWORK: {XXX}
  MIRROR_NODE_URL: http://xx.xx.xx.xx
  LOCAL_NODE: false
  SERVER_PORT: 7546
  CHAIN_ID:

---
# Source: hedera-json-rpc-relay/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: json-rpc-relay
  labels:
    helm.sh/chart: hedera-json-rpc-relay-0.1.1
    app.kubernetes.io/name: son-rpc-relay
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "0.7.0"
    app.kubernetes.io/managed-by: Helm
# This addes support for an NEG setup where the key is a string but the value is JSON
  annotations:
    cloud.google.com/neg: "{\"exposed_ports\":{ \"7546\":{\"name\": \"json-rpc-relay\"}}}"
    cloud.google.com/neg:: "{\"ingress\": true}"
spec:
  type: ClusterIP
  ports:
    - port: 7546
      targetPort: jsonrpcrelay
      protocol: TCP
      name: jsonrpcrelay
  selector:
    app: json-rpc-relay
    app.kubernetes.io/name: json-rpc-relay
    app.kubernetes.io/instance: test
```
**Checklist**

- [x] Documented (Code comments, README, etc.)

