### PR TITLE
Bump acceptance test node images

### DIFF
--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -125,9 +125,9 @@ describe('RPC Server Acceptance Tests', function () {
 
     function runLocalHederaNetwork() {
         // set env variables for docker images until local-node is updated
-        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.33.2';
-        process.env['HAVEGED_IMAGE_TAG'] = '0.33.2';
-        process.env['MIRROR_IMAGE_TAG'] = '0.72.0';
+        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.35.0-alpha.1';
+        process.env['HAVEGED_IMAGE_TAG'] = '0.35.0-alpha.1';
+        process.env['MIRROR_IMAGE_TAG'] = '0.73.0-rc1';
 
         console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -11,9 +11,9 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
 
 (function () {
   if (USE_LOCAL_NODE) {
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.33.2';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.33.2';
-    process.env['MIRROR_IMAGE_TAG'] = '0.72.0';
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.35.0-alpha.1';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.35.0-alpha.1';
+    process.env['MIRROR_IMAGE_TAG'] = '0.73.0-rc1';
 
     console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 


### PR DESCRIPTION
Signed-off-by: georgi-l95 <glazarov95@gmail.com>

**Description**:

Bump acceptance test node images to:
- Network node: 0.35.0-alpha.1
- Mirror node: 0.73.0-rc1

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
