### PR TITLE
Fix cache on getBalance

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -603,12 +603,6 @@ export class EthImpl implements Eth {
       }
     }
 
-    // Cache is only set for `not found` balances
-    const cachedLabel = `getBalance.${account}.${blockNumberOrTag}`;
-    const cachedResponse: string | undefined = this.cache.get(cachedLabel);
-    if (cachedResponse != undefined) {
-      return cachedResponse;
-    }
     let blockNumber = null;
     let balanceFound = false;
     let weibars: BigNumber | number = 0;
@@ -678,7 +672,6 @@ export class EthImpl implements Eth {
 
       if (!balanceFound) {
         this.logger.debug(`${requestIdPrefix} Unable to find account ${account} in block ${JSON.stringify(blockNumber)}(${blockNumberOrTag}), returning 0x0 balance`);
-        this.cache.set(cachedLabel, EthImpl.zeroHex);
         return EthImpl.zeroHex;
       }
 


### PR DESCRIPTION
Signed-off-by: nikolay <n.atanasow94@gmail.com>

**Description**:
Remove cache on getBalance, when account doesn't exist, because after HIP 583 we can create accounts via metamask, which asks for balance, before creation and can get stuck on 0.

**Related issue(s)**:

Fixes #815

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
