### PR TITLE
Add logic to handle missing transaction index

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1068,7 +1068,7 @@ export class EthImpl implements Eth {
   }
 
   static nullableNumberTo0x(input: number | BigNumber): string | null {
-    return input === null || input === undefined ? null : EthImpl.numberTo0x(input);
+    return input == null ? null : EthImpl.numberTo0x(input);
   }
 
   static nanOrNumberTo0x(input: number | BigNumber): string {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1024,7 +1024,7 @@ export class EthImpl implements Eth {
           removed: false,
           topics: log.topics,
           transactionHash: EthImpl.toHash32(receiptResponse.hash),
-          transactionIndex: EthImpl.numberTo0x(receiptResponse.transaction_index)
+          transactionIndex: EthImpl.nullableNumberTo0x(receiptResponse.transaction_index)
         });
       });
 
@@ -1039,7 +1039,7 @@ export class EthImpl implements Eth {
         logs: logs,
         logsBloom: receiptResponse.bloom === EthImpl.emptyHex ? EthImpl.emptyBloom : receiptResponse.bloom,
         transactionHash: EthImpl.toHash32(receiptResponse.hash),
-        transactionIndex: EthImpl.numberTo0x(receiptResponse.transaction_index),
+        transactionIndex: EthImpl.nullableNumberTo0x(receiptResponse.transaction_index),
         effectiveGasPrice: EthImpl.nanOrNumberTo0x(Number.parseInt(effectiveGas) * 10_000_000_000),
         root: receiptResponse.root,
         status: receiptResponse.status,
@@ -1068,7 +1068,7 @@ export class EthImpl implements Eth {
   }
 
   static nullableNumberTo0x(input: number | BigNumber): string | null {
-    return input === null ? null : EthImpl.numberTo0x(input);
+    return input === null || input === undefined ? null : EthImpl.numberTo0x(input);
   }
 
   static nanOrNumberTo0x(input: number | BigNumber): string {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2519,6 +2519,24 @@ describe('Eth', async function () {
       if (receipt == null) return;
       expect(receipt.gasUsed).to.eq("0x0");
     });
+
+    it('handles missing transaction index', async function() {
+      // mirror node request mocks
+      mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, {
+        ...defaultDetailedContractResultByHash, ...{
+          transaction_index: undefined
+        }
+      });
+      mock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(200, {
+        evm_address: contractEvmAddress
+      });
+      const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
+
+      expect(receipt).to.exist;
+
+      expect(receipt.logs[0].transactionIndex).to.eq(null);
+      expect(receipt.transactionIndex).to.eq(null);
+    });
   });
 
   describe('eth_getTransactionByHash', async function () {


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
It seems occasionally `transaction_index` can be undefined from mirror node.
Currently the relay throws errors in this case.
While we figure out why

- add logic to manage undefined transaction_index
- add tests

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
