### PR TITLE
Add workaround to ensure contractcallquery is sufficient

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -44,6 +44,7 @@ import {
     FileInfoQuery,
     EthereumTransaction,
     EthereumTransactionData,
+    Hbar,
 } from '@hashgraph/sdk';
 import { BigNumber } from '@hashgraph/sdk/lib/Transfer';
 import { Logger } from "pino";
@@ -241,8 +242,10 @@ export class SDKClient {
 
         const cost = await contractCallQuery
             .getCost(this.clientMain);
+        const updatedCost = cost._valueInTinybar.multipliedBy(1.001).integerValue();
+        this.logger.trace(`${requestId} ${callerName} cost estimate: ${cost}, will use updatedCost: ${updatedCost}`);
         return this.executeQuery(contractCallQuery
-            .setQueryPayment(cost), this.clientMain, callerName, requestId);
+            .setQueryPayment(Hbar.from(updatedCost, HbarUnit.Tinybar)), this.clientMain, callerName, requestId);
     }
 
     private convertGasPriceToTinyBars = (feeComponents: FeeComponents | undefined, exchangeRates: ExchangeRates) => {


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
`contractCallQuery.getCost()` seems to not be sufficient to cover the cost of the contract call query being made.
To workaround this while the issue is addressed add a factor of 1.001 which has been shown to be a sufficient bump

**Related issue(s)**:

Fixes #564 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
