### PR TITLE
Fix rate limit not reseting

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -125,10 +125,10 @@ export const predefined = {
     code: -32000,
     message: `Exceeded maximum block range: ${blockRange}`
   }),
-  'IP_RATE_LIMIT_EXCEEDED': new JsonRpcError({
+  'IP_RATE_LIMIT_EXCEEDED': (methodName: string) => new JsonRpcError({
     name: 'IP Rate limit exceeded',
     code: -32605,
-    message: 'IP Rate limit exceeded'
+    message: `IP Rate limit exceeded on ${methodName}`
   }),
   'HBAR_RATE_LIMIT_EXCEEDED': new JsonRpcError({
     name: 'HBAR Rate limit exceeded',

--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -53,13 +53,12 @@ export default class KoaJsonRpc {
   constructor(logger: Logger, register: Registry, opts?) {
     this.koaApp = new Koa();
     this.limit = '1mb';
-    this.duration = parseInt(process.env.LIMIT_DURATION!);
+    this.duration = parseInt(process.env.LIMIT_DURATION!) || 60000;
     this.registry = Object.create(null);
     this.registryTotal = Object.create(null);
     this.methodConfig = methodConfiguration;
     if (opts) {
       this.limit = opts.limit || this.limit;
-      this.duration = opts.limit || this.limit;
     }
     this.ratelimit = new RateLimit(logger.child({ name: 'ip-rate-limit' }), register, this.duration);
   }

--- a/packages/server/tests/acceptance/rateLimiter.spec.ts
+++ b/packages/server/tests/acceptance/rateLimiter.spec.ts
@@ -57,7 +57,7 @@ describe('@ratelimiter Rate Limiters Acceptance Tests', function () {
                 }
             }catch(error) {
                 rateLimited = true;
-                Assertions.jsonRpcError(error, predefined.IP_RATE_LIMIT_EXCEEDED);
+                Assertions.jsonRpcError(error, predefined.IP_RATE_LIMIT_EXCEEDED('eth_chainId'));
             }
 
             expect(rateLimited).to.be.true;


### PR DESCRIPTION
Signed-off-by: georgi-l95 <glazarov95@gmail.com>

**Description**:
If env variable `LIMIT_DURATION` is not set, rate limit duration is NaN and can't reset. Now defaults to `60000 ms`, if it's not set.

**Related issue(s)**:

Fixes #623 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
