### PR TITLE
Expand `eth_call` validation to support blockParam object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5054,11 +5054,11 @@
             }
         },
         "node_modules/@hashgraph/cryptography": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.1.tgz",
-            "integrity": "sha512-Qx7fl58Upyf1C4Xdqo2DdMaELYAni3RpAr6fVux3tpGUwp0Wo+zaWseW7k2Klg+FPlmjOjL8XBCXkOr1AbHYWQ==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.2.tgz",
+            "integrity": "sha512-9p9wZvB7JQ7sgcllVHOQb8qxVvkYVfH4TjDsNiy/V38WOXNdf9L8CMd/A3zFP+eXm9jtrybqxmtLZHVO2XZ2lA==",
             "dependencies": {
-                "bignumber.js": "^9.0.2",
+                "bignumber.js": "^9.1.0",
                 "crypto-js": "^4.1.1",
                 "elliptic": "^6.5.4",
                 "js-base64": "^3.7.2",
@@ -5150,13 +5150,13 @@
             }
         },
         "node_modules/@hashgraph/sdk": {
-            "version": "2.19.1",
-            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.19.1.tgz",
-            "integrity": "sha512-Mn/o5gEUR/modcd7AfnGjHnEULXb7LYl49pSbSgWyE+HC0wnnPCXcQmThLvul4o2gMFKu2UCTxRiL976GQaQtg==",
+            "version": "2.19.2",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.19.2.tgz",
+            "integrity": "sha512-cFS+kCukk2Y8ZyjX5XZBLMylXRyWbghkpIGDKNHQdpU3JJ7Xbp/r23hOxn4aQnz6jbO1GSH5447gCQHkfIENoQ==",
             "dependencies": {
                 "@ethersproject/rlp": "^5.7.0",
                 "@grpc/grpc-js": "^1.7.0",
-                "@hashgraph/cryptography": "^1.4.1",
+                "@hashgraph/cryptography": "^1.4.2",
                 "@hashgraph/proto": "2.11.0",
                 "axios": "^0.27.2",
                 "bignumber.js": "^9.1.0",
@@ -15732,9 +15732,9 @@
             }
         },
         "node_modules/js-base64": {
-            "version": "3.7.3",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.3.tgz",
-            "integrity": "sha512-PAr6Xg2jvd7MCR6Ld9Jg3BmTcjYsHEBx1VlwEwULb/qowPf5VD9kEMagj23Gm7JRnSvE/Da/57nChZjnvL8v6A=="
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.4.tgz",
+            "integrity": "sha512-wpM/wi20Tl+3ifTyi0RdDckS4YTD4Lf953mBRrpG8547T7hInHNPEj8+ck4gB8VDcGyeAWFK++Wb/fU1BeavKQ=="
         },
         "node_modules/js-logger": {
             "version": "1.6.1",
@@ -22869,7 +22869,7 @@
             },
             "devDependencies": {
                 "@hashgraph/hedera-local": "^2.4.3",
-                "@hashgraph/sdk": "^2.19.0",
+                "@hashgraph/sdk": "^2.19.2",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
                 "@types/cors": "^2.8.12",
@@ -26105,11 +26105,11 @@
             }
         },
         "@hashgraph/cryptography": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.1.tgz",
-            "integrity": "sha512-Qx7fl58Upyf1C4Xdqo2DdMaELYAni3RpAr6fVux3tpGUwp0Wo+zaWseW7k2Klg+FPlmjOjL8XBCXkOr1AbHYWQ==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.2.tgz",
+            "integrity": "sha512-9p9wZvB7JQ7sgcllVHOQb8qxVvkYVfH4TjDsNiy/V38WOXNdf9L8CMd/A3zFP+eXm9jtrybqxmtLZHVO2XZ2lA==",
             "requires": {
-                "bignumber.js": "^9.0.2",
+                "bignumber.js": "^9.1.0",
                 "crypto-js": "^4.1.1",
                 "elliptic": "^6.5.4",
                 "js-base64": "^3.7.2",
@@ -26218,7 +26218,7 @@
             "requires": {
                 "@hashgraph/hedera-local": "^2.4.3",
                 "@hashgraph/json-rpc-relay": "file:../relay",
-                "@hashgraph/sdk": "^2.19.0",
+                "@hashgraph/sdk": "^2.19.2",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
                 "@types/cors": "^2.8.12",
@@ -26301,13 +26301,13 @@
             }
         },
         "@hashgraph/sdk": {
-            "version": "2.19.1",
-            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.19.1.tgz",
-            "integrity": "sha512-Mn/o5gEUR/modcd7AfnGjHnEULXb7LYl49pSbSgWyE+HC0wnnPCXcQmThLvul4o2gMFKu2UCTxRiL976GQaQtg==",
+            "version": "2.19.2",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.19.2.tgz",
+            "integrity": "sha512-cFS+kCukk2Y8ZyjX5XZBLMylXRyWbghkpIGDKNHQdpU3JJ7Xbp/r23hOxn4aQnz6jbO1GSH5447gCQHkfIENoQ==",
             "requires": {
                 "@ethersproject/rlp": "^5.7.0",
                 "@grpc/grpc-js": "^1.7.0",
-                "@hashgraph/cryptography": "^1.4.1",
+                "@hashgraph/cryptography": "^1.4.2",
                 "@hashgraph/proto": "2.11.0",
                 "axios": "^0.27.2",
                 "bignumber.js": "^9.1.0",
@@ -34175,9 +34175,9 @@
             "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
         },
         "js-base64": {
-            "version": "3.7.3",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.3.tgz",
-            "integrity": "sha512-PAr6Xg2jvd7MCR6Ld9Jg3BmTcjYsHEBx1VlwEwULb/qowPf5VD9kEMagj23Gm7JRnSvE/Da/57nChZjnvL8v6A=="
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.4.tgz",
+            "integrity": "sha512-wpM/wi20Tl+3ifTyi0RdDckS4YTD4Lf953mBRrpG8547T7hInHNPEj8+ck4gB8VDcGyeAWFK++Wb/fU1BeavKQ=="
         },
         "js-logger": {
             "version": "1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "root",
             "dependencies": {
-                "@hashgraph/hedera-local": "^2.4.1",
+                "@hashgraph/hedera-local": "^2.4.3",
                 "@open-rpc/schema-utils-js": "^1.16.1",
                 "@types/find-config": "^1.0.1",
                 "keyv-file": "^0.2.0",
@@ -5086,11 +5086,11 @@
             }
         },
         "node_modules/@hashgraph/hedera-local": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.4.1.tgz",
-            "integrity": "sha512-wgajOITLGumCvMEugBzYvk+IwsLZm1hziB0UPlChLvNNrRA7mQkywtP4h59ZGqBN4Ze2jZNDIRpCudcRSK5TAQ==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.4.3.tgz",
+            "integrity": "sha512-iinpXa74J+rL3/AfYGhmvIEEnr8yHyhQdBCH2ZhJAc8Fr8FMjrzHdKKb1ovBxSyfDFKUu5dBoUzUSPwEvI9yQQ==",
             "dependencies": {
-                "@hashgraph/hethers": "^1.2.2",
+                "@hashgraph/hethers": "^1.2.4",
                 "@hashgraph/sdk": "^2.19.0",
                 "blessed": "^0.1.81",
                 "blessed-contrib": "^4.11.0",
@@ -5108,25 +5108,25 @@
             }
         },
         "node_modules/@hashgraph/hethers": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hethers/-/hethers-1.2.3.tgz",
-            "integrity": "sha512-/bDdEiAXMZZhKZJka/0a8kI+yx6kVEA8l9ii4wpI+J0/utzjTrPRhDISKcf7zc5T/gJgNA5QB+5smsr+WmgPlw==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@hashgraph/hethers/-/hethers-1.2.5.tgz",
+            "integrity": "sha512-wXzx8FMPZaJ8nILmnEDZ7hF+cmPTuTQUt0gZzXwwGi0f+bTro9BpItlYOu2qUNwLk32jluqbP5Fbf6igI04wLQ==",
             "dependencies": {
                 "@ethersproject/solidity": "5.5.0",
                 "@hethers/abstract-provider": "1.2.1",
-                "@hethers/abstract-signer": "1.2.2",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
                 "@hethers/constants": "1.2.0",
-                "@hethers/contracts": "1.2.1",
-                "@hethers/hdnode": "1.2.1",
-                "@hethers/json-wallets": "1.2.1",
+                "@hethers/contracts": "1.2.3",
+                "@hethers/hdnode": "1.2.2",
+                "@hethers/json-wallets": "1.2.2",
                 "@hethers/logger": "1.2.0",
                 "@hethers/networks": "1.2.0",
-                "@hethers/providers": "1.2.2",
+                "@hethers/providers": "1.2.3",
                 "@hethers/signing-key": "1.2.0",
                 "@hethers/transactions": "1.2.2",
                 "@hethers/units": "1.2.0",
-                "@hethers/wallet": "1.2.2"
+                "@hethers/wallet": "1.2.3"
             }
         },
         "node_modules/@hashgraph/json-rpc-relay": {
@@ -5246,9 +5246,9 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/@hethers/abstract-signer": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.2.tgz",
-            "integrity": "sha512-WsHdNnUbjqU9/6GIC/p7tyctMvgbo+Yd8n7L/9RoNYHwbGXAodWBHN7okZ3lcxB9FajCx7KmErgCu93ZIU2cuA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.3.tgz",
+            "integrity": "sha512-BPgvptjw3QPKmrlmG8o4v7QlLqqIKKR4zAvqZgPUX62unlcFcW2bSjoKx6SF/pB4Ylc1TW52t2p/OhN4J9wzLw==",
             "dependencies": {
                 "@ethersproject/bignumber": "5.5.0",
                 "@ethersproject/bytes": "5.5.0",
@@ -5412,38 +5412,20 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/@hethers/contracts": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/contracts/-/contracts-1.2.1.tgz",
-            "integrity": "sha512-K0ReJYt6d6r6biMIgPY9ldGeBA9ypvRbynY9pRIZvEKgUfbR/AyxJDY2vFiukHsG14evp6oXGJSdZjKQtXkz6w==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@hethers/contracts/-/contracts-1.2.3.tgz",
+            "integrity": "sha512-bAYyb6Ah5z1s4SSS4qj71iqnNgG+qEub9oMNk+CpgP7ZAsVT8hIXcTVordFCKwnukrD9grtXPKGPyY5qezjatw==",
             "dependencies": {
                 "@ethersproject/abi": "5.5.0",
                 "@ethersproject/bignumber": "5.5.0",
                 "@ethersproject/bytes": "5.5.0",
                 "@ethersproject/properties": "5.5.0",
-                "@hethers/abstract-provider": "1.2.0",
-                "@hethers/abstract-signer": "1.2.1",
+                "@hethers/abstract-provider": "1.2.1",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
                 "@hethers/logger": "1.2.0",
-                "@hethers/providers": "1.2.1",
-                "@hethers/transactions": "1.2.1"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@ethersproject/base64": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-            "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.5.0"
+                "@hethers/providers": "1.2.3",
+                "@hethers/transactions": "1.2.2"
             }
         },
         "node_modules/@hethers/contracts/node_modules/@ethersproject/bignumber": {
@@ -5484,240 +5466,15 @@
                 "@ethersproject/logger": "^5.5.0"
             }
         },
