### PR TITLE
Update eth_getCode to handle call to iHTS address

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -589,12 +589,12 @@ export class EthImpl implements Eth {
       if (result && result?.type === constants.TYPE_TOKEN) {
           return EthImpl.redirectBytecodeAddressReplace(address);
       }
-      else if (result && result?.type === constants.TYPE_CONTRACT && result?.entity.runtime_bytecode !== EthImpl.emptyHex) {
-          return result?.entity.runtime_bytecode;
-      }
       else if (result && result?.type === constants.TYPE_CONTRACT && address === EthImpl.iHTSAddress) {
         this.logger.debug(`${requestIdPrefix} HTS precompile, return 0x for byte code`);
         return EthImpl.invalidEVMInstruction;
+      }
+      else if (result && result?.type === constants.TYPE_CONTRACT && result?.entity.runtime_bytecode !== EthImpl.emptyHex) {
+          return result?.entity.runtime_bytecode;
       }
       else{
         const bytecode = await this.sdkClient.getContractByteCode(0, 0, address, EthImpl.ethGetCode, requestId);

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -61,7 +61,8 @@ export class EthImpl implements Eth {
   static feeHistoryEmptyResponse = { baseFeePerGas: [], gasUsedRatio: [], reward: [], oldestBlock: EthImpl.zeroHex };
   static redirectBytecodePrefix = '6080604052348015600f57600080fd5b506000610167905077618dc65e';
   static redirectBytecodePostfix = '600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033';
-
+  static iHTSAddress = '0x0000000000000000000000000000000000000167';
+  static invalidEVMInstruction = '0xfe';
 
   // endpoint metric callerNames
   static ethCall = 'eth_call';
@@ -590,6 +591,10 @@ export class EthImpl implements Eth {
       }
       else if (result && result?.type === constants.TYPE_CONTRACT && result?.entity.runtime_bytecode !== EthImpl.emptyHex) {
           return result?.entity.runtime_bytecode;
+      }
+      else if (result && result?.type === constants.TYPE_CONTRACT && address === EthImpl.iHTSAddress) {
+        this.logger.debug(`${requestIdPrefix} HTS precompile, return 0x for byte code`);
+        return EthImpl.invalidEVMInstruction;
       }
       else{
         const bytecode = await this.sdkClient.getContractByteCode(0, 0, address, EthImpl.ethGetCode, requestId);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1281,6 +1281,14 @@ describe('Eth calls using MirrorNode', async function () {
       const res = await ethImpl.getCode(htsTokenAddress, null);
       expect(res).to.equal(redirectBytecode);
     });
+
+    it('should return the static bytecode for address(0x167) call', async () => {
+      mock.onGet(`contracts/${EthImpl.iHTSAddress}`).reply(200, defaultContract);
+      mock.onGet(`accounts/${EthImpl.iHTSAddress}`).reply(404, null);
+
+      const res = await ethImpl.getCode(EthImpl.iHTSAddress, null);
+      expect(res).to.equal(EthImpl.invalidEVMInstruction);
+    });
   });
 
   describe('eth_getLogs', async function () {


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
Update eth_getCode to handle call to iHTS address.
This will support eth dev tool calls to `address(0x167)`
- Add catch case for contract type and `address(0x167)`
- Add test cases

**Related issue(s)**:

Fixes #628 

**Notes for reviewer**:
Q: Should I add support for `address(0x168)` and `address(0x169)` precompiles
Code would become
```
    if (address === EthImpl.iHTSAddress || address === EthImpl.iExchangeRateAddress || address === EthImpl.iPrngAddress) {
      this.logger.trace(`${requestIdPrefix} precompile case, return ${EthImpl.invalidEVMInstruction} for byte code`);
      return EthImpl.invalidEVMInstruction;
    }
```

Ans: We'll leave it till it's requested. Would also be better once Mirror EVM Archive Node is functional

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
