### PR TITLE
Fix undefined error when transferring with Metamask Mobile Wallet

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -988,7 +988,7 @@ export class EthImpl implements Eth {
   }
 
   static numberTo0x(input: number | BigNumber): string {
-    return EthImpl.emptyHex + input.toString(16);
+    return input ? EthImpl.emptyHex + input.toString(16) : EthImpl.emptyHex;
   }
 
   static nullableNumberTo0x(input: number | BigNumber): string | null {


### PR DESCRIPTION
Signed-off-by: georgi-l95 <glazarov95@gmail.com>

**Description**:
Fixes issue when trying to return string representation of `input` in `numberTo0x` method, but it's undefined. In this case returns only empty hex, fixes this. Can be experienced on some occasions, when trying to transfer HBAR with metamask mobile wallet.

**Related issue(s)**:

Fixes #602 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
