### PR TITLE
Return 32 byte 0 on empty state_changes array

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -499,13 +499,14 @@ export class EthImpl implements Eth {
       // retrieve the contract result details
       await this.mirrorNodeClient.getContractResultsDetails(address, contractResult.results[0].timestamp)
         .then(contractResultDetails => {
+          if(contractResultDetails === null) {
+            throw predefined.RESOURCE_NOT_FOUND(`Contract result details for contract address ${address} at timestamp=${contractResult.results[0].timestamp}`);
+          }
           if (EthImpl.isArrayNonEmpty(contractResultDetails?.state_changes)) {
             // filter the state changes to match slot and return value
             const stateChange = contractResultDetails.state_changes.find(stateChange => stateChange.slot === slot);
             result = stateChange.value_written;
-          } else {
-            throw predefined.RESOURCE_NOT_FOUND(`Contract result details for contract address ${address} at timestamp=${contractResult.results[0].timestamp}`);
-          }
+          } 
         })
         .catch((e: any) => {
           this.logger.error(

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -502,7 +502,7 @@ export class EthImpl implements Eth {
           if(contractResultDetails === null) {
             throw predefined.RESOURCE_NOT_FOUND(`Contract result details for contract address ${address} at timestamp=${contractResult.results[0].timestamp}`);
           }
-          if (EthImpl.isArrayNonEmpty(contractResultDetails?.state_changes)) {
+          if (EthImpl.isArrayNonEmpty(contractResultDetails.state_changes)) {
             // filter the state changes to match slot and return value
             const stateChange = contractResultDetails.state_changes.find(stateChange => stateChange.slot === slot);
             result = stateChange.value_written;

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2305,36 +2305,22 @@ describe('Eth calls using MirrorNode', async function () {
       expect(hasError).to.be.true;
     });
 
-    it('eth_getStorageAt should throw a predefined RESOURCE_NOT_FOUND when state_changes is null', async function () {
+    it('eth_getStorageAt should return EthImpl.zeroHex32Byte when state_changes is null', async function () {
       defaultDetailedContractResultsNullStateChange
       mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
       mock.onGet(`contracts/${contractAddress1}/results?timestamp=lte:${defaultBlock.timestamp.to}&limit=1&order=desc`).reply(200, defaultContractResults);
       mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResultsNullStateChange);
-      let hasError = false;
-      try {
-        await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
-      } catch (e: any) {
-        hasError = true;
-        expect(e.code).to.equal(predefined.RESOURCE_NOT_FOUND().code);
-        expect(e.name).to.equal(predefined.RESOURCE_NOT_FOUND().name);
-      }
-      expect(hasError).to.be.true;
+      const result = await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
+      expect(result).to.equal(EthImpl.zeroHex32Byte);
     });
 
-    it('eth_getStorageAt should throw a predefined RESOURCE_NOT_FOUND when state_changes is an empty array', async function () {
+    it('eth_getStorageAt should return EthImpl.zeroHex32Byte when state_changes is an empty array', async function () {
       defaultDetailedContractResultsNullStateChange
       mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
       mock.onGet(`contracts/${contractAddress1}/results?timestamp=lte:${defaultBlock.timestamp.to}&limit=1&order=desc`).reply(200, defaultContractResults);
       mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResultsEmptyArrayStateChange);
-      let hasError = false;
-      try {
-        await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
-      } catch (e: any) {
-        hasError = true;
-        expect(e.code).to.equal(predefined.RESOURCE_NOT_FOUND().code);
-        expect(e.name).to.equal(predefined.RESOURCE_NOT_FOUND().name);
-      }
-      expect(hasError).to.be.true;
+      const result = await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
+      expect(result).to.equal(EthImpl.zeroHex32Byte);
     });
 
     it('eth_getStorageAt should throw error when contract not found', async function () {


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:
Return 32 byte 0 string when the returned state_changes array is empty.  This is similar behavior to other test chains.

**Related issue(s)**:

Fixes #732 

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
