### PR TITLE
Better error handling

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -74,13 +74,13 @@ export interface Eth {
 
   getStorageAt(address: string, slot: string, blockNumber: string|null, requestId?: string): Promise<string>;
 
-  getTransactionByBlockHashAndIndex(hash: string, index: number, requestId?: string): Promise<Transaction | null>;
+  getTransactionByBlockHashAndIndex(hash: string, index: string, requestId?: string): Promise<Transaction | null>;
 
-  getTransactionByBlockNumberAndIndex(blockNum: string, index: number, requestId?: string): Promise<Transaction | null>;
+  getTransactionByBlockNumberAndIndex(blockNum: string, index: string, requestId?: string): Promise<Transaction | null>;
 
   getTransactionByHash(hash: string, requestId?: string): Promise<Transaction | null>;
 
-  getTransactionCount(address: string, blocknum: string, requestId?: string): Promise<string | JsonRpcError>;
+  getTransactionCount(address: string, blockNum: string, requestId?: string): Promise<string | JsonRpcError>;
 
   getTransactionReceipt(hash: string, requestId?: string): Promise<Receipt | null>;
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -155,7 +155,7 @@ export class MirrorNodeClient {
             return response.data;
         } catch (error: any) {
             ms = Date.now() - start;
-            const effectiveStatusCode = error.response !== undefined ? error.response.status : MirrorNodeClient.unknownServerErrorHttpStatusCode;
+            const effectiveStatusCode = error.response?.status || MirrorNodeClientError.ErrorCodes[error.code] || MirrorNodeClient.unknownServerErrorHttpStatusCode;
             this.mirrorResponseHistogram.labels(pathLabel, effectiveStatusCode).observe(ms);
             this.handleError(error, path, effectiveStatusCode, allowedErrorStatuses, requestId);
         }
@@ -240,7 +240,7 @@ export class MirrorNodeClient {
         const queryParams = this.getQueryParams(queryParamObject);
         return this.request(`${MirrorNodeClient.GET_CONTRACT_RESULTS_ENDPOINT}${queryParams}`,
             MirrorNodeClient.GET_CONTRACT_RESULTS_ENDPOINT,
-            [400],
+            [400, 404],
             requestId);
     }
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -203,7 +203,7 @@ export class MirrorNodeClient {
     public async getBlock(hashOrBlockNumber: string | number, requestId?: string) {
         return this.request(`${MirrorNodeClient.GET_BLOCK_ENDPOINT}${hashOrBlockNumber}`,
             MirrorNodeClient.GET_BLOCK_ENDPOINT,
-            [400],
+            [400, 404],
             requestId);
     }
 
@@ -247,7 +247,7 @@ export class MirrorNodeClient {
     public async getContractResultsDetails(contractId: string, timestamp: string, requestId?: string) {
         return this.request(`${this.getContractResultsDetailsByContractIdAndTimestamp(contractId, timestamp)}`,
             MirrorNodeClient.GET_CONTRACT_RESULTS_DETAILS_BY_CONTRACT_ID_ENDPOINT,
-            [400],
+            [400, 404],
             requestId);
     }
 

--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -55,10 +55,10 @@ export const predefined = {
     code: -32602,
     message: 'Invalid params'
   }),
-  'INTERNAL_ERROR': new JsonRpcError({
+  'INTERNAL_ERROR': (message: string = '') => new JsonRpcError({
     name: 'Internal error',
     code: -32603,
-    message: 'Unknown error invoking RPC'
+    message: message === '' ? `Error invoking RPC: ${message}` : 'Unknown error invoking RPC'
   }),
   'PARSE_ERROR': new JsonRpcError({
     name: 'Parse error',

--- a/packages/relay/src/lib/errors/MirrorNodeClientError.ts
+++ b/packages/relay/src/lib/errors/MirrorNodeClientError.ts
@@ -22,24 +22,26 @@
 export class MirrorNodeClientError extends Error {
     public statusCode: number;
 
-    static statusCodes = {
-        TIMEOUT: 567,
-        NOT_FOUND: 404
+    static ErrorCodes = {
+      ECONNABORTED: 504
     };
-  
+
+    static statusCodes = {
+      NOT_FOUND: 404
+    };
+
     constructor(message: string, statusCode: number) {
       super(message);
       this.statusCode = statusCode;
-  
+
       Object.setPrototypeOf(this, MirrorNodeClientError.prototype);
     }
 
     public isTimeout(): boolean {
-        return this.statusCode === MirrorNodeClientError.statusCodes.TIMEOUT;
+      return this.statusCode === MirrorNodeClientError.ErrorCodes.ECONNABORTED;
     }
 
     public isNotFound(): boolean {
-        return this.statusCode === MirrorNodeClientError.statusCodes.NOT_FOUND;
+      return this.statusCode === MirrorNodeClientError.statusCodes.NOT_FOUND;
     }
   }
-  

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -479,17 +479,14 @@ export class EthImpl implements Eth {
       await this.mirrorNodeClient.getContractResultsDetails(address, contractResult.results[0].timestamp)
         .then(contractResultDetails => {
           if(contractResultDetails?.state_changes != null) {
-            // loop through the state changes to match slot and return value
-            for (const stateChange of contractResultDetails.state_changes) {
-              if(stateChange.slot === slot) {
-                result = stateChange.value_written;
-              }
-            }
+            // filter the state changes to match slot and return value
+            const stateChange = contractResultDetails.state_changes.find(stateChange => stateChange.slot === slot);
+            result = stateChange.value_written;
           } else {
             throw predefined.RESOURCE_NOT_FOUND(`Contract result details for contract address ${address} at timestamp=${contractResult.results[0].timestamp}`);
           }
         })
-        .catch( (e: any) => {
+        .catch((e: any) => {
           this.logger.error(
             e,
             `${requestIdPrefix} Failed to retrieve contract result details for contract address ${address} at timestamp=${contractResult.results[0].timestamp}`,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -582,7 +582,7 @@ export class EthImpl implements Eth {
    */
   async getCode(address: string, blockNumber: string | null, requestId?: string) {
     const requestIdPrefix = formatRequestIdMessage(requestId);
-    
+
     // check for static precompile cases first before consulting nodes
     // this also account for environments where system entitites were not yet exposed to the mirror node
     if (address === EthImpl.iHTSAddress) {
@@ -611,7 +611,7 @@ export class EthImpl implements Eth {
           }
         }
       }
-      
+
       const bytecode = await this.sdkClient.getContractByteCode(0, 0, address, EthImpl.ethGetCode, requestId);
       return EthImpl.prepend0x(Buffer.from(bytecode).toString('hex'));
     } catch (e: any) {
@@ -700,11 +700,11 @@ export class EthImpl implements Eth {
    * @param blockHash
    * @param transactionIndex
    */
-  async getTransactionByBlockHashAndIndex(blockHash: string, transactionIndex: number, requestId?: string): Promise<Transaction | null> {
+  async getTransactionByBlockHashAndIndex(blockHash: string, transactionIndex: string, requestId?: string): Promise<Transaction | null> {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     this.logger.trace(`${requestIdPrefix} getTransactionByBlockHashAndIndex(hash=${blockHash}, index=${transactionIndex})`);
     return this.mirrorNodeClient
-      .getContractResults({ blockHash: blockHash, transactionIndex: transactionIndex },undefined, requestId)
+      .getContractResults({ blockHash: blockHash, transactionIndex: Number(transactionIndex) }, undefined, requestId)
       .then((contractResults) => this.getTransactionFromContractResults(contractResults, requestId))
       .catch((e: any) => {
         this.logger.error(
@@ -723,14 +723,14 @@ export class EthImpl implements Eth {
    */
   async getTransactionByBlockNumberAndIndex(
     blockNumOrTag: string,
-    transactionIndex: number,
+    transactionIndex: string,
     requestId?: string
   ): Promise<Transaction | null> {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     this.logger.trace(`${requestIdPrefix} getTransactionByBlockNumberAndIndex(blockNum=${blockNumOrTag}, index=${transactionIndex})`);
     const blockNum = await this.translateBlockTag(blockNumOrTag, requestId);
     return this.mirrorNodeClient
-      .getContractResults({ blockNumber: blockNum, transactionIndex: transactionIndex },undefined, requestId)
+      .getContractResults({ blockNumber: blockNum, transactionIndex: Number(transactionIndex) }, undefined, requestId)
       .then((contractResults) => this.getTransactionFromContractResults(contractResults, requestId))
       .catch((e: any) => {
         this.logger.error(

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -641,7 +641,7 @@ export class EthImpl implements Eth {
     this.logger.trace(`${requestIdPrefix} getBlockByHash(hash=${hash}, showDetails=${showDetails})`);
     return this.getBlock(hash, showDetails, requestId).catch((e: any) => {
       this.logger.error(e, `${requestIdPrefix} Failed to retrieve block for hash ${hash}`);
-      throw predefined.INTERNAL_ERROR(e.message);
+      throw predefined.INTERNAL_ERROR();
     });
   }
 
@@ -655,7 +655,7 @@ export class EthImpl implements Eth {
     this.logger.trace(`${requestIdPrefix} getBlockByNumber(blockNum=${blockNumOrTag}, showDetails=${showDetails})`);
     return this.getBlock(blockNumOrTag, showDetails, requestId).catch((e: any) => {
       this.logger.error(e, `${requestIdPrefix} Failed to retrieve block for blockNum ${blockNumOrTag}`);
-      throw predefined.INTERNAL_ERROR(e.message);
+      throw predefined.INTERNAL_ERROR();
     });
   }
 
@@ -672,7 +672,7 @@ export class EthImpl implements Eth {
       .then((block) => EthImpl.getTransactionCountFromBlockResponse(block))
       .catch((e: any) => {
         this.logger.error(e, `${requestIdPrefix} Failed to retrieve block for hash ${hash}`);
-        throw predefined.INTERNAL_ERROR(e.message);
+        throw predefined.INTERNAL_ERROR();
       });
   }
 
@@ -689,7 +689,7 @@ export class EthImpl implements Eth {
       .then((block) => EthImpl.getTransactionCountFromBlockResponse(block))
       .catch((e: any) => {
         this.logger.error(e, `${requestIdPrefix} Failed to retrieve block for blockNum ${blockNum}`, blockNum);
-        throw predefined.INTERNAL_ERROR(e.message);
+        throw predefined.INTERNAL_ERROR();
       });
   }
 
@@ -715,7 +715,7 @@ export class EthImpl implements Eth {
           `${requestIdPrefix} Failed to retrieve contract result for blockHash ${blockHash} and index=${transactionIndex}`
         );
 
-        throw predefined.INTERNAL_ERROR(e.message);
+        throw predefined.INTERNAL_ERROR();
       });
   }
 
@@ -746,7 +746,7 @@ export class EthImpl implements Eth {
           `${requestIdPrefix} Failed to retrieve contract result for blockNum ${blockNum} and index=${transactionIndex}`
         );
 
-        throw predefined.INTERNAL_ERROR(e.message);
+        throw predefined.INTERNAL_ERROR();
       });
   }
 
@@ -1240,7 +1240,7 @@ export class EthImpl implements Eth {
           `${requestIdPrefix} Failed to retrieve contract result details for contract address ${to} at timestamp=${timestamp}`
         );
 
-        throw predefined.INTERNAL_ERROR(e.message);
+        throw predefined.INTERNAL_ERROR();
       });
   }
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -478,7 +478,7 @@ export class EthImpl implements Eth {
       // retrieve the contract result details
       await this.mirrorNodeClient.getContractResultsDetails(address, contractResult.results[0].timestamp)
         .then(contractResultDetails => {
-          if(contractResultDetails && contractResultDetails.state_changes) {
+          if(contractResultDetails?.state_changes != null) {
             // loop through the state changes to match slot and return value
             for (const stateChange of contractResultDetails.state_changes) {
               if(stateChange.slot === slot) {
@@ -1098,7 +1098,7 @@ export class EthImpl implements Eth {
   private async getBlock(blockHashOrNumber: string, showDetails: boolean, requestId?: string ): Promise<Block | null> {
     const blockResponse = await this.getHistoricalBlockResponse(blockHashOrNumber, true);
 
-    if(blockResponse == null) return blockResponse;
+    if(blockResponse == null) return null;
 
     const timestampRange = blockResponse.timestamp;
     const timestampRangeParams = [`gte:${timestampRange.from}`, `lte:${timestampRange.to}`];
@@ -1106,7 +1106,7 @@ export class EthImpl implements Eth {
     const maxGasLimit = constants.BLOCK_GAS_LIMIT;
     const gasUsed = blockResponse.gas_used;
 
-    if (contractResults === null || contractResults.results === undefined) {
+    if (contractResults?.results == null) {
       // contract result not found
       return null;
     }
@@ -1121,11 +1121,7 @@ export class EthImpl implements Eth {
       if (!_.isNil(result.to)) {
         const transaction = await this.getTransactionFromContractResult(result.to, result.timestamp, requestId);
         if (transaction !== null) {
-          if (showDetails) {
-            transactionObjects.push(transaction);
-          } else {
-            transactionHashes.push(transaction.hash);
-          }
+          showDetails ? transactionObjects.push(transaction) : transactionHashes.push(transaction.hash);
         }
       }
     }

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -145,7 +145,7 @@ export class Precheck {
       result.passes = ethers.ethers.BigNumber.from(tinybars.toString()).mul(constants.TINYBAR_TO_WEIBAR_COEF).gte(txTotalValue);
     } catch (error: any) {
       this.logger.trace(`${requestIdPrefix} Error on balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, error=%s)`, JSON.stringify(tx), txTotalValue, error.message);
-      throw predefined.INTERNAL_ERROR;
+      throw predefined.INTERNAL_ERROR();
     }
 
     if (!result.passes) {

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -297,13 +297,13 @@ describe("Open RPC Specification", function () {
     });
 
     it('should execute "eth_getTransactionByBlockHashAndIndex"', async function () {
-        const response = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, defaultBlock.count);
+        const response = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count));
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionByBlockHashAndIndex, response);
     });
 
     it('should execute "eth_getTransactionByBlockNumberAndIndex"', async function () {
-        const response = await ethImpl.getTransactionByBlockNumberAndIndex(defaultBlock.number.toString(), defaultBlock.count);
+        const response = await ethImpl.getTransactionByBlockNumberAndIndex(EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count));
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionByBlockNumberAndIndex, response);
     });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -151,14 +151,14 @@ const logAndHandleResponse = async (methodName, methodFunction) => {
         message: response.message,
         data: response.data
       }, requestId);
-    } 
+    }
     return response;
   } catch (e: any) {
     ms = Date.now() - start;
     methodResponseHistogram.labels(methodName, responseInternalErrorCode).observe(ms);
     logger.error(e, `${messagePrefix} ${responseInternalErrorCode} ${ms} ms`);
 
-    let error = predefined.INTERNAL_ERROR;
+    let error = predefined.INTERNAL_ERROR();
     if (e instanceof MirrorNodeClientError) {
       if (e.isTimeout()) {
         error = predefined.REQUEST_TIMEOUT;

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -49,7 +49,7 @@ export default class RelayClient {
      * @param methodName
      * @param params
      */
-    async callFailing(methodName: string, params: any[], expectedRpcError = predefined.INTERNAL_ERROR) {
+    async callFailing(methodName: string, params: any[], expectedRpcError = predefined.INTERNAL_ERROR()) {
         try {
             const res = await this.call(methodName, params);
             this.logger.trace(`[POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`);

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -181,7 +181,7 @@ export default class Assertions {
         expect(res.oldestBlock).to.exist;
         expect(res.baseFeePerGas.length).to.equal(expected.resultCount + 1);
         expect(res.gasUsedRatio.length).to.equal(expected.resultCount);
-        
+
         expect(res.oldestBlock).to.equal(expected.oldestBlock);
 
         res.gasUsedRatio.map((gasRatio: string) => expect(gasRatio).to.equal(`0x${Assertions.defaultGasUsed.toString(16)}`))
@@ -193,7 +193,7 @@ export default class Assertions {
     }
 
     static unknownResponse(err) {
-        Assertions.jsonRpcError(err, predefined.INTERNAL_ERROR);
+        Assertions.jsonRpcError(err, predefined.INTERNAL_ERROR());
     }
 
     static jsonRpcError(err: any, expectedError: JsonRpcError) {


### PR DESCRIPTION
**Description**:

1. Better handle timeout errors - Currently any error that does not have a `response` property is handled as `unknownServerErrorHttpStatusCode` (567), but `axios` provides `error.code` that indicate (I'm assuming server side errors) for example `ECONNABORTED` for timeouts. Handling those errors as `unknownServerErrorHttpStatusCode` would sometimes result in test passing for the wrong reason, because other errors, like `no mock for ... detected` would also fail with status code `567`. Also update the tests to check the error message.
2. There were couple of cases when `404 not found` responses were not handled correctly and resulted in the code breaking because it was trying to access properties of `null` values. For example here https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/packages/relay/src/lib/eth.ts#L1190 because 404 is an acceptable status code, the value of contractResultDetails can be null and the code would break when trying to access the `r` property. Although this error is caught, it seems it was more of a coincidence.
3. Updates tests, removes obsolete mocks, adds missing mocks
4. Refactor the error handling to throw errors only for unexpected behaviours or when the eth method would throw an error instead of returning `null` value

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/625

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
