### PR TITLE
return the evm address in the from field when calling getTransactionByHash

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -815,6 +815,15 @@ export class EthImpl implements Eth {
       return null;
     }
 
+    let fromAddress;
+    if(contractResult.from) {
+      fromAddress = contractResult.from.substring(0, 42);
+      const accountResult = await this.mirrorNodeClient.getAccount(fromAddress, requestId);
+      if(accountResult && accountResult.evm_address && accountResult.evm_address.length > 0) {
+        fromAddress = accountResult.evm_address.substring(0,42);
+      }
+    }
+
     const maxPriorityFee = contractResult.max_priority_fee_per_gas === EthImpl.emptyHex ? undefined : contractResult.max_priority_fee_per_gas;
     const maxFee = contractResult.max_fee_per_gas === EthImpl.emptyHex ? undefined : contractResult.max_fee_per_gas;
     const rSig = contractResult.r === null ? null : contractResult.r.substring(0, 66);
@@ -825,7 +834,7 @@ export class EthImpl implements Eth {
       blockHash: contractResult.block_hash.substring(0, 66),
       blockNumber: EthImpl.numberTo0x(contractResult.block_number),
       chainId: contractResult.chain_id,
-      from: contractResult.from.substring(0, 42),
+      from: fromAddress,
       gas: EthImpl.numberTo0x(contractResult.gas_used),
       gasPrice: EthImpl.toNullIfEmptyHex(contractResult.gas_price),
       hash: contractResult.hash.substring(0, 66),

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -175,6 +175,9 @@ export const defaultContractResults = {
     }
 };
 
+export const defaultEvmAddress = '0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69';
+export const defaultFromLongZeroAddress = '0x0000000000000000000000000000000000001f41';
+
 export const defaultLogTopics = [
     "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
     "0x0000000000000000000000000000000000000000000000000000000000000000",

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1678,6 +1678,8 @@ describe('Eth', async function () {
     ethImpl = new EthImpl(null, mirrorNodeInstance, logger);
   });
 
+  const defaultFromLongZeroAddress = '0x0000000000000000000000000000000000001f41';
+  const defaultEvmAddress = '0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69';
   const defaultTxHash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392';
   const defaultTransaction = {
     "accessList": undefined,
@@ -1939,6 +1941,10 @@ describe('Eth', async function () {
     it('returns correct transaction for existing hash', async function () {
       // mirror node request mocks
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, defaultDetailedContractResultByHash);
+      mock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
+        from: `${defaultEvmAddress}`
+      });
+
       const result = await ethImpl.getTransactionByHash(defaultTxHash);
 
       expect(result).to.exist;
@@ -1974,6 +1980,9 @@ describe('Eth', async function () {
       };
 
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, detailedResultsWithNullNullableValues);
+      mock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
+        from: `${defaultEvmAddress}`
+      });
       const result = await ethImpl.getTransactionByHash(defaultTxHash);
       if (result == null) return;
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -30,7 +30,11 @@ dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 import {RelayImpl, predefined, MirrorNodeClientError} from '@hashgraph/json-rpc-relay';
 import { EthImpl } from '../../src/lib/eth';
 import { MirrorNodeClient } from '../../src/lib/clients/mirrorNodeClient';
-import { expectUnsupportedMethod } from '../helpers';
+import { 
+  defaultEvmAddress,
+  defaultFromLongZeroAddress,
+  expectUnsupportedMethod,
+ } from '../helpers';
 
 import pino from 'pino';
 import { Block, Transaction } from '../../src/lib/model';
@@ -1678,15 +1682,13 @@ describe('Eth', async function () {
     ethImpl = new EthImpl(null, mirrorNodeInstance, logger);
   });
 
-  const defaultFromLongZeroAddress = '0x0000000000000000000000000000000000001f41';
-  const defaultEvmAddress = '0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69';
   const defaultTxHash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392';
   const defaultTransaction = {
     "accessList": undefined,
     "blockHash": "0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042",
     "blockNumber": "0x11",
     "chainId": "0x12a",
-    "from": "0x0000000000000000000000000000000000001f41",
+    "from": `${defaultEvmAddress}`,
     "gas": "0x7b",
     "gasPrice": "0x4a817c80",
     "hash": defaultTxHash,
@@ -1942,7 +1944,7 @@ describe('Eth', async function () {
       // mirror node request mocks
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, defaultDetailedContractResultByHash);
       mock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
-        from: `${defaultEvmAddress}`
+        evm_address: `${defaultTransaction.from}`
       });
 
       const result = await ethImpl.getTransactionByHash(defaultTxHash);
@@ -1981,7 +1983,7 @@ describe('Eth', async function () {
 
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, detailedResultsWithNullNullableValues);
       mock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
-        from: `${defaultEvmAddress}`
+        evm_address: `${defaultTransaction.from}`
       });
       const result = await ethImpl.getTransactionByHash(defaultTxHash);
       if (result == null) return;

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -55,6 +55,8 @@ import {
     defaultDetailedContractResults,
     defaultDetailedContractResults2,
     defaultDetailedContractResults3,
+    defaultEvmAddress,
+    defaultFromLongZeroAddress,
     defaultLogs,
     defaultLogTopics,
     defaultNetworkFees,
@@ -127,7 +129,10 @@ describe("Open RPC Specification", function () {
         mock.onGet(`accounts/${contractAddress1}`).reply(200, { account: contractAddress1 });
         mock.onGet(`accounts/${contractAddress3}`).reply(200, { account: contractAddress3 });
         mock.onGet(`accounts/0xbC989b7b17d18702663F44A6004cB538b9DfcBAc`).reply(200, { account: '0xbC989b7b17d18702663F44A6004cB538b9DfcBAc' });
-
+        mock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
+            from: `${defaultEvmAddress}`
+          });
+    
         sdkClientStub.getAccountBalanceInWeiBar.returns(1000);
         sdkClientStub.getAccountBalanceInTinyBar.returns(100000000000)
         sdkClientStub.getContractByteCode.returns(Buffer.from(bytecode.replace('0x', ''), 'hex'));

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -801,6 +801,9 @@ describe('@api RPC Server Acceptance Tests', function () {
                     const mirrorTransaction = await mirrorNode.get(`/contracts/results/${transactionHash}`);
 
                     const res = await relay.call('eth_getTransactionByHash', [transactionHash]);
+                    const addressResult = await mirrorNode.get(`/accounts/${res.from}`);
+                    mirrorTransaction.from = addressResult.evm_address;
+
                     Assertions.transaction(res, mirrorTransaction);
                 });
 


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:
Currently we are returning the long-zero address in the from field.  We need to return the evm address for the account if one exists.

**Related issue(s)**:

Fixes #505 

- [x] Tested (unit, integration, etc.)
