### PR TITLE
Issue490/postman testing addition

### DIFF
--- a/helm-chart/templates/cronjob.yaml
+++ b/helm-chart/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "json-rpc-relay.fullname" . }}-restart
+  name: {{ printf "%s-%s" (include "json-rpc-relay.name" .) "restart" | trimSuffix "-"| trunc 52 }}
   namespace: {{ .Release.Namespace }}
 spec:
   concurrencyPolicy: Forbid
@@ -31,7 +31,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "json-rpc-relay.fullname" . }}-test
+  name: {{ printf "%s-%s" (include "json-rpc-relay.name" .) "test" | trimSuffix "-"| trunc 52 }}
   namespace: {{ .Release.Namespace }}
 spec:
   concurrencyPolicy: Allow
@@ -43,12 +43,31 @@ spec:
         spec:
           serviceAccountName: {{ include "json-rpc-relay.serviceAccountName" . }}-test
           restartPolicy: Never
+          initContainers:
+            - name: curl-config
+              image: curlimages/curl
+              command: 
+                - curl
+                - https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/packages/server/tests/postman.json
+                - -o
+                - postman.json
+              volumeMounts:
+              - name: config-json
+                mountPath: "/"
           containers:
-            - name: kubectl
+            - name: newman
               image: postman/newman
               command: 
                 - newman
                 - run
-                - packages/server/tests/postman.json
-                - --env-var baseUrl={{ .Values.test.baseUrl }}
+                - postman.json
+                - --env-var 
+                - baseUrl={{ .Values.test.baseUrl | quote }}
+              volumeMounts:
+              - name: config-json
+                mountPath: "/"
+                readOnly: true
+          volumes:
+            - name: config-json
+              emptyDir: {}                          
 {{- end }}            

--- a/helm-chart/templates/cronjob.yaml
+++ b/helm-chart/templates/cronjob.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   concurrencyPolicy: Forbid
-  schedule: {{ .Values.rolling_restart.schedule  }}
+  schedule: {{ .Values.rolling_restart.schedule }}
   jobTemplate:
     spec:
       backoffLimit: 2
@@ -24,5 +24,31 @@ spec:
                 - >-
                   kubectl rollout restart deployment/{{ include "json-rpc-relay.fullname" . }} && 
                   kubectl rollout status deployment/{{ include "json-rpc-relay.fullname" . }}
-{{- end }}                
-            
+{{- end }}
+
+---
+{{- if .Values.test.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "json-rpc-relay.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  concurrencyPolicy: Allow
+  schedule: {{ .Values.test.schedule }}
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          serviceAccountName: {{ include "json-rpc-relay.serviceAccountName" . }}-test
+          restartPolicy: Never
+          containers:
+            - name: kubectl
+              image: postman/newman
+              command: 
+                - newman
+                - run
+                - packages/server/tests/postman.json
+                - --env-var baseUrl={{ .Values.test.baseUrl }}
+{{- end }}            

--- a/helm-chart/templates/cronjob.yaml
+++ b/helm-chart/templates/cronjob.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "json-rpc-relay.fullname" . }}
+  name: {{ include "json-rpc-relay.fullname" . }}-restart
   namespace: {{ .Release.Namespace }}
 spec:
   concurrencyPolicy: Forbid
@@ -31,7 +31,7 @@ spec:
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ include "json-rpc-relay.fullname" . }}
+  name: {{ include "json-rpc-relay.fullname" . }}-test
   namespace: {{ .Release.Namespace }}
 spec:
   concurrencyPolicy: Allow

--- a/helm-chart/templates/role.yaml
+++ b/helm-chart/templates/role.yaml
@@ -8,4 +8,5 @@ rules:
     resources: ["deployments"]
     resourceNames: [{{ include "json-rpc-relay.fullname" . }}]
     verbs: ["get", "list", "patch", "watch"]
-{{- end }}    
+{{- end }}
+

--- a/helm-chart/templates/serviceaccount.yaml
+++ b/helm-chart/templates/serviceaccount.yaml
@@ -25,3 +25,19 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+
+---
+{{- if .Values.test.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata: 
+  name: {{ include "json-rpc-relay.serviceAccountName" . }}-test
+  namespace: {{ .Release.Namespace }} 
+  labels:
+    {{- include "json-rpc-relay.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -125,3 +125,9 @@ config:
 rolling_restart:
   enabled: false
   schedule: '@daily'
+
+# Enable periodic tests of the hashio base URL
+test:
+  enabled: false
+  schedule: '@daily'
+  baseUrl: "http://127.0.0.1:7546"


### PR DESCRIPTION
**Description**:
<!--
This PR adds support for running a scheduled (cron) of the postman/newman test; because this utilized the k8s cronjob the ability to kickoff the job in an ad-hoc nature is also available.  The command to run an ad-hoc, one-off run is `kubectl create job --from=cronjob/$CRONJOB_TEST_NAME $MY_JOB_NAME`
-->

**Related issue(s)**:

Fixes #490 

**Notes for reviewer**:
Integration deployment output:
```
# Source: hedera-json-rpc-relay/templates/cronjob.yaml
apiVersion: batch/v1
kind: CronJob
metadata:
  name: hedera-json-rpc-relay-test
  namespace: default
spec:
  concurrencyPolicy: Allow
  schedule: 0 0 * * *
  jobTemplate:
    spec:
      backoffLimit: 2
      template:
        spec:
          serviceAccountName: integration-test-hashio-hedera-json-rpc-relay-test
          restartPolicy: Never
          initContainers:
            - name: curl-config
              image: curlimages/curl
              command:
                - curl
                - https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/packages/server/tests/postman.json
                - -o
                - postman.json
              volumeMounts:
              - name: config-json
                mountPath: "/"
          containers:
            - name: newman
              image: postman/newman
              command:
                - newman
                - run
                - postman.json
                - --env-var
                - baseUrl="https://hashio-integration.hedera-devops.com/api"
              volumeMounts:
              - name: config-json
                mountPath: "/"
                readOnly: true
          volumes:
            - name: config-json
              emptyDir: {}

```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
