### PR TITLE
Add custom error message for better traceability for multiple asserts

### DIFF
--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -37,14 +37,14 @@ export default class Assertions {
 
     static assertId = (id) => {
         const [shard, realm, num] = id.split('.');
-        expect(shard).to.not.be.null;
-        expect(realm).to.not.be.null;
-        expect(num).to.not.be.null;
+        expect(shard, 'Id shard should not be null').to.not.be.null;
+        expect(realm, 'Id realm should not be null').to.not.be.null;
+        expect(num, 'Id num should not be null').to.not.be.null;
     };
 
     static unsupportedResponse = (resp: any) => {
-        expect(resp.error.code).to.eq(-32601);
-        expect(resp.error.message.endsWith('Unsupported JSON-RPC method')).to.be.true;
+        expect(resp.error.code, 'Unsuported response.error.code should equal -32601').to.eq(-32601);
+        expect(resp.error.message.endsWith('Unsupported JSON-RPC method'), "Unsuported response.error.code should end with 'Unsupported JSON-RPC method'").to.be.true;
     };
 
     static expectedError = () => {
@@ -69,33 +69,33 @@ export default class Assertions {
             expect(Number(relayResponse.baseFeePerGas)).to.be.gt(0);
         }
 
-        expect(relayResponse.difficulty).to.be.equal(ethers.utils.hexValue(0));
-        expect(relayResponse.extraData).to.be.equal(Assertions.emptyHex);
-        expect(relayResponse.miner).to.be.equal(ethers.constants.AddressZero);
-        expect(relayResponse.mixHash).to.be.equal(Assertions.zeroHex32Byte);
-        expect(relayResponse.nonce).to.be.equal(Assertions.zeroHex8Byte);
-        expect(relayResponse.receiptsRoot).to.be.equal(Assertions.zeroHex32Byte);
-        expect(relayResponse.sha3Uncles).to.be.equal(Assertions.emptyArrayHex);
-        expect(relayResponse.stateRoot).to.be.equal(Assertions.zeroHex32Byte);
-        expect(relayResponse.totalDifficulty).to.be.equal(ethers.utils.hexValue(0));
-        expect(relayResponse.uncles).to.be.exist;
-        expect(relayResponse.uncles.length).to.eq(0);
-        expect(relayResponse.logsBloom).to.eq(Assertions.emptyBloom);
-        expect(relayResponse.gasLimit).to.equal(ethers.utils.hexValue(Assertions.maxBlockGasLimit));
+        expect(relayResponse.difficulty, "Assert block: 'dificulty' shuld equal zero in hex").to.be.equal(ethers.utils.hexValue(0));
+        expect(relayResponse.extraData, "Assert block: 'extraDta' shuld equal empty hex").to.be.equal(Assertions.emptyHex);
+        expect(relayResponse.miner, "Assert block: 'miner' shuld equal zero address").to.be.equal(ethers.constants.AddressZero);
+        expect(relayResponse.mixHash, "Assert block: 'mixHash' shuld equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
+        expect(relayResponse.nonce, "Assert block: 'nonce' shuld equal zero 8byte hex").to.be.equal(Assertions.zeroHex8Byte);
+        expect(relayResponse.receiptsRoot, "Assert block: 'receiptsRoot' shuld equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
+        expect(relayResponse.sha3Uncles, "Assert block: 'sha3Uncles' shuld equal empty array hex").to.be.equal(Assertions.emptyArrayHex);
+        expect(relayResponse.stateRoot, "Assert block: 'stateRoot' shuld equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
+        expect(relayResponse.totalDifficulty, "Assert block: 'totalDifficulty' shuld equal zero in hex").to.be.equal(ethers.utils.hexValue(0));
+        expect(relayResponse.uncles, "Assert block: 'uncles' property exists").to.be.exist;
+        expect(relayResponse.uncles.length, "Assert block: 'uncles' length shuld equal 0").to.eq(0);
+        expect(relayResponse.logsBloom, "Assert block: 'logsBloom' shuld equal emptyBloom").to.eq(Assertions.emptyBloom);
+        expect(relayResponse.gasLimit, "Assert block: 'gasLimit' shuld equal 'maxBlockGasLimit'").to.equal(ethers.utils.hexValue(Assertions.maxBlockGasLimit));
 
         // Assert dynamic values
-        expect(relayResponse.hash).to.be.equal(mirrorNodeResponse.hash.slice(0, 66));
-        expect(relayResponse.number).to.be.equal(ethers.utils.hexValue(mirrorNodeResponse.number));
-        expect(relayResponse.transactions.length).to.equal(mirrorTransactions.length);
-        expect(relayResponse.parentHash).to.equal(mirrorNodeResponse.previous_hash.slice(0, 66));
-        expect(relayResponse.size).to.equal(ethers.utils.hexValue(mirrorNodeResponse.size | 0));
-        expect(relayResponse.gasUsed).to.equal(ethers.utils.hexValue(mirrorNodeResponse.gas_used));
-        expect(relayResponse.timestamp).to.equal(ethers.utils.hexValue(Number(mirrorNodeResponse.timestamp.from.split('.')[0])));
+        expect(relayResponse.hash, "Assert block: 'hash' shuld equal mirrorNode response").to.be.equal(mirrorNodeResponse.hash.slice(0, 66));
+        expect(relayResponse.number, "Assert block: 'hash' shuld equal mirrorNode response").to.be.equal(ethers.utils.hexValue(mirrorNodeResponse.number));
+        expect(relayResponse.transactions.length, "Assert block: 'transactions' count shuld equal mirrorNode response").to.equal(mirrorTransactions.length);
+        expect(relayResponse.parentHash, "Assert block: 'parentHash' shuld equal mirrorNode response").to.equal(mirrorNodeResponse.previous_hash.slice(0, 66));
+        expect(relayResponse.size, "Assert block: 'size' shuld equal mirrorNode response").to.equal(ethers.utils.hexValue(mirrorNodeResponse.size | 0));
+        expect(relayResponse.gasUsed, "Assert block: 'gasUsed' shuld equal mirrorNode response").to.equal(ethers.utils.hexValue(mirrorNodeResponse.gas_used));
+        expect(relayResponse.timestamp, "Assert block: 'timestamp' shuld equal mirrorNode response").to.equal(ethers.utils.hexValue(Number(mirrorNodeResponse.timestamp.from.split('.')[0])));
         if (relayResponse.transactions.length) {
-            expect(relayResponse.transactionsRoot).to.equal(mirrorNodeResponse.hash.slice(0, 66));
+            expect(relayResponse.transactionsRoot, "Assert block: 'transactionsRoot' shuld equal mirrorNode response").to.equal(mirrorNodeResponse.hash.slice(0, 66));
         }
         else {
-            expect(relayResponse.transactionsRoot).to.equal(Assertions.ethEmptyTrie);
+            expect(relayResponse.transactionsRoot, "Assert block: 'transactionsRoot' shuld equal 'ethEmptyTrie'").to.equal(Assertions.ethEmptyTrie);
         }
 
         // Assert transactions
@@ -112,87 +112,87 @@ export default class Assertions {
     }
 
     public static transaction(relayResponse, mirrorNodeResponse) {
-        expect(relayResponse.blockHash).to.eq(mirrorNodeResponse.block_hash.slice(0, 66));
-        expect(relayResponse.blockNumber).to.eq(ethers.utils.hexValue(mirrorNodeResponse.block_number));
+        expect(relayResponse.blockHash, "Assert transaction: 'blockHash' should equal mirrorNode response").to.eq(mirrorNodeResponse.block_hash.slice(0, 66));
+        expect(relayResponse.blockNumber, "Assert transaction: 'blockNumber' should equal mirrorNode response").to.eq(ethers.utils.hexValue(mirrorNodeResponse.block_number));
         // expect(relayResponse.chainId).to.eq(mirrorNodeResponse.chain_id); // FIXME must not be null!
-        expect(relayResponse.from).to.eq(mirrorNodeResponse.from);
-        expect(relayResponse.gas).to.eq(ethers.utils.hexValue(mirrorNodeResponse.gas_used));
+        expect(relayResponse.from, "Assert transaction: 'from' should equal mirrorNode response").to.eq(mirrorNodeResponse.from);
+        expect(relayResponse.gas, "Assert transaction: 'gas' should equal mirrorNode response").to.eq(ethers.utils.hexValue(mirrorNodeResponse.gas_used));
         // expect(relayResponse.gasPrice).to.eq(mirrorNodeResponse.gas_price); // FIXME must not be null!
-        expect(relayResponse.hash).to.eq(mirrorNodeResponse.hash.slice(0, 66));
-        expect(relayResponse.input).to.eq(mirrorNodeResponse.function_parameters);
+        expect(relayResponse.hash, "Assert transaction: 'hash' should equal mirrorNode response").to.eq(mirrorNodeResponse.hash.slice(0, 66));
+        expect(relayResponse.input, "Assert transaction: 'input' should equal mirrorNode response").to.eq(mirrorNodeResponse.function_parameters);
         if (relayResponse.to || mirrorNodeResponse.to) {
-            expect(relayResponse.to).to.eq(mirrorNodeResponse.to);
+            expect(relayResponse.to, "Assert transaction: 'to' should equal mirrorNode response").to.eq(mirrorNodeResponse.to);
         }
-        expect(relayResponse.transactionIndex).to.eq(ethers.utils.hexValue(mirrorNodeResponse.transaction_index));
-        expect(relayResponse.value).to.eq(ethers.utils.hexValue(mirrorNodeResponse.amount));
+        expect(relayResponse.transactionIndex, "Assert transaction: 'transactionIndex' should equal mirrorNode response").to.eq(ethers.utils.hexValue(mirrorNodeResponse.transaction_index));
+        expect(relayResponse.value, "Assert transaction: 'value' should equal mirrorNode response").to.eq(ethers.utils.hexValue(mirrorNodeResponse.amount));
     }
 
     static transactionReceipt = (transactionReceipt, mirrorResult) => {
-        expect(transactionReceipt.blockHash).to.exist;
-        expect(transactionReceipt.blockHash).to.not.eq('0x0');
-        expect(transactionReceipt.blockHash).to.eq(mirrorResult.block_hash.slice(0, 66));
+        expect(transactionReceipt.blockHash, "Assert transactionReceipt: 'blockHash' should exists").to.exist;
+        expect(transactionReceipt.blockHash, "Assert transactionReceipt: 'blockHash' should not be 0x0").to.not.eq('0x0');
+        expect(transactionReceipt.blockHash, "Assert transactionReceipt: 'vablockHashlue' should equal mirrorNode response").to.eq(mirrorResult.block_hash.slice(0, 66));
 
-        expect(transactionReceipt.blockNumber).to.exist;
-        expect(Number(transactionReceipt.blockNumber)).to.gt(0);
-        expect(transactionReceipt.blockNumber).to.eq(ethers.utils.hexValue(mirrorResult.block_number));
+        expect(transactionReceipt.blockNumber, "Assert transactionReceipt: 'blockNumber' should exist").to.exist;
+        expect(Number(transactionReceipt.blockNumber), "Assert transactionReceipt: 'blockNumber' should be > 0").to.gt(0);
+        expect(transactionReceipt.blockNumber, "Assert transactionReceipt: 'blockNumber' should equal mirrorNode response").to.eq(ethers.utils.hexValue(mirrorResult.block_number));
 
-        expect(transactionReceipt.cumulativeGasUsed).to.exist;
-        expect(Number(transactionReceipt.cumulativeGasUsed)).to.gt(0);
-        expect(Number(transactionReceipt.cumulativeGasUsed)).to.eq(mirrorResult.block_gas_used);
+        expect(transactionReceipt.cumulativeGasUsed, "Assert transactionReceipt: 'cumulativeGasUsed' should exist").to.exist;
+        expect(Number(transactionReceipt.cumulativeGasUsed), "Assert transactionReceipt: 'cumulativeGasUsed' should be > 0").to.gt(0);
+        expect(Number(transactionReceipt.cumulativeGasUsed), "Assert transactionReceipt: 'cumulativeGasUsed' should equal mirrorNode response").to.eq(mirrorResult.block_gas_used);
 
-        expect(transactionReceipt.gasUsed).to.exist;
-        expect(Number(transactionReceipt.gasUsed)).to.gt(0);
-        expect(Number(transactionReceipt.gasUsed)).to.eq(mirrorResult.gas_used);
+        expect(transactionReceipt.gasUsed, "Assert transactionReceipt: 'gasUsed' should exist").to.exist;
+        expect(Number(transactionReceipt.gasUsed), "Assert transactionReceipt: 'gasUsed' should be > 0").to.gt(0);
+        expect(Number(transactionReceipt.gasUsed), "Assert transactionReceipt: 'gasUsed' should equal mirrorNode response").to.eq(mirrorResult.gas_used);
 
-        expect(transactionReceipt.logsBloom).to.exist;
-        expect(transactionReceipt.logsBloom).to.not.eq('0x0');
-        expect(transactionReceipt.logsBloom).to.eq(mirrorResult.bloom);
+        expect(transactionReceipt.logsBloom, "Assert transactionReceipt: 'logsBloom' should exist").to.exist;
+        expect(transactionReceipt.logsBloom, "Assert transactionReceipt: 'logsBloom' should not be 0x0").to.not.eq('0x0');
+        expect(transactionReceipt.logsBloom, "Assert transactionReceipt: 'logsBloom' should equal mirrorNode response").to.eq(mirrorResult.bloom);
 
-        expect(transactionReceipt.transactionHash).to.exist;
-        expect(transactionReceipt.transactionHash).to.not.eq('0x0');
-        expect(transactionReceipt.transactionHash).to.eq(mirrorResult.hash);
+        expect(transactionReceipt.transactionHash, "Assert transactionReceipt: 'transactionHash' should exist").to.exist;
+        expect(transactionReceipt.transactionHash, "Assert transactionReceipt: 'transactionHash' should equal mirrorNode response").to.not.eq('0x0');
+        expect(transactionReceipt.transactionHash, "Assert transactionReceipt: 'transactionHash' should equal mirrorNode response").to.eq(mirrorResult.hash);
 
-        expect(transactionReceipt.transactionIndex).to.exist;
-        expect(Number(transactionReceipt.transactionIndex)).to.eq(mirrorResult.transaction_index);
+        expect(transactionReceipt.transactionIndex, "Assert transactionReceipt: 'transactionIndex' should exist").to.exist;
+        expect(Number(transactionReceipt.transactionIndex), "Assert transactionReceipt: 'transactionIndex' should equal mirrorNode response").to.eq(mirrorResult.transaction_index);
 
-        expect(transactionReceipt.effectiveGasPrice).to.exist;
-        expect(Number(transactionReceipt.effectiveGasPrice)).to.gt(0);
+        expect(transactionReceipt.effectiveGasPrice, "Assert transactionReceipt: 'effectiveGasPrice' should exist").to.exist;
+        expect(Number(transactionReceipt.effectiveGasPrice), "Assert transactionReceipt: 'effectiveGasPrice' should be > 0").to.gt(0);
         const effectiveGas = mirrorResult.max_fee_per_gas === undefined || mirrorResult.max_fee_per_gas == '0x'
             ? mirrorResult.gas_price
             : mirrorResult.max_fee_per_gas;
         const mirrorEffectiveGasPrice = Utils.tinyBarsToWeibars(effectiveGas);
-        expect(BigNumber.from(transactionReceipt.effectiveGasPrice).toString()).to.eq(mirrorEffectiveGasPrice.toString());
+        expect(BigNumber.from(transactionReceipt.effectiveGasPrice).toString(), "Assert transactionReceipt: 'effectiveGasPrice' should equal mirrorNode response").to.eq(mirrorEffectiveGasPrice.toString());
 
-        expect(transactionReceipt.status).to.exist;
-        expect(transactionReceipt.status).to.eq(mirrorResult.status);
+        expect(transactionReceipt.status, "Assert transactionReceipt: 'status' should exist").to.exist;
+        expect(transactionReceipt.status, "Assert transactionReceipt: 'status' should equal mirrorNode response").to.eq(mirrorResult.status);
 
-        expect(transactionReceipt.logs).to.exist;
-        expect(transactionReceipt.logs.length).to.eq(mirrorResult.logs.length);
-        expect(transactionReceipt.logs).to.deep.eq(mirrorResult.logs);
+        expect(transactionReceipt.logs, "Assert transactionReceipt: 'logs' should exist").to.exist;
+        expect(transactionReceipt.logs.length, "Assert transactionReceipt: 'logs' count should equal to mirrorNode response").to.eq(mirrorResult.logs.length);
+        expect(transactionReceipt.logs, "Assert transactionReceipt: 'logs' should equal mirrorNode response").to.deep.eq(mirrorResult.logs);
 
-        expect(transactionReceipt.from).to.eq(mirrorResult.from);
+        expect(transactionReceipt.from, "Assert transactionReceipt: 'from' should equal mirrorNode response").to.eq(mirrorResult.from);
 
-        expect(transactionReceipt.to).to.eq(mirrorResult.to);
+        expect(transactionReceipt.to, "Assert transactionReceipt: 'to' should equal mirrorNode response").to.eq(mirrorResult.to);
     };
 
     public static feeHistory(res: any, expected: any) {
-        expect(res.baseFeePerGas).to.exist.to.be.an('Array');
-        expect(res.gasUsedRatio).to.exist.to.be.an('Array');
-        expect(res.oldestBlock).to.exist;
-        expect(res.baseFeePerGas.length).to.equal(expected.resultCount + 1);
-        expect(res.gasUsedRatio.length).to.equal(expected.resultCount);
+        expect(res.baseFeePerGas, "Assert feeHistory: 'baseFeePerGas' should exist and be an Array").to.exist.to.be.an('Array');
+        expect(res.gasUsedRatio, "Assert feeHistory: 'gasUsedRatio' should exist and be an Array").to.exist.to.be.an('Array');
+        expect(res.oldestBlock, "Assert feeHistory: 'oldestBlock' should exist").to.exist;
+        expect(res.baseFeePerGas.length, "Assert feeHistory: 'baseFeePerGas' length should equal passed expected value").to.equal(expected.expected + 1);
+        expect(res.gasUsedRatio.length, "Assert feeHistory: 'gasUsedRatio' length should equal passed expected value").to.equal(expected.resultCount);
 
-        expect(res.oldestBlock).to.equal(expected.oldestBlock);
+        expect(res.oldestBlock, "Assert feeHistory: 'oldestBlock' should equal passed expected value").to.equal(expected.oldestBlock);
 
-        res.gasUsedRatio.map((gasRatio: string) => expect(gasRatio).to.equal(`0x${Assertions.defaultGasUsed.toString(16)}`))
+        res.gasUsedRatio.map((gasRatio: string) => expect(gasRatio, "Assert feeHistory: 'gasRatio' should equal 'defaultGasUsed'").to.equal(`0x${Assertions.defaultGasUsed.toString(16)}`));
 
         if (expected.checkReward) {
-            expect(res.reward).to.exist.to.be.an('Array');
-            expect(res.reward.length).to.equal(expected.resultCount);
+            expect(res.reward, "Assert feeHistory: 'reward' should exist and be an Array").to.exist.to.be.an('Array');
+            expect(res.reward.length, "Assert feeHistory: 'reward' length should equal passed expected value").to.equal(expected.resultCount);
         }
     }
 
-    static unknownResponse(err) {
+    static unknownResponse(err: any) {
         Assertions.jsonRpcError(err, predefined.INTERNAL_ERROR());
     }
 

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -43,8 +43,8 @@ export default class Assertions {
     };
 
     static unsupportedResponse = (resp: any) => {
-        expect(resp.error.code, 'Unsuported response.error.code should equal -32601').to.eq(-32601);
-        expect(resp.error.message.endsWith('Unsupported JSON-RPC method'), "Unsuported response.error.code should end with 'Unsupported JSON-RPC method'").to.be.true;
+        expect(resp.error.code, 'Unsupported response.error.code should equal -32601').to.eq(-32601);
+        expect(resp.error.message.endsWith('Unsupported JSON-RPC method'), "Unsupported response.error.code should end with 'Unsupported JSON-RPC method'").to.be.true;
     };
 
     static expectedError = () => {
@@ -69,33 +69,33 @@ export default class Assertions {
             expect(Number(relayResponse.baseFeePerGas)).to.be.gt(0);
         }
 
-        expect(relayResponse.difficulty, "Assert block: 'dificulty' shuld equal zero in hex").to.be.equal(ethers.utils.hexValue(0));
-        expect(relayResponse.extraData, "Assert block: 'extraDta' shuld equal empty hex").to.be.equal(Assertions.emptyHex);
-        expect(relayResponse.miner, "Assert block: 'miner' shuld equal zero address").to.be.equal(ethers.constants.AddressZero);
-        expect(relayResponse.mixHash, "Assert block: 'mixHash' shuld equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
-        expect(relayResponse.nonce, "Assert block: 'nonce' shuld equal zero 8byte hex").to.be.equal(Assertions.zeroHex8Byte);
-        expect(relayResponse.receiptsRoot, "Assert block: 'receiptsRoot' shuld equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
-        expect(relayResponse.sha3Uncles, "Assert block: 'sha3Uncles' shuld equal empty array hex").to.be.equal(Assertions.emptyArrayHex);
-        expect(relayResponse.stateRoot, "Assert block: 'stateRoot' shuld equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
-        expect(relayResponse.totalDifficulty, "Assert block: 'totalDifficulty' shuld equal zero in hex").to.be.equal(ethers.utils.hexValue(0));
+        expect(relayResponse.difficulty, "Assert block: 'difficulty' should equal zero in hex").to.be.equal(ethers.utils.hexValue(0));
+        expect(relayResponse.extraData, "Assert block: 'extraDta' should equal empty hex").to.be.equal(Assertions.emptyHex);
+        expect(relayResponse.miner, "Assert block: 'miner' should equal zero address").to.be.equal(ethers.constants.AddressZero);
+        expect(relayResponse.mixHash, "Assert block: 'mixHash' should equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
+        expect(relayResponse.nonce, "Assert block: 'nonce' should equal zero 8byte hex").to.be.equal(Assertions.zeroHex8Byte);
+        expect(relayResponse.receiptsRoot, "Assert block: 'receiptsRoot' should equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
+        expect(relayResponse.sha3Uncles, "Assert block: 'sha3Uncles' should equal empty array hex").to.be.equal(Assertions.emptyArrayHex);
+        expect(relayResponse.stateRoot, "Assert block: 'stateRoot' should equal zero 32bytes hex").to.be.equal(Assertions.zeroHex32Byte);
+        expect(relayResponse.totalDifficulty, "Assert block: 'totalDifficulty' should equal zero in hex").to.be.equal(ethers.utils.hexValue(0));
         expect(relayResponse.uncles, "Assert block: 'uncles' property exists").to.be.exist;
-        expect(relayResponse.uncles.length, "Assert block: 'uncles' length shuld equal 0").to.eq(0);
-        expect(relayResponse.logsBloom, "Assert block: 'logsBloom' shuld equal emptyBloom").to.eq(Assertions.emptyBloom);
-        expect(relayResponse.gasLimit, "Assert block: 'gasLimit' shuld equal 'maxBlockGasLimit'").to.equal(ethers.utils.hexValue(Assertions.maxBlockGasLimit));
+        expect(relayResponse.uncles.length, "Assert block: 'uncles' length should equal 0").to.eq(0);
+        expect(relayResponse.logsBloom, "Assert block: 'logsBloom' should equal emptyBloom").to.eq(Assertions.emptyBloom);
+        expect(relayResponse.gasLimit, "Assert block: 'gasLimit' should equal 'maxBlockGasLimit'").to.equal(ethers.utils.hexValue(Assertions.maxBlockGasLimit));
 
         // Assert dynamic values
-        expect(relayResponse.hash, "Assert block: 'hash' shuld equal mirrorNode response").to.be.equal(mirrorNodeResponse.hash.slice(0, 66));
-        expect(relayResponse.number, "Assert block: 'hash' shuld equal mirrorNode response").to.be.equal(ethers.utils.hexValue(mirrorNodeResponse.number));
-        expect(relayResponse.transactions.length, "Assert block: 'transactions' count shuld equal mirrorNode response").to.equal(mirrorTransactions.length);
-        expect(relayResponse.parentHash, "Assert block: 'parentHash' shuld equal mirrorNode response").to.equal(mirrorNodeResponse.previous_hash.slice(0, 66));
-        expect(relayResponse.size, "Assert block: 'size' shuld equal mirrorNode response").to.equal(ethers.utils.hexValue(mirrorNodeResponse.size | 0));
-        expect(relayResponse.gasUsed, "Assert block: 'gasUsed' shuld equal mirrorNode response").to.equal(ethers.utils.hexValue(mirrorNodeResponse.gas_used));
-        expect(relayResponse.timestamp, "Assert block: 'timestamp' shuld equal mirrorNode response").to.equal(ethers.utils.hexValue(Number(mirrorNodeResponse.timestamp.from.split('.')[0])));
+        expect(relayResponse.hash, "Assert block: 'hash' should equal mirrorNode response").to.be.equal(mirrorNodeResponse.hash.slice(0, 66));
+        expect(relayResponse.number, "Assert block: 'hash' should equal mirrorNode response").to.be.equal(ethers.utils.hexValue(mirrorNodeResponse.number));
+        expect(relayResponse.transactions.length, "Assert block: 'transactions' count should equal mirrorNode response").to.equal(mirrorTransactions.length);
+        expect(relayResponse.parentHash, "Assert block: 'parentHash' should equal mirrorNode response").to.equal(mirrorNodeResponse.previous_hash.slice(0, 66));
+        expect(relayResponse.size, "Assert block: 'size' should equal mirrorNode response").to.equal(ethers.utils.hexValue(mirrorNodeResponse.size | 0));
+        expect(relayResponse.gasUsed, "Assert block: 'gasUsed' should equal mirrorNode response").to.equal(ethers.utils.hexValue(mirrorNodeResponse.gas_used));
+        expect(relayResponse.timestamp, "Assert block: 'timestamp' should equal mirrorNode response").to.equal(ethers.utils.hexValue(Number(mirrorNodeResponse.timestamp.from.split('.')[0])));
         if (relayResponse.transactions.length) {
-            expect(relayResponse.transactionsRoot, "Assert block: 'transactionsRoot' shuld equal mirrorNode response").to.equal(mirrorNodeResponse.hash.slice(0, 66));
+            expect(relayResponse.transactionsRoot, "Assert block: 'transactionsRoot' should equal mirrorNode response").to.equal(mirrorNodeResponse.hash.slice(0, 66));
         }
         else {
-            expect(relayResponse.transactionsRoot, "Assert block: 'transactionsRoot' shuld equal 'ethEmptyTrie'").to.equal(Assertions.ethEmptyTrie);
+            expect(relayResponse.transactionsRoot, "Assert block: 'transactionsRoot' should equal 'ethEmptyTrie'").to.equal(Assertions.ethEmptyTrie);
         }
 
         // Assert transactions
@@ -179,7 +179,7 @@ export default class Assertions {
         expect(res.baseFeePerGas, "Assert feeHistory: 'baseFeePerGas' should exist and be an Array").to.exist.to.be.an('Array');
         expect(res.gasUsedRatio, "Assert feeHistory: 'gasUsedRatio' should exist and be an Array").to.exist.to.be.an('Array');
         expect(res.oldestBlock, "Assert feeHistory: 'oldestBlock' should exist").to.exist;
-        expect(res.baseFeePerGas.length, "Assert feeHistory: 'baseFeePerGas' length should equal passed expected value").to.equal(expected.expected + 1);
+        expect(res.baseFeePerGas.length, "Assert feeHistory: 'baseFeePerGas' length should equal passed expected value").to.equal(expected.resultCount + 1);
         expect(res.gasUsedRatio.length, "Assert feeHistory: 'gasUsedRatio' length should equal passed expected value").to.equal(expected.resultCount);
 
         expect(res.oldestBlock, "Assert feeHistory: 'oldestBlock' should equal passed expected value").to.equal(expected.oldestBlock);

--- a/packages/server/tests/helpers/nodeCheck.ts
+++ b/packages/server/tests/helpers/nodeCheck.ts
@@ -7,7 +7,7 @@ const net = require("net");
     const isLocalNode = !supportedEnvs.includes(network.toLowerCase());
     if (isLocalNode) {
         let nodeStarted = false;
-        let retries = 10;
+        const retries = 10;
         while (!nodeStarted && retries >= 0) {
             net
             .createConnection('5600', '127.0.0.1')

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -344,28 +344,28 @@ class BaseTest {
   }
 
   static defaultResponseChecks(response) {
-    expect(response).to.have.property('data');
-    expect(response.data).to.have.property('id');
-    expect(response.data).to.have.property('jsonrpc');
-    expect(response.data).to.have.property('result');
-    expect(response.data.id).to.be.equal('2');
-    expect(response.data.jsonrpc).to.be.equal('2.0');
+    expect(response, "Default response: Should have 'data' property").to.have.property('data');
+    expect(response.data, "Default response: 'data' should have 'id' property").to.have.property('id');
+    expect(response.data, "Default response: 'data' should have 'jsonrpc' property").to.have.property('jsonrpc');
+    expect(response.data, "Default response: 'data' should have 'result' property").to.have.property('result');
+    expect(response.data.id, "Default response: 'data.id' should equal '2'").to.be.equal('2');
+    expect(response.data.jsonrpc, "Default response: 'data.jsonrpc' should equal '2.0'").to.be.equal('2.0');
   }
 
   static errorResponseChecks(response, code, message, name?) {
-    expect(response).to.have.property('data');
-    expect(response.data).to.have.property('id');
-    expect(response.data).to.have.property('jsonrpc');
-    expect(response.data.id).to.be.equal('2');
-    expect(response.data.jsonrpc).to.be.equal('2.0');
-    expect(response.data).to.have.property('error');
-    expect(response.data.error).to.have.property('code');
-    expect(response.data.error.code).to.be.equal(code);
-    expect(response.data.error).to.have.property('message');
-    expect(response.data.error.message.endsWith(message)).to.be.true;
+    expect(response, "Error response: should have 'data' property").to.have.property('data');
+    expect(response.data, "Error response: 'data' should have 'id' property").to.have.property('id');
+    expect(response.data, "Error response: 'data' should have 'jsonrpc' property").to.have.property('jsonrpc');
+    expect(response.data.id, "Error response: 'data.id' should equal '2'").to.be.equal('2');
+    expect(response.data.jsonrpc, "Error response: 'data.jsonrpc' should equal '2.0'").to.be.equal('2.0');
+    expect(response.data, "Error response: 'data' should have 'error' property").to.have.property('error');
+    expect(response.data.error, "Error response: 'data.error' should have 'code' property").to.have.property('code');
+    expect(response.data.error.code, "Error response: 'data.error.code' should equal passed 'code' value").to.be.equal(code);
+    expect(response.data.error, "Error response: 'error' should have 'message' property").to.have.property('message');
+    expect(response.data.error.message.endsWith(message), "Error response: 'data.error.message' should end with passed 'message' value").to.be.true;
     if (name) {
-      expect(response.data.error).to.have.property('name');
-      expect(response.data.error.name).to.be.equal(name);
+      expect(response.data.error, "Error response: 'data.error' should have 'name' property").to.have.property('name');
+      expect(response.data.error.name, "Error response: 'data.error.name' should match passed 'name' value").to.be.equal(name);
     }
   }
 

--- a/tools/subgraph-example/README.md
+++ b/tools/subgraph-example/README.md
@@ -115,7 +115,7 @@ The easiest way to run a local `graph-node` against `testnet`, `previewnet` or `
 2. Replace `'mainnet:http://host.docker.internal:8545'` on [this](https://github.com/graphprotocol/graph-node/blob/master/docker/docker-compose.yml#L22) line with:
      1. `'mainnet:https://mainnet.hashio.io/api'` for `mainnet`
      2.  `'testnet:https://testnet.hashio.io/api'` for `testnet`
-     3.  `'previewnet:https://previewnet.hashio.io/api'` for `testnet`
+     3.  `'previewnet:https://previewnet.hashio.io/api'` for `previewnet`
 3. In the `subgraph.yaml` file change the dataSources network with to the network you want to index. Also don't forget to update the address (and the startBlock).
 
 Advanced info on how to set up an indexer could be found in [The Graph Docs](https://thegraph.com/docs/en/indexing/operating-graph-node/) and the [official graph-node GitHub repository](https://github.com/graphprotocol/graph-node)


### PR DESCRIPTION
Signed-off-by: Maksim Dimitrov <dimitrov.maksim@gmail.com>

**Description**:
Adds custom messages in cases with multiple expect/asserts for better traceability

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/774

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
