### PR TITLE
Handle empty hex bloom in eth_getTransactionReceipt

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -746,7 +746,7 @@ export class EthImpl implements Eth {
           return EthImpl.numberTo0x(Number(accountInfo.ethereumNonce));
       }
       else if (result?.type === constants.TYPE_CONTRACT) {
-        return EthImpl.numberTo0x(1)
+        return EthImpl.numberTo0x(1);
       }
 
       return EthImpl.zeroHex;
@@ -964,14 +964,13 @@ export class EthImpl implements Eth {
         gasUsed: EthImpl.numberTo0x(receiptResponse.gas_used),
         contractAddress: createdContract,
         logs: logs,
-        logsBloom: receiptResponse.bloom,
+        logsBloom: receiptResponse.bloom === EthImpl.emptyHex ? EthImpl.emptyBloom : receiptResponse.bloom,
         transactionHash: EthImpl.toHash32(receiptResponse.hash),
         transactionIndex: EthImpl.numberTo0x(receiptResponse.transaction_index),
         effectiveGasPrice: EthImpl.nanOrNumberTo0x(Number.parseInt(effectiveGas) * 10_000_000_000),
         root: receiptResponse.root,
         status: receiptResponse.status,
       };
-
 
       this.logger.trace(`${requestIdPrefix} receipt for ${hash} found in block ${receipt.blockNumber}`);
       return receipt;

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2115,6 +2115,19 @@ describe('Eth', async function () {
 
       expect(receipt.effectiveGasPrice).to.eq('0x0');
     });
+
+    it('handles empty bloom', async function () {
+      const receiptWith0xBloom = {
+        ...defaultDetailedContractResultByHash,
+        bloom: '0x'
+      };
+      mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, receiptWith0xBloom);
+      const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
+
+      expect(receipt).to.exist;
+      if (receipt == null) return;
+      expect(receipt.logsBloom).to.eq(EthImpl.emptyBloom);
+    });
   });
 
   describe('eth_getTransactionByHash', async function () {


### PR DESCRIPTION
Signed-off-by: Maksim Dimitrov <dimitrov.maksim@gmail.com>

**Description**:

Return `EthImpl.emptyBloom` if `receiptResponse.bloom == EthImpl.emptyHex` when returning `eth_getTransactionReceipt` response

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/599

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
