### PR TITLE
Handle empty state_changes array in contract details

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -482,6 +482,7 @@ export class EthImpl implements Eth {
    */
   async getStorageAt(address: string, slot: string, blockNumberOrTag?: string | null, requestId?: string) : Promise<string> {
     const requestIdPrefix = formatRequestIdMessage(requestId);
+    this.logger.trace(`${requestIdPrefix} getStorageAt(address=${address}, slot=${slot}, blockNumberOrTag=${blockNumberOrTag})`);
     let result = EthImpl.zeroHex32Byte; // if contract or slot not found then return 32 byte 0
     const blockResponse  = await this.getHistoricalBlockResponse(blockNumberOrTag, false);
 
@@ -498,7 +499,7 @@ export class EthImpl implements Eth {
       // retrieve the contract result details
       await this.mirrorNodeClient.getContractResultsDetails(address, contractResult.results[0].timestamp)
         .then(contractResultDetails => {
-          if (contractResultDetails?.state_changes != null) {
+          if (contractResultDetails?.state_changes != null && Array.isArray(contractResultDetails?.state_changes) && contractResultDetails?.state_changes.length > 0) {
             // filter the state changes to match slot and return value
             const stateChange = contractResultDetails.state_changes.find(stateChange => stateChange.slot === slot);
             result = stateChange.value_written;

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -499,7 +499,7 @@ export class EthImpl implements Eth {
       // retrieve the contract result details
       await this.mirrorNodeClient.getContractResultsDetails(address, contractResult.results[0].timestamp)
         .then(contractResultDetails => {
-          if (contractResultDetails?.state_changes != null && Array.isArray(contractResultDetails?.state_changes) && contractResultDetails?.state_changes.length > 0) {
+          if (EthImpl.isArrayNonEmpty(contractResultDetails?.state_changes)) {
             // filter the state changes to match slot and return value
             const stateChange = contractResultDetails.state_changes.find(stateChange => stateChange.slot === slot);
             result = stateChange.value_written;
@@ -1401,4 +1401,9 @@ export class EthImpl implements Eth {
 
     return contractAddress;
   }
+
+  static isArrayNonEmpty(input: any): boolean {
+    return Array.isArray(input) && input.length > 0;
+  }
+
 }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -42,6 +42,7 @@ import { Block, Transaction } from '../../src/lib/model';
 import constants from '../../src/lib/constants';
 import { SDKClient } from '../../src/lib/clients';
 import { SDKClientError } from '../../src/lib/errors/SDKClientError';
+
 const LRU = require('lru-cache');
 
 const logger = pino();
@@ -2225,13 +2226,13 @@ describe('Eth calls using MirrorNode', async function () {
         await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
       } catch (e: any) {
         hasError = true;
-        expect(e.code).to.equal(-32001);
-        expect(e.name).to.equal('Resource not found');
+        expect(e.code).to.equal(predefined.RESOURCE_NOT_FOUND().code);
+        expect(e.name).to.equal(predefined.RESOURCE_NOT_FOUND().name);
       }
       expect(hasError).to.be.true;
     });
 
-    it('eth_getStorageAt should throw a predefined RESOURCE_NOT_FOUND when block is null', async function () {
+    it('eth_getStorageAt should throw a predefined RESOURCE_NOT_FOUND when state_changes is null', async function () {
       defaultDetailedContractResultsNullStateChange
       mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
       mock.onGet(`contracts/${contractAddress1}/results?timestamp=lte:${defaultBlock.timestamp.to}&limit=1&order=desc`).reply(200, defaultContractResults);
@@ -2241,13 +2242,13 @@ describe('Eth calls using MirrorNode', async function () {
         await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
       } catch (e: any) {
         hasError = true;
-        expect(e.code).to.equal(-32001);
-        expect(e.name).to.equal('Resource not found');
+        expect(e.code).to.equal(predefined.RESOURCE_NOT_FOUND().code);
+        expect(e.name).to.equal(predefined.RESOURCE_NOT_FOUND().name);
       }
       expect(hasError).to.be.true;
     });
 
-    it('eth_getStorageAt should throw a predefined RESOURCE_NOT_FOUND when block is an empty array', async function () {
+    it('eth_getStorageAt should throw a predefined RESOURCE_NOT_FOUND when state_changes is an empty array', async function () {
       defaultDetailedContractResultsNullStateChange
       mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
       mock.onGet(`contracts/${contractAddress1}/results?timestamp=lte:${defaultBlock.timestamp.to}&limit=1&order=desc`).reply(200, defaultContractResults);
@@ -2257,8 +2258,8 @@ describe('Eth calls using MirrorNode', async function () {
         await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
       } catch (e: any) {
         hasError = true;
-        expect(e.code).to.equal(-32001);
-        expect(e.name).to.equal('Resource not found');
+        expect(e.code).to.equal(predefined.RESOURCE_NOT_FOUND().code);
+        expect(e.name).to.equal(predefined.RESOURCE_NOT_FOUND().name);
       }
       expect(hasError).to.be.true;
     });
@@ -2274,8 +2275,8 @@ describe('Eth calls using MirrorNode', async function () {
         await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
       } catch (e: any) {
         hasError = true;
-        expect(e.code).to.equal(-32001);
-        expect(e.name).to.equal('Resource not found');
+        expect(e.code).to.equal(predefined.RESOURCE_NOT_FOUND().code);
+        expect(e.name).to.equal(predefined.RESOURCE_NOT_FOUND().name);
       }
       expect(hasError).to.be.true;
     });


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

Handle the case when the state_changes field returned as an empty array. 

Fixes #732 


- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
