### PR TITLE
Remove unnecessary call when details not requested

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1223,9 +1223,13 @@ export class EthImpl implements Eth {
     for (const result of contractResults.results) {
       // depending on stage of contract execution revert the result.to value may be null
       if (!_.isNil(result.to)) {
-        const transaction = await this.getTransactionFromContractResult(result.to, result.timestamp, requestId);
-        if (transaction !== null) {
-          showDetails ? transactionObjects.push(transaction) : transactionHashes.push(transaction.hash);
+        if(showDetails) {
+          const transaction = await this.getTransactionFromContractResult(result.to, result.timestamp, requestId);
+          if (transaction !== null) {
+            transactionObjects.push(transaction);
+          }  
+        } else {
+          transactionHashes.push(result.hash);
         }
       }
     }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -652,8 +652,6 @@ describe('Eth calls using MirrorNode', async function () {
     // mirror node request mocks
     mock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
     mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultContractResults);
-    mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResults);
-    mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults);
     mock.onGet('network/fees').reply(200, defaultNetworkFees);
     const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
     expect(result).to.exist;
@@ -667,7 +665,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(2);
     expect((result.transactions[0] as string)).equal(contractHash1);
-    expect((result.transactions[1] as string)).equal(contractHash1);
+    expect((result.transactions[1] as string)).equal(contractHash2);
 
     // verify expected constants
     verifyBlockConstants(result);
@@ -826,8 +824,6 @@ describe('Eth calls using MirrorNode', async function () {
     // mirror node request mocks
     mock.onGet(`blocks/${blockHash}`).reply(200, defaultBlock);
     mock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultContractResults);
-    mock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResults);
-    mock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults);
     mock.onGet('network/fees').reply(200, defaultNetworkFees);
 
     const result = await ethImpl.getBlockByHash(blockHash, false);
@@ -842,7 +838,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result.timestamp).equal(blockTimestampHex);
     expect(result.transactions.length).equal(2);
     expect((result.transactions[0] as string)).equal(contractHash1);
-    expect((result.transactions[1] as string)).equal(contractHash1);
+    expect((result.transactions[1] as string)).equal(contractHash2);
 
     // verify expected constants
     verifyBlockConstants(result);


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

**Description**:

Do not make additional calls to the mirror node unnecessarily when `showDetails` parameter is false.  The transaction hash is already available in the result set from the first call to retrieve contractResults.

In the example in issue #827, the block contained 100 contract results.  Iterating over them when details were not asked for was needlessly costly.
 
**Related issue(s)**:

Fixes #840 and #827 (the particular use case in this issue)

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
