### PR TITLE
Add TransactionRecordQuery calls to capture failed transaction costs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4055,9 +4055,9 @@
             }
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.6.12",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.12.tgz",
-            "integrity": "sha512-JmvQ03OTSpVd9JTlj/K3IWHSz4Gk/JMLUTtW7Zb0KvO1LcOYGATh5cNuRYzCAeDR3O8wq+q8FZe97eO9MBrkUw==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.1.tgz",
+            "integrity": "sha512-GVtMU4oh/TeKkWGzXUEsyZtyvSUIT1z49RtGH1UnEGeL+sLuxKl8QH3KZTlSB329R1sWJmesm5hQ5CxXdYH9dg==",
             "dependencies": {
                 "@grpc/proto-loader": "^0.7.0",
                 "@types/node": ">=12.12.47"
@@ -4274,16 +4274,16 @@
             }
         },
         "node_modules/@hashgraph/sdk": {
-            "version": "2.18.1",
-            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.18.1.tgz",
-            "integrity": "sha512-9eZ8jLT+fVa9hxGxL+2N5QHbLtTS8Dj3Ed+ls6gu7BHlvBOj1nKKw4v90J3oLDc6aD2tqTX5+NnOfN0F13LkEw==",
+            "version": "2.18.3",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.18.3.tgz",
+            "integrity": "sha512-sWJXo8DPT0PFk1ENpy42bYyuKxk9lPFq4V/2EFUqvMgmaQ6nlVxTUxIY87gDC5doNs4cNJXzGiNyv3Z30U0Vng==",
             "dependencies": {
-                "@ethersproject/rlp": "^5.6.1",
-                "@grpc/grpc-js": "^1.6.7",
+                "@ethersproject/rlp": "^5.7.0",
+                "@grpc/grpc-js": "^1.7.0",
                 "@hashgraph/cryptography": "^1.4.1",
-                "@hashgraph/proto": "2.9.0",
+                "@hashgraph/proto": "2.10.0",
                 "axios": "^0.27.2",
-                "bignumber.js": "^9.0.2",
+                "bignumber.js": "^9.1.0",
                 "crypto-js": "^4.1.1",
                 "js-base64": "^3.7.2",
                 "js-logger": "^1.6.1",
@@ -4301,6 +4301,18 @@
                 "expo": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@hashgraph/sdk/node_modules/@hashgraph/proto": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.10.0.tgz",
+            "integrity": "sha512-QladbhCa3SSjFeJV8mO0J/2oEJ7Vkj44jvG5pM4ltTcp8fSXneUHSKJ/cEYKLCyWr7pj0TyVLoJ1RF8uA5kIqg==",
+            "dependencies": {
+                "long": "^4.0.0",
+                "protobufjs": "^6.11.3"
+            },
+            "engines": {
+                "node": ">=10.0.0"
             }
         },
         "node_modules/@hethers/abstract-provider": {
@@ -30609,7 +30621,7 @@
             "name": "@hashgraph/json-rpc-relay",
             "version": "0.10.0-SNAPSHOT",
             "dependencies": {
-                "@hashgraph/sdk": "^2.18.0",
+                "@hashgraph/sdk": "^2.18.3",
                 "@keyvhq/core": "^1.6.9",
                 "axios": "^0.26.1",
                 "axios-retry": "^3.2.5",
@@ -30667,7 +30679,7 @@
             },
             "devDependencies": {
                 "@hashgraph/hedera-local": "^1.1.0",
-                "@hashgraph/sdk": "^2.18.0",
+                "@hashgraph/sdk": "^2.18.3",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
                 "@types/cors": "^2.8.12",
@@ -33620,9 +33632,9 @@
             "requires": {}
         },
         "@grpc/grpc-js": {
-            "version": "1.6.12",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.12.tgz",
-            "integrity": "sha512-JmvQ03OTSpVd9JTlj/K3IWHSz4Gk/JMLUTtW7Zb0KvO1LcOYGATh5cNuRYzCAeDR3O8wq+q8FZe97eO9MBrkUw==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.1.tgz",
+            "integrity": "sha512-GVtMU4oh/TeKkWGzXUEsyZtyvSUIT1z49RtGH1UnEGeL+sLuxKl8QH3KZTlSB329R1sWJmesm5hQ5CxXdYH9dg==",
             "requires": {
                 "@grpc/proto-loader": "^0.7.0",
                 "@types/node": ">=12.12.47"
@@ -33777,7 +33789,7 @@
         "@hashgraph/json-rpc-relay": {
             "version": "file:packages/relay",
             "requires": {
-                "@hashgraph/sdk": "^2.18.0",
+                "@hashgraph/sdk": "^2.18.3",
                 "@keyvhq/core": "^1.6.9",
                 "@types/chai": "^4.3.0",
                 "@types/mocha": "^9.1.0",
@@ -33820,7 +33832,7 @@
             "requires": {
                 "@hashgraph/hedera-local": "^1.1.0",
                 "@hashgraph/json-rpc-relay": "file:../relay",
-                "@hashgraph/sdk": "^2.18.0",
+                "@hashgraph/sdk": "^2.18.3",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
                 "@types/cors": "^2.8.12",
@@ -33898,22 +33910,33 @@
             }
         },
         "@hashgraph/sdk": {
-            "version": "2.18.1",
-            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.18.1.tgz",
-            "integrity": "sha512-9eZ8jLT+fVa9hxGxL+2N5QHbLtTS8Dj3Ed+ls6gu7BHlvBOj1nKKw4v90J3oLDc6aD2tqTX5+NnOfN0F13LkEw==",
+            "version": "2.18.3",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.18.3.tgz",
+            "integrity": "sha512-sWJXo8DPT0PFk1ENpy42bYyuKxk9lPFq4V/2EFUqvMgmaQ6nlVxTUxIY87gDC5doNs4cNJXzGiNyv3Z30U0Vng==",
             "requires": {
-                "@ethersproject/rlp": "^5.6.1",
-                "@grpc/grpc-js": "^1.6.7",
+                "@ethersproject/rlp": "^5.7.0",
+                "@grpc/grpc-js": "^1.7.0",
                 "@hashgraph/cryptography": "^1.4.1",
-                "@hashgraph/proto": "2.9.0",
+                "@hashgraph/proto": "2.10.0",
                 "axios": "^0.27.2",
-                "bignumber.js": "^9.0.2",
+                "bignumber.js": "^9.1.0",
                 "crypto-js": "^4.1.1",
                 "js-base64": "^3.7.2",
                 "js-logger": "^1.6.1",
                 "long": "^4.0.0",
                 "protobufjs": "^6.11.3",
                 "utf8": "^3.0.0"
+            },
+            "dependencies": {
+                "@hashgraph/proto": {
+                    "version": "2.10.0",
+                    "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.10.0.tgz",
+                    "integrity": "sha512-QladbhCa3SSjFeJV8mO0J/2oEJ7Vkj44jvG5pM4ltTcp8fSXneUHSKJ/cEYKLCyWr7pj0TyVLoJ1RF8uA5kIqg==",
+                    "requires": {
+                        "long": "^4.0.0",
+                        "protobufjs": "^6.11.3"
+                    }
+                }
             }
         },
         "@hethers/abstract-provider": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -27,7 +27,7 @@
         "test": "nyc ts-mocha --recursive ./tests/**/*.spec.ts --exit"
     },
     "dependencies": {
-        "@hashgraph/sdk": "^2.18.0",
+        "@hashgraph/sdk": "^2.18.3",
         "@keyvhq/core": "^1.6.9",
         "axios": "^0.26.1",
         "buffer": "^6.0.3",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@hashgraph/hedera-local": "^1.1.0",
-        "@hashgraph/sdk": "^2.18.0",
+        "@hashgraph/sdk": "^2.18.3",
         "@koa/cors": "^3.1.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
Add TransactionRecordQuery calls to capture fail transaction costs

- update `executeTransaction` catch with `TransactionRecordQuery` logic
- update `executeGetTransactionRecord` catch with `TransactionRecordQuery` logic

**Related issue(s)**:

Fixes #592 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
