### PR TITLE
Bump local node acceptance test images for 0.31.A

### DIFF
--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -124,6 +124,13 @@ describe('RPC Server Acceptance Tests', function () {
     }
 
     function runLocalHederaNetwork() {
+        // set env variables for docker images until local-node is updated
+        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.31.0-alpha.3';
+        process.env['HAVEGED_IMAGE_TAG'] = '0.31.0-alpha.3';
+        process.env['MIRROR_IMAGE_TAG'] = '0.66.1';
+    
+        console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
+        
         console.log('Installing local node...');
         shell.exec(`npm install @hashgraph/hedera-local -g`);
       

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -10,14 +10,7 @@ const LOCAL_RELAY_URL = 'http://localhost:7546';
 const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
 
 (function () {
-  if (USE_LOCAL_NODE) {
-    // set env variables for docker images until local-node is updated
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.31.0-alpha.3';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.31.0-alpha.3';
-    process.env['MIRROR_IMAGE_TAG'] = '0.66.1';
-
-    console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
-    
+  if (USE_LOCAL_NODE) {    
     console.log('Installing local node...');
     shell.exec(`npm install @hashgraph/hedera-local -g`);
   

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -11,6 +11,13 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
 
 (function () {
   if (USE_LOCAL_NODE) {
+    // set env variables for docker images until local-node is updated
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.31.0-alpha.3';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.31.0-alpha.3';
+    process.env['MIRROR_IMAGE_TAG'] = '0.66.1';
+
+    console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
+    
     console.log('Installing local node...');
     shell.exec(`npm install @hashgraph/hedera-local -g`);
   


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
Bump local node images for acceptance tests 0.31.A
- `NETWORK_NODE_IMAGE_TAG` & `HAVEGED_IMAGE_TAG` to `0.31.0-alpha.3`
- `MIRROR_IMAGE_TAG`  to `0.66.1`

**Related issue(s)**:

Fixes #618 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
