### PR TITLE
Replace js-cache with lru-cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12027,9 +12027,9 @@
             }
         },
         "node_modules/@xmldom/xmldom": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
-            "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==",
+            "version": "0.7.8",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.8.tgz",
+            "integrity": "sha512-PrJx38EfpitFhwmILRl37jAdBlsww6AZ6rRVK4QS7T7RHLhX7mSs647sTmgr9GIxe3qjXdesmomEgbgaokrVFg==",
             "optional": true,
             "peer": true,
             "engines": {
@@ -12751,11 +12751,6 @@
                 "babel-plugin-react-native-web": "~0.17.1",
                 "metro-react-native-babel-preset": "~0.67.0"
             }
-        },
-        "node_modules/backbone-events-standalone": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/backbone-events-standalone/-/backbone-events-standalone-0.2.7.tgz",
-            "integrity": "sha512-8RgZDihR30W2nXuEAb5+6cH8UwU5FSGxUuQYOcMXf7GsIFKTFmWuAvNn3LYkmACzgl+4kiEDxqFoRg7a50MCZw=="
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -18849,14 +18844,6 @@
             "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
             "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
         },
-        "node_modules/infinite-timeout": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/infinite-timeout/-/infinite-timeout-0.1.0.tgz",
-            "integrity": "sha512-M6M2Fg556g6jHe50gLSXxSauqu8seMGbnEgD20ofhnlBlIZOLnchDdDLDh3G505HEci3qOFjrkMH3YPAFKKt2A==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/inflation": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
@@ -19764,18 +19751,6 @@
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
             "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
-        },
-        "node_modules/js-cache": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/js-cache/-/js-cache-1.0.3.tgz",
-            "integrity": "sha512-1vJ8wLHuuzxbzJZxRBs51HAhlCIuO/bNROmjroBHUhoxBbhwnqBCHe2TEw2KPdW/n8qPu4+h9HZHcNZEod7jxw==",
-            "dependencies": {
-                "backbone-events-standalone": "*",
-                "infinite-timeout": "*"
-            },
-            "engines": {
-                "node": ">=0.8"
-            }
         },
         "node_modules/js-logger": {
             "version": "1.6.1",
@@ -28043,11 +28018,11 @@
                 "dotenv": "^16.0.0",
                 "ethers": "^5.6.8",
                 "find-config": "^1.0.0",
-                "js-cache": "^1.0.3",
                 "keccak": "^3.0.2",
                 "keyv": "^4.2.2",
                 "keyv-file": "^0.2.0",
                 "lodash": "^4.17.21",
+                "lru-cache": "^7.14.0",
                 "pino": "^7.11.0",
                 "rlp": "^3.0.0"
             },
@@ -28072,6 +28047,14 @@
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.14.8"
+            }
+        },
+        "packages/relay/node_modules/lru-cache": {
+            "version": "7.14.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+            "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
+            "engines": {
+                "node": ">=12"
             }
         },
         "packages/server": {
@@ -33155,11 +33138,11 @@
                 "dotenv": "^16.0.0",
                 "ethers": "^5.6.8",
                 "find-config": "^1.0.0",
-                "js-cache": "^1.0.3",
                 "keccak": "^3.0.2",
                 "keyv": "^4.2.2",
                 "keyv-file": "^0.2.0",
                 "lodash": "^4.17.21",
+                "lru-cache": "^7.14.0",
                 "pino": "^7.11.0",
                 "rlp": "^3.0.0",
                 "sinon": "^14.0.0",
@@ -33178,6 +33161,11 @@
                     "requires": {
                         "follow-redirects": "^1.14.8"
                     }
+                },
+                "lru-cache": {
+                    "version": "7.14.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
+                    "integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ=="
                 }
             }
         },
@@ -36810,9 +36798,9 @@
             }
         },
         "@xmldom/xmldom": {
-            "version": "0.7.6",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.6.tgz",
-            "integrity": "sha512-HHXP9hskkFQHy8QxxUXkS7946FFIhYVfGqsk0WLwllmexN9x/+R4UBLvurHEuyXRfVEObVR8APuQehykLviwSQ==",
+            "version": "0.7.8",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.8.tgz",
+            "integrity": "sha512-PrJx38EfpitFhwmILRl37jAdBlsww6AZ6rRVK4QS7T7RHLhX7mSs647sTmgr9GIxe3qjXdesmomEgbgaokrVFg==",
             "optional": true,
             "peer": true
         },