-        "node_modules/@hethers/contracts/node_modules/@ethersproject/hash": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
-            "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/abstract-signer": "^5.5.0",
-                "@ethersproject/address": "^5.5.0",
-                "@ethersproject/bignumber": "^5.5.0",
-                "@ethersproject/bytes": "^5.5.0",
-                "@ethersproject/keccak256": "^5.5.0",
-                "@ethersproject/logger": "^5.5.0",
-                "@ethersproject/properties": "^5.5.0",
-                "@ethersproject/strings": "^5.5.0"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@ethersproject/keccak256": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
-            "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.5.0",
-                "js-sha3": "0.8.0"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@ethersproject/sha2": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
-            "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.5.0",
-                "@ethersproject/logger": "^5.5.0",
-                "hash.js": "1.1.7"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@ethersproject/strings": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
-            "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.5.0",
-                "@ethersproject/constants": "^5.5.0",
-                "@ethersproject/logger": "^5.5.0"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@hashgraph/proto": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.9.0.tgz",
-            "integrity": "sha512-Ot0OVLCl9lNBpHZozN0BS4mvlpxgJ0Bkea4p+6MoQ/+sZtOCu+FMsidIVdvFZBvdNjgPXx8byYjkpmFaxiIOpQ==",
-            "dependencies": {
-                "long": "^4.0.0",
-                "protobufjs": "^6.11.3"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@hethers/abstract-provider": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/abstract-provider/-/abstract-provider-1.2.0.tgz",
-            "integrity": "sha512-vFb4/fIe5Ry+//z0CpH6+qtkuZhTqI274m4OYigC14h++xwyx2Ic3AUd9Nchbg9ee6kz8PHgoSRH2CEEahDPRQ==",
-            "dependencies": {
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@ethersproject/web": "5.5.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/networks": "1.2.0",
-                "@hethers/transactions": "1.2.0"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@hethers/abstract-provider/node_modules/@hethers/transactions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@hethers/abstract-signer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.1.tgz",
-            "integrity": "sha512-oTUECt5GgemSSXFiQQ5VLuT4MGttMiNo/26ktaAUIgj97sR83FWVvJRbT0/Z1U0b95M57EYtyrVfd/TCa31CaA==",
-            "dependencies": {
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/abstract-provider": "1.2.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/transactions": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@hethers/abstract-signer/node_modules/@hethers/transactions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@hethers/providers": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/providers/-/providers-1.2.1.tgz",
-            "integrity": "sha512-EiWUDJiUCp0em6JqLzEhPp4cNeSkP/xSByy/bpFYNwTPF3KFoWVMsIonXxAfQO0FDKcqvrRRZ3j0qyJhCVPc1A==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/basex": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/hash": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@ethersproject/random": "5.5.0",
-                "@ethersproject/sha2": "5.5.0",
-                "@ethersproject/strings": "5.5.0",
-                "@ethersproject/web": "5.5.0",
-                "@hashgraph/proto": "2.9.0",
-                "@hashgraph/sdk": "^2.17.1",
-                "@hethers/abstract-provider": "1.2.0",
-                "@hethers/abstract-signer": "1.2.1",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/networks": "1.2.0",
-                "@hethers/transactions": "1.2.1",
-                "@types/axios": "^0.14.0",
-                "axios": "^0.24.0",
-                "bech32": "1.1.4",
-                "ws": "7.4.6"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/@hethers/transactions": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.1.tgz",
-            "integrity": "sha512-MOWduldiPaLIT2PsuARxSrysUFRx5MwcMAaZJh1Zk6Xniitj8dSEE5tM1kbuoLqOL4t7fe4oppnhNrGGJvq7Cg==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
-        "node_modules/@hethers/contracts/node_modules/axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-            "dependencies": {
-                "follow-redirects": "^1.14.4"
-            }
-        },
         "node_modules/@hethers/contracts/node_modules/bn.js": {
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/@hethers/hdnode": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/hdnode/-/hdnode-1.2.1.tgz",
-            "integrity": "sha512-J1vfopqdaP3N/vwVXZRYwAG2dyvJVLTcsXpHbXJjmijFnsdYXAs/w/tkrQWimltDIR4QeOagMX9MqlBKBgfUGA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@hethers/hdnode/-/hdnode-1.2.2.tgz",
+            "integrity": "sha512-vnY1r1qr4WUCPdMuDVtkkEDIrmKuCv+uQblurAeUNHb/qxgbvhwgZKcntO+E43iodagyUxfl6AGL+MGamOsrRg==",
             "dependencies": {
                 "@ethersproject/basex": "5.5.0",
                 "@ethersproject/bignumber": "5.5.0",
@@ -5727,28 +5484,10 @@
                 "@ethersproject/sha2": "5.5.0",
                 "@ethersproject/strings": "5.5.0",
                 "@ethersproject/wordlists": "5.5.0",
-                "@hethers/abstract-signer": "1.2.1",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/logger": "1.2.0",
                 "@hethers/signing-key": "1.2.0",
-                "@hethers/transactions": "1.2.1"
-            }
-        },
-        "node_modules/@hethers/hdnode/node_modules/@ethersproject/base64": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-            "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.5.0"
+                "@hethers/transactions": "1.2.2"
             }
         },
         "node_modules/@hethers/hdnode/node_modules/@ethersproject/bignumber": {
@@ -5787,25 +5526,6 @@
             ],
             "dependencies": {
                 "@ethersproject/logger": "^5.5.0"
-            }
-        },
-        "node_modules/@hethers/hdnode/node_modules/@ethersproject/keccak256": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
-            "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.5.0",
-                "js-sha3": "0.8.0"
             }
         },
         "node_modules/@hethers/hdnode/node_modules/@ethersproject/sha2": {
@@ -5848,106 +5568,15 @@
                 "@ethersproject/logger": "^5.5.0"
             }
         },
-        "node_modules/@hethers/hdnode/node_modules/@hethers/abstract-provider": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/abstract-provider/-/abstract-provider-1.2.0.tgz",
-            "integrity": "sha512-vFb4/fIe5Ry+//z0CpH6+qtkuZhTqI274m4OYigC14h++xwyx2Ic3AUd9Nchbg9ee6kz8PHgoSRH2CEEahDPRQ==",
-            "dependencies": {
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@ethersproject/web": "5.5.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/networks": "1.2.0",
-                "@hethers/transactions": "1.2.0"
-            }
-        },
-        "node_modules/@hethers/hdnode/node_modules/@hethers/abstract-provider/node_modules/@hethers/transactions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
-        "node_modules/@hethers/hdnode/node_modules/@hethers/abstract-signer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.1.tgz",
-            "integrity": "sha512-oTUECt5GgemSSXFiQQ5VLuT4MGttMiNo/26ktaAUIgj97sR83FWVvJRbT0/Z1U0b95M57EYtyrVfd/TCa31CaA==",
-            "dependencies": {
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/abstract-provider": "1.2.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/transactions": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0"
-            }
-        },
-        "node_modules/@hethers/hdnode/node_modules/@hethers/abstract-signer/node_modules/@hethers/transactions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
-        "node_modules/@hethers/hdnode/node_modules/@hethers/transactions": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.1.tgz",
-            "integrity": "sha512-MOWduldiPaLIT2PsuARxSrysUFRx5MwcMAaZJh1Zk6Xniitj8dSEE5tM1kbuoLqOL4t7fe4oppnhNrGGJvq7Cg==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
         "node_modules/@hethers/hdnode/node_modules/bn.js": {
             "version": "4.12.0",
             "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/@hethers/json-wallets": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/json-wallets/-/json-wallets-1.2.1.tgz",
-            "integrity": "sha512-bcbVDFRVwM0DB3ofRra8VFHUphElrnd+lswqAVtpSqPZnTWPlarSFQ4DU1k7EB2hVF6PXmUffXME5eDfHWdZZA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@hethers/json-wallets/-/json-wallets-1.2.2.tgz",
+            "integrity": "sha512-rU7KHLIp9LTJ0tq2M3rfw5sFgIzMFLOzIVSlT+AR/A+8vA5LrnJS3Fehp8XW0rcOxIdCPvTKHL+Ll1q24XQhNg==",
             "dependencies": {
                 "@ethersproject/bytes": "5.5.0",
                 "@ethersproject/keccak256": "5.5.0",
@@ -5955,51 +5584,13 @@
                 "@ethersproject/properties": "5.5.0",
                 "@ethersproject/random": "5.5.0",
                 "@ethersproject/strings": "5.5.0",
-                "@hethers/abstract-signer": "1.2.1",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
-                "@hethers/hdnode": "1.2.1",
+                "@hethers/hdnode": "1.2.2",
                 "@hethers/logger": "1.2.0",
-                "@hethers/transactions": "1.2.1",
+                "@hethers/transactions": "1.2.2",
                 "aes-js": "3.0.0",
                 "scrypt-js": "3.0.1"
-            }
-        },
-        "node_modules/@hethers/json-wallets/node_modules/@ethersproject/base64": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-            "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.5.0"
-            }
-        },
-        "node_modules/@hethers/json-wallets/node_modules/@ethersproject/bignumber": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-            "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "dependencies": {
-                "@ethersproject/bytes": "^5.5.0",
-                "@ethersproject/logger": "^5.5.0",
-                "bn.js": "^4.11.9"
             }
         },
         "node_modules/@hethers/json-wallets/node_modules/@ethersproject/bytes": {
@@ -6059,102 +5650,6 @@
                 "@ethersproject/logger": "^5.5.0"
             }
         },
