### PR TITLE
Use evm_address from mirror node query of recently deployed contracts to populate the transaction receipt result

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1001,11 +1001,12 @@ export class EthImpl implements Eth {
         receiptResponse.max_fee_per_gas === undefined || receiptResponse.max_fee_per_gas == '0x'
           ? receiptResponse.gas_price
           : receiptResponse.max_fee_per_gas;
-      const createdContract =
-        receiptResponse.created_contract_ids.length > 0
-          ? EthImpl.prepend0x(ContractId.fromString(receiptResponse.created_contract_ids[0]).toSolidityAddress())
-          : undefined;
 
+      let createdContract;
+      if (receiptResponse.created_contract_ids.length) {
+        const contract = await this.mirrorNodeClient.getContract(receiptResponse.created_contract_ids[0]);
+        createdContract = contract?.evm_address ?? EthImpl.prepend0x(ContractId.fromString(receiptResponse.created_contract_ids[0]).toSolidityAddress());
+      }
 
       // support stricter go-eth client which requires the transaction hash property on logs
       const logs = receiptResponse.logs.map(log => {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2344,6 +2344,7 @@ describe('Eth', async function () {
     it('valid receipt on match', async function () {
       // mirror node request mocks
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, defaultDetailedContractResultByHash);
+      mock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
       const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
 
       // Assert the data format
@@ -2389,6 +2390,7 @@ describe('Eth', async function () {
       };
 
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, contractResult);
+      mock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
       const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
 
       expect(receipt).to.exist;
@@ -2403,6 +2405,7 @@ describe('Eth', async function () {
         bloom: '0x'
       };
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, receiptWith0xBloom);
+      mock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
       const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
 
       expect(receipt).to.exist;
@@ -2417,6 +2420,7 @@ describe('Eth', async function () {
       };
 
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, receiptWithErrorMessage);
+      mock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
       const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
 
       expect(receipt).to.exist;
@@ -2429,6 +2433,7 @@ describe('Eth', async function () {
         gas_used: null
       };
       mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, receiptWithNullGasUsed);
+      mock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
       const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
 
       expect(receipt).to.exist;

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -327,6 +327,7 @@ describe("Open RPC Specification", function () {
     });
 
     it('should execute "eth_getTransactionReceipt"', async function () {
+        mock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
         const response = await ethImpl.getTransactionReceipt(defaultTxHash);
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionReceipt, response);


### PR DESCRIPTION
Signed-off-by: nikolay <n.atanasow94@gmail.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #685

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
