### PR TITLE
Bump services 0.30 and mirror 0.65.0-beta1

### DIFF
--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -125,9 +125,9 @@ describe('RPC Server Acceptance Tests', function () {
 
     function runLocalHederaNetwork() {
         // set env variables for docker images until local-node is updated
-        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.30.0-alpha.2';
-        process.env['HAVEGED_IMAGE_TAG'] = '0.30.0-alpha.2';
-        process.env['MIRROR_IMAGE_TAG'] = '0.64.0';
+        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.30.0';
+        process.env['HAVEGED_IMAGE_TAG'] = '0.30.0';
+        process.env['MIRROR_IMAGE_TAG'] = '0.65.0-beta1';
       
         console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
       

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -12,9 +12,9 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
 (function () {
   if (USE_LOCAL_NODE) {
     // set env variables for docker images until local-node is updated
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.30.0-alpha.2';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.30.0-alpha.2';
-    process.env['MIRROR_IMAGE_TAG'] = '0.64.0';
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.30.0';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.30.0';
+    process.env['MIRROR_IMAGE_TAG'] = '0.65.0-beta1';
   
     console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
   


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
Bump 
- services 0.3
- mirror 0.65.0-beta1

**Related issue(s)**:

Fixes #543 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