-        "node_modules/@hethers/json-wallets/node_modules/@hethers/abstract-provider": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/abstract-provider/-/abstract-provider-1.2.0.tgz",
-            "integrity": "sha512-vFb4/fIe5Ry+//z0CpH6+qtkuZhTqI274m4OYigC14h++xwyx2Ic3AUd9Nchbg9ee6kz8PHgoSRH2CEEahDPRQ==",
-            "dependencies": {
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@ethersproject/web": "5.5.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/networks": "1.2.0",
-                "@hethers/transactions": "1.2.0"
-            }
-        },
-        "node_modules/@hethers/json-wallets/node_modules/@hethers/abstract-provider/node_modules/@hethers/transactions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
-        "node_modules/@hethers/json-wallets/node_modules/@hethers/abstract-signer": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.1.tgz",
-            "integrity": "sha512-oTUECt5GgemSSXFiQQ5VLuT4MGttMiNo/26ktaAUIgj97sR83FWVvJRbT0/Z1U0b95M57EYtyrVfd/TCa31CaA==",
-            "dependencies": {
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/abstract-provider": "1.2.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/transactions": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0"
-            }
-        },
-        "node_modules/@hethers/json-wallets/node_modules/@hethers/abstract-signer/node_modules/@hethers/transactions": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
-        "node_modules/@hethers/json-wallets/node_modules/@hethers/transactions": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.1.tgz",
-            "integrity": "sha512-MOWduldiPaLIT2PsuARxSrysUFRx5MwcMAaZJh1Zk6Xniitj8dSEE5tM1kbuoLqOL4t7fe4oppnhNrGGJvq7Cg==",
-            "dependencies": {
-                "@ethersproject/base64": "5.5.0",
-                "@ethersproject/bignumber": "5.5.0",
-                "@ethersproject/bytes": "5.5.0",
-                "@ethersproject/keccak256": "5.5.0",
-                "@ethersproject/properties": "5.5.0",
-                "@hethers/address": "1.2.0",
-                "@hethers/constants": "1.2.0",
-                "@hethers/logger": "1.2.0",
-                "@hethers/signing-key": "1.2.0"
-            },
-            "peerDependencies": {
-                "@hashgraph/proto": "^2.9.0",
-                "@hashgraph/sdk": "^2.17.1"
-            }
-        },
-        "node_modules/@hethers/json-wallets/node_modules/bn.js": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        },
         "node_modules/@hethers/logger": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@hethers/logger/-/logger-1.2.0.tgz",
@@ -6170,9 +5665,9 @@
             }
         },
         "node_modules/@hethers/providers": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@hethers/providers/-/providers-1.2.2.tgz",
-            "integrity": "sha512-848ioZjfogmwNYHr4GV+Y6mIk3C3S5LFwyPssnsy13AYOopIlekLCaHTzRumA+E+rBxAfxF7BnmW9b1QR2JikQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@hethers/providers/-/providers-1.2.3.tgz",
+            "integrity": "sha512-2lB4q1Ub18mqDL3cbNiS1tlB7HmqXi9T4EUQrK3VsPllQCMjsqqvZVtu/H9S3qv9ZZQazc2kcfmj4JmV8YrMsA==",
             "dependencies": {
                 "@ethersproject/base64": "5.5.0",
                 "@ethersproject/basex": "5.5.0",
@@ -6187,7 +5682,7 @@
                 "@hashgraph/proto": "2.9.0",
                 "@hashgraph/sdk": "^2.19.0",
                 "@hethers/abstract-provider": "1.2.1",
-                "@hethers/abstract-signer": "1.2.2",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
                 "@hethers/constants": "1.2.0",
                 "@hethers/logger": "1.2.0",
@@ -6516,9 +6011,9 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/@hethers/wallet": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@hethers/wallet/-/wallet-1.2.2.tgz",
-            "integrity": "sha512-foYAH5Vxszr24tOyeQ5dRhCBpp4hWaBTLtxeaov6Y35Lu0HHdbGRN1ZiqgYoQC5H/TRrcHYaLt1wvuyHSQKXNA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@hethers/wallet/-/wallet-1.2.3.tgz",
+            "integrity": "sha512-0VKYmrg7AHtUO8hYGdNEVdd5sQMhyTw/h30U79ulAkjANk35hYMuxI878VAdMro8UcUlNE0kDKjnxpIrPlQoXQ==",
             "dependencies": {
                 "@ethersproject/bignumber": "5.5.0",
                 "@ethersproject/bytes": "5.5.0",
@@ -6529,10 +6024,10 @@
                 "@ethersproject/wordlists": "5.5.0",
                 "@hashgraph/sdk": "^2.19.0",
                 "@hethers/abstract-provider": "1.2.1",
-                "@hethers/abstract-signer": "1.2.2",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
-                "@hethers/hdnode": "1.2.1",
-                "@hethers/json-wallets": "1.2.1",
+                "@hethers/hdnode": "1.2.2",
+                "@hethers/json-wallets": "1.2.2",
                 "@hethers/logger": "1.2.0",
                 "@hethers/signing-key": "1.2.0",
                 "@hethers/transactions": "1.2.2"
@@ -8789,6 +8284,7 @@
             "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
             "dev": true,
             "hasInstallScript": true,
+            "optional": true,
             "dependencies": {
                 "node-gyp-build": "4.3.0"
             },
@@ -14215,7 +13711,6 @@
             "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
             "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
             "dev": true,
-            "hasInstallScript": true,
             "optional": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
@@ -14528,7 +14023,6 @@
             "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
             "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
             "dev": true,
-            "hasInstallScript": true,
             "optional": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
@@ -23374,7 +22868,7 @@
                 "pino-pretty": "^7.6.1"
             },
             "devDependencies": {
-                "@hashgraph/hedera-local": "^2.1.3",
+                "@hashgraph/hedera-local": "^2.4.3",
                 "@hashgraph/sdk": "^2.19.0",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
@@ -26624,11 +26118,11 @@
             }
         },
         "@hashgraph/hedera-local": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.4.1.tgz",
-            "integrity": "sha512-wgajOITLGumCvMEugBzYvk+IwsLZm1hziB0UPlChLvNNrRA7mQkywtP4h59ZGqBN4Ze2jZNDIRpCudcRSK5TAQ==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.4.3.tgz",
+            "integrity": "sha512-iinpXa74J+rL3/AfYGhmvIEEnr8yHyhQdBCH2ZhJAc8Fr8FMjrzHdKKb1ovBxSyfDFKUu5dBoUzUSPwEvI9yQQ==",
             "requires": {
-                "@hashgraph/hethers": "^1.2.2",
+                "@hashgraph/hethers": "^1.2.4",
                 "@hashgraph/sdk": "^2.19.0",
                 "blessed": "^0.1.81",
                 "blessed-contrib": "^4.11.0",
@@ -26643,25 +26137,25 @@
             }
         },
         "@hashgraph/hethers": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hethers/-/hethers-1.2.3.tgz",
-            "integrity": "sha512-/bDdEiAXMZZhKZJka/0a8kI+yx6kVEA8l9ii4wpI+J0/utzjTrPRhDISKcf7zc5T/gJgNA5QB+5smsr+WmgPlw==",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/@hashgraph/hethers/-/hethers-1.2.5.tgz",
+            "integrity": "sha512-wXzx8FMPZaJ8nILmnEDZ7hF+cmPTuTQUt0gZzXwwGi0f+bTro9BpItlYOu2qUNwLk32jluqbP5Fbf6igI04wLQ==",
             "requires": {
                 "@ethersproject/solidity": "5.5.0",
                 "@hethers/abstract-provider": "1.2.1",
-                "@hethers/abstract-signer": "1.2.2",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
                 "@hethers/constants": "1.2.0",
-                "@hethers/contracts": "1.2.1",
-                "@hethers/hdnode": "1.2.1",
-                "@hethers/json-wallets": "1.2.1",
+                "@hethers/contracts": "1.2.3",
+                "@hethers/hdnode": "1.2.2",
+                "@hethers/json-wallets": "1.2.2",
                 "@hethers/logger": "1.2.0",
                 "@hethers/networks": "1.2.0",
-                "@hethers/providers": "1.2.2",
+                "@hethers/providers": "1.2.3",
                 "@hethers/signing-key": "1.2.0",
                 "@hethers/transactions": "1.2.2",
                 "@hethers/units": "1.2.0",
-                "@hethers/wallet": "1.2.2"
+                "@hethers/wallet": "1.2.3"
             }
         },
         "@hashgraph/json-rpc-relay": {
@@ -26722,7 +26216,7 @@
         "@hashgraph/json-rpc-server": {
             "version": "file:packages/server",
             "requires": {
-                "@hashgraph/hedera-local": "^2.1.3",
+                "@hashgraph/hedera-local": "^2.4.3",
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "@hashgraph/sdk": "^2.19.0",
                 "@koa/cors": "^3.1.0",
@@ -26876,9 +26370,9 @@
             }
         },
         "@hethers/abstract-signer": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.2.tgz",
-            "integrity": "sha512-WsHdNnUbjqU9/6GIC/p7tyctMvgbo+Yd8n7L/9RoNYHwbGXAodWBHN7okZ3lcxB9FajCx7KmErgCu93ZIU2cuA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.3.tgz",
+            "integrity": "sha512-BPgvptjw3QPKmrlmG8o4v7QlLqqIKKR4zAvqZgPUX62unlcFcW2bSjoKx6SF/pB4Ylc1TW52t2p/OhN4J9wzLw==",
             "requires": {
                 "@ethersproject/bignumber": "5.5.0",
                 "@ethersproject/bytes": "5.5.0",
@@ -26985,30 +26479,22 @@
             }
         },
         "@hethers/contracts": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/contracts/-/contracts-1.2.1.tgz",
