### PR TITLE
Events not returned on getPastEvents call

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1379,7 +1379,9 @@ export class EthImpl implements Eth {
   private addTopicsToParams(params: any, topics: any[] | null) {
     if (topics) {
       for (let i = 0; i < topics.length; i++) {
-        params[`topic${i}`] = topics[i];
+        if (!_.isNil(topics[i])) {
+          params[`topic${i}`] = topics[i];
+        }
       }
     }
   }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -242,10 +242,15 @@ describe('Eth calls using MirrorNode', async function () {
     "0x0000000000000000000000000000000000000000000000000000000000000005"
   ];
 
+  const defaultLogTopics1 = [
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+    "0x000000000000000000000000000000000000000000000000000000000208fa13",
+  ];
+
   const defaultNullLogTopics = [
     "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-    null,
     "0x000000000000000000000000000000000000000000000000000000000208fa13",
+    null,
     null
   ];
 
@@ -326,7 +331,7 @@ describe('Eth calls using MirrorNode', async function () {
       "contract_id": contractId2,
       "data": "0x",
       "index": 0,
-      "topics": defaultNullLogTopics,
+      "topics": defaultLogTopics1,
       "root_contract_id": "0.0.34806097",
       "timestamp": contractTimestamp3,
       "block_hash": blockHash3 ,
@@ -1979,8 +1984,8 @@ describe('Eth calls using MirrorNode', async function () {
         `contracts/results/logs` +
         `?timestamp=gte:${defaultBlock.timestamp.from}` +
         `&timestamp=lte:${defaultBlock.timestamp.to}` +
-        `&topic0=${defaultNullLogTopics[0]}` +
-        `&topic2=${defaultNullLogTopics[2]}&limit=100&order=asc`
+        `&topic0=${defaultLogTopics1[0]}` +
+        `&topic1=${defaultLogTopics1[1]}&limit=100&order=asc`
       ).reply(200, filteredLogs);
       for (const log of filteredLogs.logs) {
         mock.onGet(`contracts/${log.address}`).reply(200, defaultContract);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -242,6 +242,12 @@ describe('Eth calls using MirrorNode', async function () {
     "0x0000000000000000000000000000000000000000000000000000000000000005"
   ];
 
+  const defaultNullLogTopics = [
+    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+    null,
+    "0x000000000000000000000000000000000000000000000000000000000208fa13",
+    null
+  ];
 
   const logBloom1 = '0x1111';
   const logBloom2 = '0x2222';
@@ -304,6 +310,23 @@ describe('Eth calls using MirrorNode', async function () {
       "data": "0x",
       "index": 0,
       "topics": [],
+      "root_contract_id": "0.0.34806097",
+      "timestamp": contractTimestamp3,
+      "block_hash": blockHash3 ,
+      "block_number": blockNumber3,
+      "transaction_hash": contractHash3,
+      "transaction_index": 1
+    }
+  ];
+
+  const defaultLogs4 = [
+    {
+      "address": "0x0000000000000000000000000000000002131951",
+      "bloom": logBloom4,
+      "contract_id": contractId2,
+      "data": "0x",
+      "index": 0,
+      "topics": defaultNullLogTopics,
       "root_contract_id": "0.0.34806097",
       "timestamp": contractTimestamp3,
       "block_hash": blockHash3 ,
@@ -1945,6 +1968,31 @@ describe('Eth calls using MirrorNode', async function () {
       expect(result).to.exist;
       expectLogData1(result[0]);
       expectLogData2(result[1]);
+    });
+
+    it('with null topics filter', async function() {
+      const filteredLogs = {
+        logs: [defaultLogs4[0]]
+      };
+      mock.onGet("blocks?limit=1&order=desc").reply(200, { blocks: [defaultBlock] });
+      mock.onGet(
+        `contracts/results/logs` +
+        `?timestamp=gte:${defaultBlock.timestamp.from}` +
+        `&timestamp=lte:${defaultBlock.timestamp.to}` +
+        `&topic0=${defaultNullLogTopics[0]}` +
+        `&topic2=${defaultNullLogTopics[2]}&limit=100&order=asc`
+      ).reply(200, filteredLogs);
+      for (const log of filteredLogs.logs) {
+        mock.onGet(`contracts/${log.address}`).reply(200, defaultContract);
+      }
+      const result = await ethImpl.getLogs(null, null, null, null, defaultNullLogTopics);
+      console.log(result);
+
+      expect(result).to.exist;
+      expect(result[0].topics.length).to.eq(defaultLogs4[0].topics.length)
+      for (let index = 0; index < result[0].topics.length; index++) {
+        expect(result[0].topics[index]).to.eq(defaultLogs4[0].topics[index]);
+      }
     });
 
     it('with topics and blocks filter', async function () {


### PR DESCRIPTION
Signed-off-by: nikolay <n.atanasow94@gmail.com>

**Description**:
Changes behaviour of `eth_getLogs` to add topics in the parameters passed to the mirror node, only if they exist and are not undefined or null.

**Related issue(s)**:

Fixes #711

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