@@ -37379,11 +37367,6 @@
                 "babel-plugin-react-native-web": "~0.17.1",
                 "metro-react-native-babel-preset": "~0.67.0"
             }
-        },
-        "backbone-events-standalone": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/backbone-events-standalone/-/backbone-events-standalone-0.2.7.tgz",
-            "integrity": "sha512-8RgZDihR30W2nXuEAb5+6cH8UwU5FSGxUuQYOcMXf7GsIFKTFmWuAvNn3LYkmACzgl+4kiEDxqFoRg7a50MCZw=="
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -41921,11 +41904,6 @@
             "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
             "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
         },
-        "infinite-timeout": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/infinite-timeout/-/infinite-timeout-0.1.0.tgz",
-            "integrity": "sha512-M6M2Fg556g6jHe50gLSXxSauqu8seMGbnEgD20ofhnlBlIZOLnchDdDLDh3G505HEci3qOFjrkMH3YPAFKKt2A=="
-        },
         "inflation": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
@@ -42592,15 +42570,6 @@
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
             "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
-        },
-        "js-cache": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/js-cache/-/js-cache-1.0.3.tgz",
-            "integrity": "sha512-1vJ8wLHuuzxbzJZxRBs51HAhlCIuO/bNROmjroBHUhoxBbhwnqBCHe2TEw2KPdW/n8qPu4+h9HZHcNZEod7jxw==",
-            "requires": {
-                "backbone-events-standalone": "*",
-                "infinite-timeout": "*"
-            }
         },
         "js-logger": {
             "version": "1.6.1",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -34,7 +34,7 @@
         "dotenv": "^16.0.0",
         "ethers": "^5.6.8",
         "find-config": "^1.0.0",
-        "js-cache": "^1.0.3",
+        "lru-cache": "^7.14.0",
         "keccak": "^3.0.2",
         "keyv": "^4.2.2",
         "keyv-file": "^0.2.0",

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -22,6 +22,7 @@ enum CACHE_KEY {
     GAS_PRICE = 'gas_price',
     FEE_HISTORY = 'fee_history'
 }
+
 enum CACHE_TTL {
     ONE_HOUR = 3_600_000
 }
@@ -33,8 +34,10 @@ enum ORDER {
 
 export default {
     TINYBAR_TO_WEIBAR_COEF: 10_000_000_000,
+
     CACHE_KEY,
     CACHE_TTL,
+    CACHE_MAX: 1000,
 
     DEFAULT_TINY_BAR_GAS: 72, // (853454 / 1000) * (1 / 12)
     ETH_FUNCTIONALITY_CODE: 84,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -30,9 +30,8 @@ import { MirrorNodeClientError } from './errors/MirrorNodeClientError';
 import constants from './constants';
 import { Precheck } from './precheck';
 import { formatRequestIdMessage } from '../formatters';
-
+const LRU = require('lru-cache');
 const _ = require('lodash');
-const cache = require('js-cache');
 const createHash = require('keccak');
 
 /**
@@ -77,6 +76,24 @@ export class EthImpl implements Eth {
   static blockLatest = 'latest';
   static blockEarliest = 'earliest';
   static blockPending = 'pending';
+  
+  /**
+   * Configurable options used when initializing the cache.
+   *
+   * @private
+   */
+  private readonly options = {
+    //The maximum number (or size) of items that remain in the cache (assuming no TTL pruning or explicit deletions).
+    max: constants.CACHE_MAX,
+    // Max time to live in ms, for items before they are considered stale.
+    ttl: constants.CACHE_TTL.ONE_HOUR,
+  }
+  /**
+   * The LRU cache used for caching items from requests.
+   *
+   * @private
+   */
+   private readonly cache;
 
   /**
    * The sdk client use for connecting to both the consensus nodes and mirror node. The account
@@ -121,13 +138,16 @@ export class EthImpl implements Eth {
     nodeClient: SDKClient,
     mirrorNodeClient: MirrorNodeClient,
     logger: Logger,
-    chain: string
+    chain: string,
+    cache?
   ) {
     this.sdkClient = nodeClient;
     this.mirrorNodeClient = mirrorNodeClient;
     this.logger = logger;
     this.chain = chain;
     this.precheck = new Precheck(mirrorNodeClient, nodeClient, logger, chain);
+    this.cache = cache;
+    if (!cache) this.cache = new LRU(this.options);
   }
 
   /**
@@ -164,13 +184,13 @@ export class EthImpl implements Eth {
         return EthImpl.feeHistoryZeroBlockCountResponse;
       }
 
-      let feeHistory: object | undefined = cache.get(constants.CACHE_KEY.FEE_HISTORY);
+      let feeHistory: object | undefined = this.cache.get(constants.CACHE_KEY.FEE_HISTORY);
       if (!feeHistory) {
 
         feeHistory = await this.getFeeHistory(blockCount, newestBlockNumber, latestBlockNumber, rewardPercentiles, requestId);
 
         this.logger.trace(`${requestIdPrefix} caching ${constants.CACHE_KEY.FEE_HISTORY} for ${constants.CACHE_TTL.ONE_HOUR} ms`);
-        cache.set(constants.CACHE_KEY.FEE_HISTORY, feeHistory, constants.CACHE_TTL.ONE_HOUR);
+        this.cache.set(constants.CACHE_KEY.FEE_HISTORY, feeHistory);
       }
 
       return feeHistory;
@@ -317,13 +337,13 @@ export class EthImpl implements Eth {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     this.logger.trace(`${requestIdPrefix} gasPrice()`);
     try {
-      let gasPrice: number | undefined = cache.get(constants.CACHE_KEY.GAS_PRICE);
+      let gasPrice: number | undefined = this.cache.get(constants.CACHE_KEY.GAS_PRICE);
 
       if (!gasPrice) {
         gasPrice = await this.getFeeWeibars(EthImpl.ethGasPrice, requestId);
 
         this.logger.trace(`${requestIdPrefix} caching ${constants.CACHE_KEY.GAS_PRICE} for ${constants.CACHE_TTL.ONE_HOUR} ms`);
-        cache.set(constants.CACHE_KEY.GAS_PRICE, gasPrice, constants.CACHE_TTL.ONE_HOUR);
+        this.cache.set(constants.CACHE_KEY.GAS_PRICE, gasPrice);
       }
 
       return EthImpl.numberTo0x(gasPrice);
@@ -524,7 +544,7 @@ export class EthImpl implements Eth {
     
     // Cache is only set for `not found` balances
     const cachedLabel = `getBalance.${account}.${blockNumberOrTag}`;
-    const cachedResponse: string | undefined = cache.get(cachedLabel);
+    const cachedResponse: string | undefined = this.cache.get(cachedLabel);
     if (cachedResponse != undefined) {
       return cachedResponse;
     }
@@ -574,7 +594,7 @@ export class EthImpl implements Eth {
 
       if (!balanceFound) {
         this.logger.debug(`${requestIdPrefix} Unable to find account ${account} in block ${JSON.stringify(blockNumber)}(${blockNumberOrTag}), returning 0x0 balance`);
-        cache.set(cachedLabel, EthImpl.zeroHex, constants.CACHE_TTL.ONE_HOUR);
+        this.cache.set(cachedLabel, EthImpl.zeroHex);
         return EthImpl.zeroHex;
       }
 
@@ -604,7 +624,7 @@ export class EthImpl implements Eth {
     this.logger.trace(`${requestIdPrefix} getCode(address=${address}, blockNumber=${blockNumber})`);
 
     const cachedLabel = `getCode.${address}.${blockNumber}`;
-    const cachedResponse: string | undefined = cache.get(cachedLabel);
+    const cachedResponse: string | undefined = this.cache.get(cachedLabel);
     if (cachedResponse != undefined) {
       return cachedResponse;
     }
@@ -630,7 +650,7 @@ export class EthImpl implements Eth {
         // handle INVALID_CONTRACT_ID
         if (e.isInvalidContractId()) {
           this.logger.debug(`${requestIdPrefix} Unable to find code for contract ${address} in block "${blockNumber}", returning 0x0, err code: ${e.statusCode}`);
-          cache.set(cachedLabel, EthImpl.emptyHex, constants.CACHE_TTL.ONE_HOUR);
+          this.cache.set(cachedLabel, EthImpl.emptyHex);
           return EthImpl.emptyHex;
         }
         this.logger.error(e, `${requestIdPrefix} Error raised during getCode for address ${address}, err code: ${e.statusCode}`);
@@ -1292,7 +1312,7 @@ export class EthImpl implements Eth {
 
           // Use the `toBlock` if it is the only passed tag, if not utilize the `fromBlock` or default to "latest"
           const blockTag = toBlock && !fromBlock ? toBlock : fromBlock || "latest";
-          
+
           const fromBlockResponse = await this.getHistoricalBlockResponse(blockTag, true, requestId);
           if (fromBlockResponse != null) {
             params.timestamp.push(`gte:${fromBlockResponse.timestamp.from}`);
@@ -1361,14 +1381,14 @@ export class EthImpl implements Eth {
 
   private async getLogEvmAddress(address: string, requestId: string | undefined) {
     const cachedLabel = `getLogEvmAddress.${address}`;
-    let contractAddress = cache.get(cachedLabel);
+    let contractAddress = this.cache.get(cachedLabel);
 
     // If contractAddress === undefined it means there's no cache record
     // and a mirror node request should be executed.
     if (contractAddress === undefined) {
       const contract = await this.mirrorNodeClient.getContract(address, requestId);
       contractAddress = contract.evm_address;
-      cache.set(cachedLabel, contractAddress, constants.CACHE_TTL.ONE_HOUR);
+      this.cache.set(cachedLabel, contractAddress);
     }
 
     return contractAddress;

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -25,7 +25,6 @@ import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
 import { Registry } from 'prom-client';
 import sinon from 'sinon';
-import cache from 'js-cache';
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 import { RelayImpl } from '@hashgraph/json-rpc-relay';
 import { predefined } from '../../src/lib/errors/JsonRpcError';
@@ -43,6 +42,7 @@ import { Block, Transaction } from '../../src/lib/model';
 import constants from '../../src/lib/constants';
 import { SDKClient } from '../../src/lib/clients';
 import { SDKClientError } from '../../src/lib/errors/SDKClientError';
+const LRU = require('lru-cache');
 
 const logger = pino();
 const registry = new Registry();
@@ -77,11 +77,13 @@ const verifyBlockConstants = (block: Block) => {
 let mock: MockAdapter;
 let mirrorNodeInstance: MirrorNodeClient;
 let sdkClientStub;
+let cache;
 
 describe('Eth calls using MirrorNode', async function () {
   this.timeout(10000);
 
   let ethImpl: EthImpl;
+
   this.beforeAll(() => {
     // mock axios
     const instance = axios.create({
@@ -98,8 +100,12 @@ describe('Eth calls using MirrorNode', async function () {
     // @ts-ignore
     mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
     sdkClientStub = sinon.createStubInstance(SDKClient);
+    cache = new LRU({
+      max: constants.CACHE_MAX,
+      ttl: constants.CACHE_TTL.ONE_HOUR
+    });
     // @ts-ignore
-    ethImpl = new EthImpl(sdkClientStub, mirrorNodeInstance, logger, '0x12a');
+    ethImpl = new EthImpl(sdkClientStub, mirrorNodeInstance, logger, '0x12a', cache);
   });
 
   this.beforeEach(() => {
@@ -1499,7 +1505,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const result = await ethImpl.getLogs(null, null, null, null, null);
 
-      expect(cache.keys().includes('getLogEvmAddress.0x0000000000000000000000000000000002131951')).to.be.true;
+      // expect(cache.keys().includes('getLogEvmAddress.0x0000000000000000000000000000000002131951')).to.be.true;
 
       expect(result).to.exist;
       expect(result.length).to.eq(4);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1505,7 +1505,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const result = await ethImpl.getLogs(null, null, null, null, null);
 
-      // expect(cache.keys().includes('getLogEvmAddress.0x0000000000000000000000000000000002131951')).to.be.true;
+      expect(cache.keyList.includes('getLogEvmAddress.0x0000000000000000000000000000000002131951')).to.be.true;
 
       expect(result).to.exist;
       expect(result.length).to.eq(4);


### PR DESCRIPTION
Signed-off-by: georgi-l95 <glazarov95@gmail.com>

**Description**:
Replace `js-cache` with `lru-cache`. A cache object that deletes the least-recently-used items with customisable options.

Options currently set during initialization are:
  - `max` - The maximum number (or size) of items that remain in the cache (assuming no TTL pruning or explicit deletions).
  - `ttl` - Max time to live for items before they are considered stale.
  
**Related issue(s)**:

Fixes #658 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