-            "integrity": "sha512-K0ReJYt6d6r6biMIgPY9ldGeBA9ypvRbynY9pRIZvEKgUfbR/AyxJDY2vFiukHsG14evp6oXGJSdZjKQtXkz6w==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@hethers/contracts/-/contracts-1.2.3.tgz",
+            "integrity": "sha512-bAYyb6Ah5z1s4SSS4qj71iqnNgG+qEub9oMNk+CpgP7ZAsVT8hIXcTVordFCKwnukrD9grtXPKGPyY5qezjatw==",
             "requires": {
                 "@ethersproject/abi": "5.5.0",
                 "@ethersproject/bignumber": "5.5.0",
                 "@ethersproject/bytes": "5.5.0",
                 "@ethersproject/properties": "5.5.0",
-                "@hethers/abstract-provider": "1.2.0",
-                "@hethers/abstract-signer": "1.2.1",
+                "@hethers/abstract-provider": "1.2.1",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
                 "@hethers/logger": "1.2.0",
-                "@hethers/providers": "1.2.1",
-                "@hethers/transactions": "1.2.1"
+                "@hethers/providers": "1.2.3",
+                "@hethers/transactions": "1.2.2"
             },
             "dependencies": {
-                "@ethersproject/base64": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-                    "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.5.0"
-                    }
-                },
                 "@ethersproject/bignumber": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
@@ -27025,177 +26511,6 @@
                     "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
                     "requires": {
                         "@ethersproject/logger": "^5.5.0"
-                    }
-                },
-                "@ethersproject/hash": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.5.0.tgz",
-                    "integrity": "sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==",
-                    "requires": {
-                        "@ethersproject/abstract-signer": "^5.5.0",
-                        "@ethersproject/address": "^5.5.0",
-                        "@ethersproject/bignumber": "^5.5.0",
-                        "@ethersproject/bytes": "^5.5.0",
-                        "@ethersproject/keccak256": "^5.5.0",
-                        "@ethersproject/logger": "^5.5.0",
-                        "@ethersproject/properties": "^5.5.0",
-                        "@ethersproject/strings": "^5.5.0"
-                    }
-                },
-                "@ethersproject/keccak256": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
-                    "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.5.0",
-                        "js-sha3": "0.8.0"
-                    }
-                },
-                "@ethersproject/sha2": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.5.0.tgz",
-                    "integrity": "sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.5.0",
-                        "@ethersproject/logger": "^5.5.0",
-                        "hash.js": "1.1.7"
-                    }
-                },
-                "@ethersproject/strings": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.5.0.tgz",
-                    "integrity": "sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.5.0",
-                        "@ethersproject/constants": "^5.5.0",
-                        "@ethersproject/logger": "^5.5.0"
-                    }
-                },
-                "@hashgraph/proto": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.9.0.tgz",
-                    "integrity": "sha512-Ot0OVLCl9lNBpHZozN0BS4mvlpxgJ0Bkea4p+6MoQ/+sZtOCu+FMsidIVdvFZBvdNjgPXx8byYjkpmFaxiIOpQ==",
-                    "requires": {
-                        "long": "^4.0.0",
-                        "protobufjs": "^6.11.3"
-                    }
-                },
-                "@hethers/abstract-provider": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/@hethers/abstract-provider/-/abstract-provider-1.2.0.tgz",
-                    "integrity": "sha512-vFb4/fIe5Ry+//z0CpH6+qtkuZhTqI274m4OYigC14h++xwyx2Ic3AUd9Nchbg9ee6kz8PHgoSRH2CEEahDPRQ==",
-                    "requires": {
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@ethersproject/web": "5.5.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/networks": "1.2.0",
-                        "@hethers/transactions": "1.2.0"
-                    },
-                    "dependencies": {
-                        "@hethers/transactions": {
-                            "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-                            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-                            "requires": {
-                                "@ethersproject/base64": "5.5.0",
-                                "@ethersproject/bignumber": "5.5.0",
-                                "@ethersproject/bytes": "5.5.0",
-                                "@ethersproject/keccak256": "5.5.0",
-                                "@ethersproject/properties": "5.5.0",
-                                "@hethers/address": "1.2.0",
-                                "@hethers/constants": "1.2.0",
-                                "@hethers/logger": "1.2.0",
-                                "@hethers/signing-key": "1.2.0"
-                            }
-                        }
-                    }
-                },
-                "@hethers/abstract-signer": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.1.tgz",
-                    "integrity": "sha512-oTUECt5GgemSSXFiQQ5VLuT4MGttMiNo/26ktaAUIgj97sR83FWVvJRbT0/Z1U0b95M57EYtyrVfd/TCa31CaA==",
-                    "requires": {
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@hethers/abstract-provider": "1.2.0",
-                        "@hethers/address": "1.2.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/transactions": "1.2.0"
-                    },
-                    "dependencies": {
-                        "@hethers/transactions": {
-                            "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-                            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-                            "requires": {
-                                "@ethersproject/base64": "5.5.0",
-                                "@ethersproject/bignumber": "5.5.0",
-                                "@ethersproject/bytes": "5.5.0",
-                                "@ethersproject/keccak256": "5.5.0",
-                                "@ethersproject/properties": "5.5.0",
-                                "@hethers/address": "1.2.0",
-                                "@hethers/constants": "1.2.0",
-                                "@hethers/logger": "1.2.0",
-                                "@hethers/signing-key": "1.2.0"
-                            }
-                        }
-                    }
-                },
-                "@hethers/providers": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/@hethers/providers/-/providers-1.2.1.tgz",
-                    "integrity": "sha512-EiWUDJiUCp0em6JqLzEhPp4cNeSkP/xSByy/bpFYNwTPF3KFoWVMsIonXxAfQO0FDKcqvrRRZ3j0qyJhCVPc1A==",
-                    "requires": {
-                        "@ethersproject/base64": "5.5.0",
-                        "@ethersproject/basex": "5.5.0",
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/hash": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@ethersproject/random": "5.5.0",
-                        "@ethersproject/sha2": "5.5.0",
-                        "@ethersproject/strings": "5.5.0",
-                        "@ethersproject/web": "5.5.0",
-                        "@hashgraph/proto": "2.9.0",
-                        "@hashgraph/sdk": "^2.17.1",
-                        "@hethers/abstract-provider": "1.2.0",
-                        "@hethers/abstract-signer": "1.2.1",
-                        "@hethers/address": "1.2.0",
-                        "@hethers/constants": "1.2.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/networks": "1.2.0",
-                        "@hethers/transactions": "1.2.1",
-                        "@types/axios": "^0.14.0",
-                        "axios": "^0.24.0",
-                        "bech32": "1.1.4",
-                        "ws": "7.4.6"
-                    }
-                },
-                "@hethers/transactions": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.1.tgz",
-                    "integrity": "sha512-MOWduldiPaLIT2PsuARxSrysUFRx5MwcMAaZJh1Zk6Xniitj8dSEE5tM1kbuoLqOL4t7fe4oppnhNrGGJvq7Cg==",
-                    "requires": {
-                        "@ethersproject/base64": "5.5.0",
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/keccak256": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@hethers/address": "1.2.0",
-                        "@hethers/constants": "1.2.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/signing-key": "1.2.0"
-                    }
-                },
-                "axios": {
-                    "version": "0.24.0",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-                    "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-                    "requires": {
-                        "follow-redirects": "^1.14.4"
                     }
                 },
                 "bn.js": {
@@ -27206,9 +26521,9 @@
             }
         },
         "@hethers/hdnode": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/hdnode/-/hdnode-1.2.1.tgz",
-            "integrity": "sha512-J1vfopqdaP3N/vwVXZRYwAG2dyvJVLTcsXpHbXJjmijFnsdYXAs/w/tkrQWimltDIR4QeOagMX9MqlBKBgfUGA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@hethers/hdnode/-/hdnode-1.2.2.tgz",
+            "integrity": "sha512-vnY1r1qr4WUCPdMuDVtkkEDIrmKuCv+uQblurAeUNHb/qxgbvhwgZKcntO+E43iodagyUxfl6AGL+MGamOsrRg==",
             "requires": {
                 "@ethersproject/basex": "5.5.0",
                 "@ethersproject/bignumber": "5.5.0",
@@ -27218,20 +26533,12 @@
                 "@ethersproject/sha2": "5.5.0",
                 "@ethersproject/strings": "5.5.0",
                 "@ethersproject/wordlists": "5.5.0",
-                "@hethers/abstract-signer": "1.2.1",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/logger": "1.2.0",
                 "@hethers/signing-key": "1.2.0",
-                "@hethers/transactions": "1.2.1"
+                "@hethers/transactions": "1.2.2"
             },
             "dependencies": {
-                "@ethersproject/base64": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-                    "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.5.0"
-                    }
-                },
                 "@ethersproject/bignumber": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
@@ -27248,15 +26555,6 @@
                     "integrity": "sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==",
                     "requires": {
                         "@ethersproject/logger": "^5.5.0"
-                    }
-                },
-                "@ethersproject/keccak256": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.5.0.tgz",
-                    "integrity": "sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.5.0",
-                        "js-sha3": "0.8.0"
                     }
                 },
                 "@ethersproject/sha2": {
@@ -27279,86 +26577,6 @@
                         "@ethersproject/logger": "^5.5.0"
                     }
                 },
