### PR TITLE
Return appropriate http codes

### DIFF
--- a/packages/server/src/koaJsonRpc/lib/RpcResponse.ts
+++ b/packages/server/src/koaJsonRpc/lib/RpcResponse.ts
@@ -19,7 +19,8 @@
  */
 
 export default function jsonResp(id, error, result) {
-  const o: any = {};
+  const response: any = {};
+
   if (error && result) {
     throw new Error('Mutually exclusive error and result exist');
   }
@@ -29,7 +30,7 @@ export default function jsonResp(id, error, result) {
   }
 
   if (typeof result !== 'undefined') {
-    o.result = result;
+    response.result = result;
   } else if (error) {
     if (typeof error.code !== 'number') {
       throw new TypeError(`Invalid error code type ${typeof error.code}`);
@@ -39,12 +40,12 @@ export default function jsonResp(id, error, result) {
       throw new TypeError(`Invalid error message type ${typeof error.message}`);
     }
 
-    o.error = error;
+    response.error = error;
   } else {
     throw new Error('Missing result or error');
   }
 
-  o.jsonrpc = '2.0';
-  o.id = id;
-  return o;
+  response.jsonrpc = '2.0';
+  response.id = id;
+  return response;
 }

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -74,12 +74,12 @@ export default class RelayClient {
     async callUnsupported(methodName: string, params: any[], requestId?: string) {
         const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
         try {
-            const res = await this.call(methodName, params, requestId);
-            this.logger.trace(`${requestIdPrefix} [POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`);
-            Assertions.expectedError();
+            await this.call(methodName, params, requestId);
         } catch (err) {
-            Assertions.unsupportedResponse(err);
-            return err;
+            this.logger.trace(`${requestIdPrefix} [POST] to relay '${methodName}' with params [${params}] returned ${err.body}`);
+            const response = JSON.parse(err.body);
+            Assertions.unsupportedResponse(response);
+            return response;
         }
     };
 
@@ -122,7 +122,7 @@ export default class RelayClient {
 
     /**
      * @param requestId
-     * 
+     *
      * Returns the result of eth_gasPrice as a Number.
      */
     async gasPrice(requestId?: string): Promise<number> {

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -14,12 +14,12 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
     process.env['NETWORK_NODE_IMAGE_TAG'] = '0.32.0';
     process.env['HAVEGED_IMAGE_TAG'] = '0.32.0';
     process.env['MIRROR_IMAGE_TAG'] = '0.70.1';
-    
+
     console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
-    
+
     console.log('Installing local node...');
     shell.exec(`npm install @hashgraph/hedera-local -g`);
-  
+
     console.log('Starting local node...');
     shell.exec(`hedera start -d`);
     console.log('Hedera Hashgraph local node env started');

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -197,124 +197,146 @@ describe('RPC Server', async function() {
   });
 
   it('should execute "web3_sha"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'web3_sha',
-      'params': [null]
-    });
-
-    BaseTest.methodNotFoundCheck(res);
+    try{
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'web3_sha',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.methodNotFoundCheck(error.response);
+    }
   });
 
   it('should execute "net_peerCount"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'net_peerCount',
-      'params': [null]
-    });
-
-    BaseTest.methodNotFoundCheck(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'net_peerCount',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.methodNotFoundCheck(error.response);
+    }
   });
 
   it('should execute "eth_submitHashrate"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_submitHashrate',
-      'params': [null]
-    });
-
-    BaseTest.unsupportedJsonRpcMethodChecks(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_submitHashrate',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.unsupportedJsonRpcMethodChecks(error.response);
+    }
   });
 
   it('should execute "eth_signTypedData"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_signTypedData',
-      'params': [null]
-    });
-
-    BaseTest.methodNotFoundCheck(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_signTypedData',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.methodNotFoundCheck(error.response);
+    }
   });
 
   it('should execute "eth_signTransaction"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_signTransaction',
-      'params': [null]
-    });
-
-    BaseTest.unsupportedJsonRpcMethodChecks(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_signTransaction',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.unsupportedJsonRpcMethodChecks(error.response);
+    }
   });
 
   it('should execute "eth_sign"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_sign',
-      'params': [null]
-    });
-
-    BaseTest.unsupportedJsonRpcMethodChecks(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_sign',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.unsupportedJsonRpcMethodChecks(error.response);
+    }
   });
 
   it('should execute "eth_sendTransaction"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_sendTransaction',
-      'params': [null]
-    });
-
-    BaseTest.unsupportedJsonRpcMethodChecks(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_sendTransaction',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.unsupportedJsonRpcMethodChecks(error.response);
+    }
   });
 
   it('should execute "eth_protocolVersion"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_protocolVersion',
-      'params': [null]
-    });
-
-    BaseTest.unsupportedJsonRpcMethodChecks(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_protocolVersion',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.unsupportedJsonRpcMethodChecks(error.response);
+    }
   });
 
   it('should execute "eth_getProof"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_getProof',
-      'params': [null]
-    });
-
-    BaseTest.methodNotFoundCheck(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_getProof',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.methodNotFoundCheck(error.response);
+    }
   });
 
   it('should execute "eth_coinbase"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_coinbase',
-      'params': [null]
-    });
-
-    BaseTest.unsupportedJsonRpcMethodChecks(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_coinbase',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.unsupportedJsonRpcMethodChecks(error.response);
+    }
   });
 
   it('should execute "eth_getWork"', async function() {
-    const res = await this.testClient.post('/', {
-      'id': '2',
-      'jsonrpc': '2.0',
-      'method': 'eth_getWork',
-      'params': [null]
-    });
-
-    BaseTest.unsupportedJsonRpcMethodChecks(res);
+    try {
+      await this.testClient.post('/', {
+        'id': '2',
+        'jsonrpc': '2.0',
+        'method': 'eth_getWork',
+        'params': [null]
+      });
+    } catch (error) {
+      BaseTest.unsupportedJsonRpcMethodChecks(error.response);
+    }
   });
 
   it('should execute "eth_maxPriorityFeePerGas"', async function() {
@@ -370,10 +392,14 @@ class BaseTest {
   }
 
   static unsupportedJsonRpcMethodChecks(response) {
+    expect(response.status).to.eq(400);
+    expect(response.statusText).to.eq('Bad Request');
     this.errorResponseChecks(response, -32601, 'Unsupported JSON-RPC method');
   }
 
   static methodNotFoundCheck(response) {
+    expect(response.status).to.eq(400);
+    expect(response.statusText).to.eq('Bad Request');
     this.errorResponseChecks(response, -32601, 'Method not found');
   }
 }


### PR DESCRIPTION
**Description**:

Currently we return 200 status code in most cases. This PR updates the relay to return the appropriate codes:

InternalError => 500
InvalidParams (JsonRpc request params) => 400
MethodNotFound or UnsupportedMethod => 400
RateLimit => 429
JsonRpcError =>  500 for InternalError, 400 for the rest


**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/751

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
