### PR TITLE
Fix transaction index param

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -74,13 +74,13 @@ export interface Eth {
 
   getStorageAt(address: string, slot: string, blockNumber: string|null, requestId?: string): Promise<string>;
 
-  getTransactionByBlockHashAndIndex(hash: string, index: number, requestId?: string): Promise<Transaction | null>;
+  getTransactionByBlockHashAndIndex(hash: string, index: string, requestId?: string): Promise<Transaction | null>;
 
-  getTransactionByBlockNumberAndIndex(blockNum: string, index: number, requestId?: string): Promise<Transaction | null>;
+  getTransactionByBlockNumberAndIndex(blockNum: string, index: string, requestId?: string): Promise<Transaction | null>;
 
   getTransactionByHash(hash: string, requestId?: string): Promise<Transaction | null>;
 
-  getTransactionCount(address: string, blocknum: string, requestId?: string): Promise<string | JsonRpcError>;
+  getTransactionCount(address: string, blockNum: string, requestId?: string): Promise<string | JsonRpcError>;
 
   getTransactionReceipt(hash: string, requestId?: string): Promise<Receipt | null>;
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -574,7 +574,7 @@ export class EthImpl implements Eth {
    */
   async getCode(address: string, blockNumber: string | null, requestId?: string) {
     const requestIdPrefix = formatRequestIdMessage(requestId);
-    
+
     // check for static precompile cases first before consulting nodes
     // this also account for environments where system entitites were not yet exposed to the mirror node
     if (address === EthImpl.iHTSAddress) {
@@ -603,7 +603,7 @@ export class EthImpl implements Eth {
           }
         }
       }
-      
+
       const bytecode = await this.sdkClient.getContractByteCode(0, 0, address, EthImpl.ethGetCode, requestId);
       return EthImpl.prepend0x(Buffer.from(bytecode).toString('hex'));
     } catch (e: any) {
@@ -692,11 +692,11 @@ export class EthImpl implements Eth {
    * @param blockHash
    * @param transactionIndex
    */
-  async getTransactionByBlockHashAndIndex(blockHash: string, transactionIndex: number, requestId?: string): Promise<Transaction | null> {
+  async getTransactionByBlockHashAndIndex(blockHash: string, transactionIndex: string, requestId?: string): Promise<Transaction | null> {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     this.logger.trace(`${requestIdPrefix} getTransactionByBlockHashAndIndex(hash=${blockHash}, index=${transactionIndex})`);
     return this.mirrorNodeClient
-      .getContractResults({ blockHash: blockHash, transactionIndex: transactionIndex },undefined, requestId)
+      .getContractResults({ blockHash: blockHash, transactionIndex: Number(transactionIndex) }, undefined, requestId)
       .then((contractResults) => this.getTransactionFromContractResults(contractResults, requestId))
       .catch((e: any) => {
         this.logger.error(
@@ -715,14 +715,14 @@ export class EthImpl implements Eth {
    */
   async getTransactionByBlockNumberAndIndex(
     blockNumOrTag: string,
-    transactionIndex: number,
+    transactionIndex: string,
     requestId?: string
   ): Promise<Transaction | null> {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     this.logger.trace(`${requestIdPrefix} getTransactionByBlockNumberAndIndex(blockNum=${blockNumOrTag}, index=${transactionIndex})`);
     const blockNum = await this.translateBlockTag(blockNumOrTag, requestId);
     return this.mirrorNodeClient
-      .getContractResults({ blockNumber: blockNum, transactionIndex: transactionIndex },undefined, requestId)
+      .getContractResults({ blockNumber: blockNum, transactionIndex: Number(transactionIndex) }, undefined, requestId)
       .then((contractResults) => this.getTransactionFromContractResults(contractResults, requestId))
       .catch((e: any) => {
         this.logger.error(

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -297,13 +297,13 @@ describe("Open RPC Specification", function () {
     });
 
     it('should execute "eth_getTransactionByBlockHashAndIndex"', async function () {
-        const response = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, defaultBlock.count);
+        const response = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count));
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionByBlockHashAndIndex, response);
     });
 
     it('should execute "eth_getTransactionByBlockNumberAndIndex"', async function () {
-        const response = await ethImpl.getTransactionByBlockNumberAndIndex(defaultBlock.number.toString(), defaultBlock.count);
+        const response = await ethImpl.getTransactionByBlockNumberAndIndex(EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count));
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionByBlockNumberAndIndex, response);
     });


### PR DESCRIPTION
Signed-off-by: Maksim Dimitrov <dimitrov.maksim@gmail.com>

**Description**:

Fix eth_getTransactionByBlockHashAndIndex and eth_getTransactionByBlockNumberAndIndex transaction index param not being converted from hex to decimal when querying the mirror node

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/634

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