-                "@hethers/abstract-provider": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/@hethers/abstract-provider/-/abstract-provider-1.2.0.tgz",
-                    "integrity": "sha512-vFb4/fIe5Ry+//z0CpH6+qtkuZhTqI274m4OYigC14h++xwyx2Ic3AUd9Nchbg9ee6kz8PHgoSRH2CEEahDPRQ==",
-                    "requires": {
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@ethersproject/web": "5.5.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/networks": "1.2.0",
-                        "@hethers/transactions": "1.2.0"
-                    },
-                    "dependencies": {
-                        "@hethers/transactions": {
-                            "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-                            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-                            "requires": {
-                                "@ethersproject/base64": "5.5.0",
-                                "@ethersproject/bignumber": "5.5.0",
-                                "@ethersproject/bytes": "5.5.0",
-                                "@ethersproject/keccak256": "5.5.0",
-                                "@ethersproject/properties": "5.5.0",
-                                "@hethers/address": "1.2.0",
-                                "@hethers/constants": "1.2.0",
-                                "@hethers/logger": "1.2.0",
-                                "@hethers/signing-key": "1.2.0"
-                            }
-                        }
-                    }
-                },
-                "@hethers/abstract-signer": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.1.tgz",
-                    "integrity": "sha512-oTUECt5GgemSSXFiQQ5VLuT4MGttMiNo/26ktaAUIgj97sR83FWVvJRbT0/Z1U0b95M57EYtyrVfd/TCa31CaA==",
-                    "requires": {
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@hethers/abstract-provider": "1.2.0",
-                        "@hethers/address": "1.2.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/transactions": "1.2.0"
-                    },
-                    "dependencies": {
-                        "@hethers/transactions": {
-                            "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-                            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-                            "requires": {
-                                "@ethersproject/base64": "5.5.0",
-                                "@ethersproject/bignumber": "5.5.0",
-                                "@ethersproject/bytes": "5.5.0",
-                                "@ethersproject/keccak256": "5.5.0",
-                                "@ethersproject/properties": "5.5.0",
-                                "@hethers/address": "1.2.0",
-                                "@hethers/constants": "1.2.0",
-                                "@hethers/logger": "1.2.0",
-                                "@hethers/signing-key": "1.2.0"
-                            }
-                        }
-                    }
-                },
-                "@hethers/transactions": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.1.tgz",
-                    "integrity": "sha512-MOWduldiPaLIT2PsuARxSrysUFRx5MwcMAaZJh1Zk6Xniitj8dSEE5tM1kbuoLqOL4t7fe4oppnhNrGGJvq7Cg==",
-                    "requires": {
-                        "@ethersproject/base64": "5.5.0",
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/keccak256": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@hethers/address": "1.2.0",
-                        "@hethers/constants": "1.2.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/signing-key": "1.2.0"
-                    }
-                },
                 "bn.js": {
                     "version": "4.12.0",
                     "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -27367,9 +26585,9 @@
             }
         },
         "@hethers/json-wallets": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@hethers/json-wallets/-/json-wallets-1.2.1.tgz",
-            "integrity": "sha512-bcbVDFRVwM0DB3ofRra8VFHUphElrnd+lswqAVtpSqPZnTWPlarSFQ4DU1k7EB2hVF6PXmUffXME5eDfHWdZZA==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@hethers/json-wallets/-/json-wallets-1.2.2.tgz",
+            "integrity": "sha512-rU7KHLIp9LTJ0tq2M3rfw5sFgIzMFLOzIVSlT+AR/A+8vA5LrnJS3Fehp8XW0rcOxIdCPvTKHL+Ll1q24XQhNg==",
             "requires": {
                 "@ethersproject/bytes": "5.5.0",
                 "@ethersproject/keccak256": "5.5.0",
@@ -27377,33 +26595,15 @@
                 "@ethersproject/properties": "5.5.0",
                 "@ethersproject/random": "5.5.0",
                 "@ethersproject/strings": "5.5.0",
-                "@hethers/abstract-signer": "1.2.1",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
-                "@hethers/hdnode": "1.2.1",
+                "@hethers/hdnode": "1.2.2",
                 "@hethers/logger": "1.2.0",
-                "@hethers/transactions": "1.2.1",
+                "@hethers/transactions": "1.2.2",
                 "aes-js": "3.0.0",
                 "scrypt-js": "3.0.1"
             },
             "dependencies": {
-                "@ethersproject/base64": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.5.0.tgz",
-                    "integrity": "sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.5.0"
-                    }
-                },
-                "@ethersproject/bignumber": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.5.0.tgz",
-                    "integrity": "sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==",
-                    "requires": {
-                        "@ethersproject/bytes": "^5.5.0",
-                        "@ethersproject/logger": "^5.5.0",
-                        "bn.js": "^4.11.9"
-                    }
-                },
                 "@ethersproject/bytes": {
                     "version": "5.5.0",
                     "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.5.0.tgz",
@@ -27430,91 +26630,6 @@
                         "@ethersproject/constants": "^5.5.0",
                         "@ethersproject/logger": "^5.5.0"
                     }
-                },
-                "@hethers/abstract-provider": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/@hethers/abstract-provider/-/abstract-provider-1.2.0.tgz",
-                    "integrity": "sha512-vFb4/fIe5Ry+//z0CpH6+qtkuZhTqI274m4OYigC14h++xwyx2Ic3AUd9Nchbg9ee6kz8PHgoSRH2CEEahDPRQ==",
-                    "requires": {
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@ethersproject/web": "5.5.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/networks": "1.2.0",
-                        "@hethers/transactions": "1.2.0"
-                    },
-                    "dependencies": {
-                        "@hethers/transactions": {
-                            "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-                            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-                            "requires": {
-                                "@ethersproject/base64": "5.5.0",
-                                "@ethersproject/bignumber": "5.5.0",
-                                "@ethersproject/bytes": "5.5.0",
-                                "@ethersproject/keccak256": "5.5.0",
-                                "@ethersproject/properties": "5.5.0",
-                                "@hethers/address": "1.2.0",
-                                "@hethers/constants": "1.2.0",
-                                "@hethers/logger": "1.2.0",
-                                "@hethers/signing-key": "1.2.0"
-                            }
-                        }
-                    }
-                },
-                "@hethers/abstract-signer": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/@hethers/abstract-signer/-/abstract-signer-1.2.1.tgz",
-                    "integrity": "sha512-oTUECt5GgemSSXFiQQ5VLuT4MGttMiNo/26ktaAUIgj97sR83FWVvJRbT0/Z1U0b95M57EYtyrVfd/TCa31CaA==",
-                    "requires": {
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@hethers/abstract-provider": "1.2.0",
-                        "@hethers/address": "1.2.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/transactions": "1.2.0"
-                    },
-                    "dependencies": {
-                        "@hethers/transactions": {
-                            "version": "1.2.0",
-                            "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.0.tgz",
-                            "integrity": "sha512-lgZQneLT0Us1c/SD9sCYssvWgQzV8s+eo8kYwCwEc1R1BWcspjzywuHgpSMRB0528yq7N/cwtTyc0PwubOKLAA==",
-                            "requires": {
-                                "@ethersproject/base64": "5.5.0",
-                                "@ethersproject/bignumber": "5.5.0",
-                                "@ethersproject/bytes": "5.5.0",
-                                "@ethersproject/keccak256": "5.5.0",
-                                "@ethersproject/properties": "5.5.0",
-                                "@hethers/address": "1.2.0",
-                                "@hethers/constants": "1.2.0",
-                                "@hethers/logger": "1.2.0",
-                                "@hethers/signing-key": "1.2.0"
-                            }
-                        }
-                    }
-                },
-                "@hethers/transactions": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/@hethers/transactions/-/transactions-1.2.1.tgz",
-                    "integrity": "sha512-MOWduldiPaLIT2PsuARxSrysUFRx5MwcMAaZJh1Zk6Xniitj8dSEE5tM1kbuoLqOL4t7fe4oppnhNrGGJvq7Cg==",
-                    "requires": {
-                        "@ethersproject/base64": "5.5.0",
-                        "@ethersproject/bignumber": "5.5.0",
-                        "@ethersproject/bytes": "5.5.0",
-                        "@ethersproject/keccak256": "5.5.0",
-                        "@ethersproject/properties": "5.5.0",
-                        "@hethers/address": "1.2.0",
-                        "@hethers/constants": "1.2.0",
-                        "@hethers/logger": "1.2.0",
-                        "@hethers/signing-key": "1.2.0"
-                    }
-                },
-                "bn.js": {
-                    "version": "4.12.0",
-                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
                 }
             }
         },
@@ -27533,9 +26648,9 @@
             }
         },
         "@hethers/providers": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@hethers/providers/-/providers-1.2.2.tgz",
-            "integrity": "sha512-848ioZjfogmwNYHr4GV+Y6mIk3C3S5LFwyPssnsy13AYOopIlekLCaHTzRumA+E+rBxAfxF7BnmW9b1QR2JikQ==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@hethers/providers/-/providers-1.2.3.tgz",
+            "integrity": "sha512-2lB4q1Ub18mqDL3cbNiS1tlB7HmqXi9T4EUQrK3VsPllQCMjsqqvZVtu/H9S3qv9ZZQazc2kcfmj4JmV8YrMsA==",
             "requires": {
                 "@ethersproject/base64": "5.5.0",
                 "@ethersproject/basex": "5.5.0",
@@ -27550,7 +26665,7 @@
                 "@hashgraph/proto": "2.9.0",
                 "@hashgraph/sdk": "^2.19.0",
                 "@hethers/abstract-provider": "1.2.1",
-                "@hethers/abstract-signer": "1.2.2",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
                 "@hethers/constants": "1.2.0",
                 "@hethers/logger": "1.2.0",
@@ -27760,9 +26875,9 @@
             }
         },
         "@hethers/wallet": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@hethers/wallet/-/wallet-1.2.2.tgz",
-            "integrity": "sha512-foYAH5Vxszr24tOyeQ5dRhCBpp4hWaBTLtxeaov6Y35Lu0HHdbGRN1ZiqgYoQC5H/TRrcHYaLt1wvuyHSQKXNA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@hethers/wallet/-/wallet-1.2.3.tgz",
+            "integrity": "sha512-0VKYmrg7AHtUO8hYGdNEVdd5sQMhyTw/h30U79ulAkjANk35hYMuxI878VAdMro8UcUlNE0kDKjnxpIrPlQoXQ==",
             "requires": {
                 "@ethersproject/bignumber": "5.5.0",
                 "@ethersproject/bytes": "5.5.0",
@@ -27773,10 +26888,10 @@
                 "@ethersproject/wordlists": "5.5.0",
                 "@hashgraph/sdk": "^2.19.0",
                 "@hethers/abstract-provider": "1.2.1",
-                "@hethers/abstract-signer": "1.2.2",
+                "@hethers/abstract-signer": "1.2.3",
                 "@hethers/address": "1.2.0",
-                "@hethers/hdnode": "1.2.1",
-                "@hethers/json-wallets": "1.2.1",
+                "@hethers/hdnode": "1.2.2",
+                "@hethers/json-wallets": "1.2.2",
                 "@hethers/logger": "1.2.0",
                 "@hethers/signing-key": "1.2.0",
                 "@hethers/transactions": "1.2.2"
@@ -29597,6 +28712,7 @@
             "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.9.tgz",
             "integrity": "sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==",
             "dev": true,
+            "optional": true,
             "requires": {
                 "node-gyp-build": "4.3.0"
             }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "check:node": "ts-node packages/server/tests/helpers/nodeCheck.ts"
     },
     "dependencies": {
-        "@hashgraph/hedera-local": "^2.4.1",
+        "@hashgraph/hedera-local": "^2.4.3",
         "@open-rpc/schema-utils-js": "^1.16.1",
         "@types/find-config": "^1.0.1",
         "keyv-file": "^0.2.0",

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1050,7 +1050,7 @@ export class EthImpl implements Eth {
 
     return new Transaction({
       accessList: undefined, // we don't support access lists, so punt for now
-      blockHash: contractResult.block_hash.substring(0, 66),
+      blockHash: EthImpl.toHash32(contractResult.block_hash),
       blockNumber: EthImpl.numberTo0x(contractResult.block_number),
       chainId: contractResult.chain_id,
       from: fromAddress,
@@ -1237,7 +1237,7 @@ export class EthImpl implements Eth {
       }
     }
 
-    const blockHash = blockResponse.hash.substring(0, 66);
+    const blockHash = EthImpl.toHash32(blockResponse.hash);
     const transactionArray = showDetails ? transactionObjects : transactionHashes;
     return new Block({
       baseFeePerGas: await this.gasPrice(requestId),
@@ -1327,7 +1327,7 @@ export class EthImpl implements Eth {
           const sSig = contractResultDetails.s === null ? null : contractResultDetails.s.substring(0, 66);
           return new Transaction({
             accessList: undefined, // we don't support access lists for now, so punt
-            blockHash: contractResultDetails.block_hash.substring(0, 66),
+            blockHash: EthImpl.toHash32(contractResultDetails.block_hash),
             blockNumber: EthImpl.numberTo0x(contractResultDetails.block_number),
             chainId: contractResultDetails.chain_id,
             from: contractResultDetails.from.substring(0, 42),

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@hashgraph/hedera-local": "^2.4.3",
-        "@hashgraph/sdk": "^2.19.0",
+        "@hashgraph/sdk": "^2.19.2",
         "@koa/cors": "^3.1.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,7 @@
         "pino-pretty": "^7.6.1"
     },
     "devDependencies": {
-        "@hashgraph/hedera-local": "^2.1.3",
+        "@hashgraph/hedera-local": "^2.4.3",
         "@hashgraph/sdk": "^2.19.0",
         "@koa/cors": "^3.1.0",
         "@types/chai": "^4.3.0",

--- a/packages/server/src/validator/constants.ts
+++ b/packages/server/src/validator/constants.ts
@@ -4,6 +4,7 @@ export const DEFAULT_HEX_ERROR = 'Expected 0x prefixed hexadecimal value';
 export const HASH_ERROR = '0x prefixed string representing the hash (32 bytes)';
 export const ADDRESS_ERROR = 'Expected 0x prefixed string representing the address (20 bytes)';
 export const BLOCK_NUMBER_ERROR = 'Expected 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending"';
+export const BLOCK_PARAMS_ERROR = `Expected ${HASH_ERROR} in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending`;
 export const BLOCK_HASH_ERROR = `Expected ${HASH_ERROR} of a block`;
 export const TRANSACTION_HASH_ERROR = `Expected ${HASH_ERROR} of a transaction`;
 export const TOPIC_HASH_ERROR = `Expected ${HASH_ERROR} of a topic`;

--- a/packages/server/src/validator/methods.ts
+++ b/packages/server/src/validator/methods.ts
@@ -65,7 +65,7 @@ export const METHODS = {
     },
     1: {
       required: true,
-      type: 'blockNumber'
+      type: 'blockParams'
     }
   },
   "eth_sendRawTransaction": {

--- a/packages/server/src/validator/methods.ts
+++ b/packages/server/src/validator/methods.ts
@@ -14,7 +14,7 @@ export const METHODS = {
       required: true
     },
     1: {
-      type: 'blockParams',
+      type: 'blockNumber',
       required: true
     }
   },
@@ -24,7 +24,7 @@ export const METHODS = {
       required: true
     },
     1: {
-      type: 'blockParams',
+      type: 'blockNumber',
       required: true
     }
   },
@@ -55,7 +55,7 @@ export const METHODS = {
     },
     1: {
       required: true,
-      type: 'blockParams'
+      type: 'blockNumber'
     }
   },
   "eth_call": {
@@ -127,7 +127,7 @@ export const METHODS = {
       type: 'hex'
     },
     2: {
-      type: 'blockParams'
+      type: 'blockNumber'
     }
   },
   "eth_getTransactionByBlockHashAndIndex": {

--- a/packages/server/src/validator/methods.ts
+++ b/packages/server/src/validator/methods.ts
@@ -14,7 +14,7 @@ export const METHODS = {
       required: true
     },
     1: {
-      type: 'blockNumber',
+      type: 'blockParams',
       required: true
     }
   },
@@ -24,7 +24,7 @@ export const METHODS = {
       required: true
     },
     1: {
-      type: 'blockNumber',
+      type: 'blockParams',
       required: true
     }
   },
@@ -55,7 +55,7 @@ export const METHODS = {
     },
     1: {
       required: true,
-      type: 'blockNumber'
+      type: 'blockParams'
     }
   },
   "eth_call": {
@@ -127,7 +127,7 @@ export const METHODS = {
       type: 'hex'
     },
     2: {
-      type: 'blockNumber'
+      type: 'blockParams'
     }
   },
   "eth_getTransactionByBlockHashAndIndex": {

--- a/packages/server/src/validator/objectTypes.ts
+++ b/packages/server/src/validator/objectTypes.ts
@@ -2,6 +2,16 @@ import { Validator } from ".";
 import { predefined } from '@hashgraph/json-rpc-relay';
 
 export const OBJECTS_VALIDATIONS = {
+  "blockHashObject": {
+    "blockHash": {
+      type: "blockHash"
+    }
+  },
+  "blockNumberObject": {
+    "blockNumber": {
+      type: "blockNumber"
+    }
+  },
   "filter": {
     "blockHash": {
       type: "blockHash"
@@ -118,3 +128,38 @@ export class FilterObject {
     return this.constructor.name;
   }
 };
+
+export class BlockHashObject {
+  blockHash: string;
+
+  constructor (param: any) {
+    Validator.hasUnexpectedParams(param, OBJECTS_VALIDATIONS.blockHashObject, this.name());
+    this.blockHash = param.blockHash;
+  }
+
+  validate() {
+    return Validator.validateObject(this, OBJECTS_VALIDATIONS.blockHashObject);
+  }
+
+  name() {
+    return this.constructor.name;
+  }
+};
+
+export class BlockNumberObject {
+  blockNumber: string;
+
+  constructor (param: any) {
+    Validator.hasUnexpectedParams(param, OBJECTS_VALIDATIONS.blockNumberObject, this.name());
+    this.blockNumber = param.blockNumber;
+  }
+
+  validate() {
+    return Validator.validateObject(this, OBJECTS_VALIDATIONS.blockNumberObject);
+  }
+
+  name() {
+    return this.constructor.name;
+  }
+};
+

--- a/packages/server/src/validator/types.ts
+++ b/packages/server/src/validator/types.ts
@@ -30,6 +30,18 @@ export const TYPES = {
     test: (param: boolean) => param === true || param === false,
     error: 'Expected boolean type'
   },
+  'blockParams': {
+    test: (param: any) => {
+      if(Object.prototype.toString.call(param) === "[object Object]") {
+        if (param.hasOwnProperty('blockHash')) {
+          return new Validator.BlockHashObject(param).validate();
+        }
+        return new Validator.BlockNumberObject(param).validate();
+      }
+      return /^0[xX]([1-9A-Fa-f]+[0-9A-Fa-f]{0,13}|0)$/.test(param) && Number.MAX_SAFE_INTEGER >= Number(param) || ["earliest", "latest", "pending"].includes(param)
+    },
+    error: Constants.BLOCK_PARAMS_ERROR
+  },
   "filter": {
     test: (param: any) => {
       if(Object.prototype.toString.call(param) === "[object Object]") {

--- a/packages/server/src/validator/types.ts
+++ b/packages/server/src/validator/types.ts
@@ -23,7 +23,7 @@ export const TYPES = {
     error: Constants.BLOCK_HASH_ERROR
   },
   'blockNumber': {
-    test: (param: string) => /^0[xX]([1-9A-Fa-f]+[0-9A-Fa-f]{0,13}|0)$/.test(param) && Number.MAX_SAFE_INTEGER >= Number(param) || ["earliest", "latest", "pending"].includes(param),
+    test: (param: string) => /^0[xX]([1-9A-Fa-f][0-9A-Fa-f]{0,13}|0)$/.test(param) && Number.MAX_SAFE_INTEGER >= Number(param) || ["earliest", "latest", "pending"].includes(param),
     error: Constants.BLOCK_NUMBER_ERROR
   },
   'boolean': {

--- a/packages/server/tests/acceptance/erc20.spec.ts
+++ b/packages/server/tests/acceptance/erc20.spec.ts
@@ -171,9 +171,10 @@ describe('@erc20 Acceptance Tests', async function () {
                                 });
 
                                 it('emits a transfer event', async function () {
-                                    await expect(tx)
-                                        .to.emit(contract, 'Transfer')
-                                        .withArgs(tokenOwnerWallet.address, toWallet.address, amount);
+                                    const transferEvent = (await tx.wait()).events.filter(e => e.event === 'Transfer')[0].args;
+                                    expect(transferEvent.from).to.eq(tokenOwnerWallet.address);
+                                    expect(transferEvent.to).to.eq(toWallet.address);
+                                    expect(transferEvent.value).to.eq(amount);
                                 });
 
                                 it ('other account transfers tokens back to owner', async function () {
@@ -194,9 +195,10 @@ describe('@erc20 Acceptance Tests', async function () {
 
                                 it('emits an approval event', async function () {
                                     const allowance = await contract.allowance(tokenOwner, spender);
-                                    await expect(tx)
-                                        .to.emit(contract, 'Approval')
-                                        .withArgs(tokenOwnerWallet.address, spenderWallet.address, allowance);
+                                    const approvalEvent = (await tx.wait()).events.filter(e => e.event === 'Approval')[0].args;
+                                    expect(approvalEvent.owner).to.eq(tokenOwnerWallet.address);
+                                    expect(approvalEvent.spender).to.eq(spenderWallet.address);
+                                    expect(approvalEvent.value).to.eq(allowance);
                                 });
 
                                 describe('when the token owner has enough balance', function () {
@@ -224,9 +226,10 @@ describe('@erc20 Acceptance Tests', async function () {
                                     });
 
                                     it('emits a transfer event', async function () {
-                                        await expect(tx)
-                                            .to.emit(contract, 'Transfer')
-                                            .withArgs(tokenOwnerWallet.address, toWallet.address, amount);
+                                        const transferEvent = (await tx.wait()).events.filter(e => e.event === 'Transfer')[0].args;
+                                        expect(transferEvent.from).to.eq(tokenOwnerWallet.address);
+                                        expect(transferEvent.to).to.eq(toWallet.address);
+                                        expect(transferEvent.value).to.eq(amount);
                                     });
                                 });
 
@@ -360,9 +363,8 @@ describe('@erc20 Acceptance Tests', async function () {
             await servicesNode.associateHTSToken(account.accountId, htsResult.receipt.tokenId, account.privateKey, htsResult.client, requestId);
             await servicesNode.approveHTSToken(account.accountId, htsResult.receipt.tokenId, htsResult.client, requestId);
         }
-
         // Setup initial balance of token owner account
-        await servicesNode.transferHTSToken(accounts[0].accountId, htsResult.receipt.tokenId, initialSupply, htsResult.client, requestId);
+        await servicesNode.transferHTSToken(accounts[0].accountId, htsResult.receipt.tokenId, initialSupply, htsResult.client.operatorAccountId, requestId);
         const evmAddress = Utils.idToEvmAddress(htsResult.receipt.tokenId.toString());
         return new ethers.Contract(evmAddress, abi, accounts[0].wallet);
     };

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -125,9 +125,9 @@ describe('RPC Server Acceptance Tests', function () {
 
     function runLocalHederaNetwork() {
         // set env variables for docker images until local-node is updated
-        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.33.2';
-        process.env['HAVEGED_IMAGE_TAG'] = '0.33.2';
-        process.env['MIRROR_IMAGE_TAG'] = '0.72.0';
+        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.32.0';
+        process.env['HAVEGED_IMAGE_TAG'] = '0.32.0';
+        process.env['MIRROR_IMAGE_TAG'] = '0.70.1';
 
         console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -125,9 +125,9 @@ describe('RPC Server Acceptance Tests', function () {
 
     function runLocalHederaNetwork() {
         // set env variables for docker images until local-node is updated
-        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.32.0';
-        process.env['HAVEGED_IMAGE_TAG'] = '0.32.0';
-        process.env['MIRROR_IMAGE_TAG'] = '0.70.1';
+        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.33.2';
+        process.env['HAVEGED_IMAGE_TAG'] = '0.33.2';
+        process.env['MIRROR_IMAGE_TAG'] = '0.72.0';
 
         console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -1300,7 +1300,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                 expect(res).to.eq(BASIC_CONTRACT_PING_RESULT);
             });
 
-            it('should fail to execute "eth_call" with correct block number', async function () {
+            it('should execute "eth_call" with correct block number', async function () {
                 const callData = {
                     from: '0x' + accounts[2].address,
                     to: evmAddress,
@@ -1311,7 +1311,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                 expect(res).to.eq(BASIC_CONTRACT_PING_RESULT);
             });
 
-            it('should fail to execute "eth_call" with correct block hash', async function () {
+            it('should execute "eth_call" with correct block hash object', async function () {
                 const blockHash = '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3';
                 const callData = {
                     from: '0x' + accounts[2].address,
@@ -1323,7 +1323,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                 expect(res).to.eq(BASIC_CONTRACT_PING_RESULT);
             });
 
-            it('should fail to execute "eth_call" with correct block hash', async function () {
+            it('should execute "eth_call" with correct block number object', async function () {
                 const callData = {
                     from: '0x' + accounts[2].address,
                     to: evmAddress,

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -1299,6 +1299,101 @@ describe('@api RPC Server Acceptance Tests', function () {
                 const res = await relay.call('eth_call', [callData, 'latest'], requestId);
                 expect(res).to.eq(BASIC_CONTRACT_PING_RESULT);
             });
+
+            it('should fail to execute "eth_call" with correct block number', async function () {
+                const callData = {
+                    from: '0x' + accounts[2].address,
+                    to: evmAddress,
+                    data: BASIC_CONTRACT_PING_CALL_DATA
+                };
+                
+                const res = await relay.call('eth_call', [callData, '0x1'], requestId);
+                expect(res).to.eq(BASIC_CONTRACT_PING_RESULT);
+            });
+
+            it('should fail to execute "eth_call" with correct block hash', async function () {
+                const blockHash = '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3';
+                const callData = {
+                    from: '0x' + accounts[2].address,
+                    to: evmAddress,
+                    data: BASIC_CONTRACT_PING_CALL_DATA
+                };
+                
+                const res = await relay.call('eth_call', [callData, {'blockHash' : blockHash}], requestId);
+                expect(res).to.eq(BASIC_CONTRACT_PING_RESULT);
+            });
+
+            it('should fail to execute "eth_call" with correct block hash', async function () {
+                const callData = {
+                    from: '0x' + accounts[2].address,
+                    to: evmAddress,
+                    data: BASIC_CONTRACT_PING_CALL_DATA
+                };
+                
+                const res = await relay.call('eth_call', [callData, {'blockNumber' : '0x1'}], requestId);
+                expect(res).to.eq(BASIC_CONTRACT_PING_RESULT);
+            });
+
+            it('should fail to execute "eth_call" with wrong block tag', async function () {
+                const callData = {
+                    from: '0x' + accounts[2].address,
+                    to: evmAddress,
+                    data: BASIC_CONTRACT_PING_CALL_DATA
+                };
+                
+                try {
+                    await relay.call('eth_call', [callData, 'newest'], requestId);
+                    Assertions.expectedError();
+                } catch (error) {
+                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending'));
+                }
+            });
+
+            it('should fail to execute "eth_call" with wrong block number', async function () {
+                const callData = {
+                    from: '0x' + accounts[2].address,
+                    to: evmAddress,
+                    data: BASIC_CONTRACT_PING_CALL_DATA
+                };
+                
+                try {
+                    await relay.call('eth_call', [callData, '123'], requestId);
+                    Assertions.expectedError();
+                } catch (error) {
+                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending'));
+                }
+            });
+
+            it('should fail to execute "eth_call" with wrong block hash object', async function () {
+                const callData = {
+                    from: '0x' + accounts[2].address,
+                    to: evmAddress,
+                    data: BASIC_CONTRACT_PING_CALL_DATA
+                };
+                
+                try {
+                    await relay.call('eth_call', [callData, {'blockHash' : '0x123'}], requestId);
+                    Assertions.expectedError();
+                } catch (error) {
+
+                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(`'blockHash' for BlockHashObject`, 'Expected 0x prefixed string representing the hash (32 bytes) of a block'));
+                }
+            });
+
+            it('should fail to execute "eth_call" with wrong block number object', async function () {
+                const callData = {
+                    from: '0x' + accounts[2].address,
+                    to: evmAddress,
+                    data: BASIC_CONTRACT_PING_CALL_DATA
+                };
+                
+                try {
+                    await relay.call('eth_call', [callData, {'blockNumber' : '123'}], requestId);
+                    Assertions.expectedError();
+                } catch (error) {
+                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, 'Expected 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending"'));
+                }
+            });
         });
 
         // Test state changes with getStorageAt

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -11,9 +11,9 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
 
 (function () {
   if (USE_LOCAL_NODE) {
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.33.2';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.33.2';
-    process.env['MIRROR_IMAGE_TAG'] = '0.72.0';
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.32.0';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.32.0';
+    process.env['MIRROR_IMAGE_TAG'] = '0.70.1';
 
     console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -11,9 +11,9 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
 
 (function () {
   if (USE_LOCAL_NODE) {
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.32.0';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.32.0';
-    process.env['MIRROR_IMAGE_TAG'] = '0.70.1';
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.33.2';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.33.2';
+    process.env['MIRROR_IMAGE_TAG'] = '0.72.0';
 
     console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -1096,7 +1096,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
         }
       });
 
@@ -1111,7 +1111,38 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+        }
+      });
+
+      it('validates Block param is valid block hash', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_call',
+            'params': [{"to": "0x0000000000000000000000000000000000000001"}, { "blockHash": "0x123" }]
+          });
+
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
+        }
+      });
+
+      it('validates Block param is valid block number', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_call',
+            'params': [{"to": "0x0000000000000000000000000000000000000001"}, { "blockNumber": "123" }]
+          });
+
+          Assertions.expectedError();
+        } catch (error) {
+          console.log(error.response)
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -609,7 +609,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 1 is non valid block number', async function() {
+      it('validates parameter 1 is valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -620,11 +620,12 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+
         }
       });
 
-      it('validates parameter 1 is non valid block tag', async function() {
+      it('validates parameter 1 is valid block tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -635,37 +636,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
-        }
-      });
-
-      it('validates Block param is non valid block hash object', async function() {
-        try {
-          await this.testClient.post('/', {
-            'id': '2',
-            'jsonrpc': '2.0',
-            'method': 'eth_getBalance',
-            'params': ["0x0000000000000000000000000000000000000001", { "blockHash": "0x123" }]
-          });
-
-          Assertions.expectedError();
-        } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
-        }
-      });
-
-      it('validates Block param is non valid block number object', async function() {
-        try {
-          await this.testClient.post('/', {
-            'id': '2',
-            'jsonrpc': '2.0',
-            'method': 'eth_getBalance',
-            'params': ["0x0000000000000000000000000000000000000001", { "blockNumber": "123" }]
-          });
-
-          Assertions.expectedError();
-        } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });
@@ -717,7 +688,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 1 is non valid block number', async function() {
+      it('validates parameter 1 is valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -728,11 +699,11 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
 
-      it('validates parameter 1 is non valid block tag', async function() {
+      it('validates parameter 1 is valid block tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -743,37 +714,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
-        }
-      });
-
-      it('validates Block param is non valid block hash object', async function() {
-        try {
-          await this.testClient.post('/', {
-            'id': '2',
-            'jsonrpc': '2.0',
-            'method': 'eth_getCode',
-            'params': ["0x0000000000000000000000000000000000000001", { "blockHash": "0x123" }]
-          });
-          0x1204567890abcde
-          Assertions.expectedError();
-        } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
-        }
-      });
-
-      it('validates Block param is non valid block number object', async function() {
-        try {
-          await this.testClient.post('/', {
-            'id': '2',
-            'jsonrpc': '2.0',
-            'method': 'eth_getCode',
-            'params': ["0x0000000000000000000000000000000000000001", { "blockNumber": "123" }]
-          });
-
-          Assertions.expectedError();
-        } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });
@@ -963,7 +904,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 1 is a non valid block number', async function() {
+      it('validates parameter 1 is a valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -974,11 +915,11 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
 
-      it('validates parameter 1 is a non valid block tag', async function() {
+      it('validates parameter 1 is a valid block tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -989,37 +930,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
-        }
-      });
-
-      it('validates Block param is non valid block hash object', async function() {
-        try {
-          await this.testClient.post('/', {
-            'id': '2',
-            'jsonrpc': '2.0',
-            'method': 'eth_getTransactionCount',
-            'params': ["0x0000000000000000000000000000000000000001", { "blockHash": "0x123" }]
-          });
-          0x1204567890abcde
-          Assertions.expectedError();
-        } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
-        }
-      });
-
-      it('validates Block param is non valid block number object', async function() {
-        try {
-          await this.testClient.post('/', {
-            'id': '2',
-            'jsonrpc': '2.0',
-            'method': 'eth_getTransactionCount',
-            'params': ["0x0000000000000000000000000000000000000001", { "blockNumber": "123" }]
-          });
-
-          Assertions.expectedError();
-        } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });
@@ -1471,7 +1382,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 1 is non valid hex', async function() {
+      it('validates parameter 1 is valid hex', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1486,7 +1397,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 2 is non valid block number', async function() {
+      it('validates parameter 2 is valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1497,11 +1408,11 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_PARAMS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
 
-      it('validates parameter 2 is non valid block tag', async function() {
+      it('validates parameter 2 is valid block tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1512,37 +1423,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_PARAMS_ERROR}`);
-        }
-      });
-
-      it('validates Block param is non valid block hash object', async function() {
-        try {
-          await this.testClient.post('/', {
-            'id': '2',
-            'jsonrpc': '2.0',
-            'method': 'eth_getStorageAt',
-            'params': ["0x0000000000000000000000000000000000000001", "0x1", { "blockHash": "0x123" }]
-          });
-          0x1204567890abcde
-          Assertions.expectedError();
-        } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
-        }
-      });
-
-      it('validates Block param is non valid block number object', async function() {
-        try {
-          await this.testClient.post('/', {
-            'id': '2',
-            'jsonrpc': '2.0',
-            'method': 'eth_getStorageAt',
-            'params': ["0x0000000000000000000000000000000000000001", "0x1", { "blockNumber": "123" }]
-          });
-
-          Assertions.expectedError();
-        } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -609,7 +609,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 1 is valid block number', async function() {
+      it('validates parameter 1 is non valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -620,12 +620,11 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
-
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
         }
       });
 
-      it('validates parameter 1 is valid block tag', async function() {
+      it('validates parameter 1 is non valid block tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -636,7 +635,37 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+        }
+      });
+
+      it('validates Block param is non valid block hash object', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_getBalance',
+            'params': ["0x0000000000000000000000000000000000000001", { "blockHash": "0x123" }]
+          });
+
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
+        }
+      });
+
+      it('validates Block param is non valid block number object', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_getBalance',
+            'params': ["0x0000000000000000000000000000000000000001", { "blockNumber": "123" }]
+          });
+
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });
@@ -688,7 +717,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 1 is valid block number', async function() {
+      it('validates parameter 1 is non valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -699,11 +728,11 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
         }
       });
 
-      it('validates parameter 1 is valid block tag', async function() {
+      it('validates parameter 1 is non valid block tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -714,7 +743,37 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+        }
+      });
+
+      it('validates Block param is non valid block hash object', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_getCode',
+            'params': ["0x0000000000000000000000000000000000000001", { "blockHash": "0x123" }]
+          });
+          0x1204567890abcde
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
+        }
+      });
+
+      it('validates Block param is non valid block number object', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_getCode',
+            'params': ["0x0000000000000000000000000000000000000001", { "blockNumber": "123" }]
+          });
+
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });
@@ -904,7 +963,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 1 is a valid block number', async function() {
+      it('validates parameter 1 is a non valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -915,11 +974,11 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
         }
       });
 
-      it('validates parameter 1 is a valid block tag', async function() {
+      it('validates parameter 1 is a non valid block tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -930,7 +989,37 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+        }
+      });
+
+      it('validates Block param is non valid block hash object', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_getTransactionCount',
+            'params': ["0x0000000000000000000000000000000000000001", { "blockHash": "0x123" }]
+          });
+          0x1204567890abcde
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
+        }
+      });
+
+      it('validates Block param is non valid block number object', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_getTransactionCount',
+            'params': ["0x0000000000000000000000000000000000000001", { "blockNumber": "123" }]
+          });
+
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });
@@ -1085,7 +1174,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates Block param is valid block hex', async function() {
+      it('validates Block param is non valid block hex', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1100,7 +1189,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates Block param is valid tag', async function() {
+      it('validates Block param is non valid tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1115,7 +1204,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates Block param is valid block hash', async function() {
+      it('validates Block param is non valid block hash', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1130,7 +1219,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates Block param is valid block number', async function() {
+      it('validates Block param is non valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1141,7 +1230,6 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          console.log(error.response)
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
@@ -1383,7 +1471,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 1 is valid hex', async function() {
+      it('validates parameter 1 is non valid hex', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1398,7 +1486,7 @@ describe('RPC Server', async function() {
         }
       });
 
-      it('validates parameter 2 is valid block number', async function() {
+      it('validates parameter 2 is non valid block number', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1409,11 +1497,11 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_PARAMS_ERROR}`);
         }
       });
 
-      it('validates parameter 2 is valid block tag', async function() {
+      it('validates parameter 2 is non valid block tag', async function() {
         try {
           await this.testClient.post('/', {
             'id': '2',
@@ -1424,7 +1512,37 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_PARAMS_ERROR}`);
+        }
+      });
+
+      it('validates Block param is non valid block hash object', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_getStorageAt',
+            'params': ["0x0000000000000000000000000000000000000001", "0x1", { "blockHash": "0x123" }]
+          });
+          0x1204567890abcde
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
+        }
+      });
+
+      it('validates Block param is non valid block number object', async function() {
+        try {
+          await this.testClient.post('/', {
+            'id': '2',
+            'jsonrpc': '2.0',
+            'method': 'eth_getStorageAt',
+            'params': ["0x0000000000000000000000000000000000000001", "0x1", { "blockNumber": "123" }]
+          });
+
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
         }
       });
     });


### PR DESCRIPTION
Signed-off-by: georgi-l95 <glazarov95@gmail.com>

**Description**:
Expand `eth_call` validation to support `blockParam` object, introduced with [EIP-1898](https://eips.ethereum.org/EIPS/eip-1898). The Graph is passing blockHash as parameter and currently validations only accepts `blockNumber` or `tag`. More info can be found in this issue from this [comment](https://github.com/hashgraph/hedera-json-rpc-relay/issues/626#issuecomment-1383554578) onwards.

Fix some minor intermittent bugs in ERC20 tests.

Bump network images to `0.33.2` and mirror-node images to `0.72.0`.

**Related issue(s)**:

Fixes #816 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
