### PR TITLE
Add nullable check to estimateGas validation

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -322,7 +322,7 @@ export class EthImpl implements Eth {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async estimateGas(transaction: any, _blockParam: string | null, requestId?: string) {
     const requestIdPrefix = formatRequestIdMessage(requestId);
-    this.logger.trace(`${requestIdPrefix} estimateGas()`);
+    this.logger.trace(`${requestIdPrefix} estimateGas(transaction=${JSON.stringify(transaction)}, _blockParam=${_blockParam})`);
     if (!transaction || !transaction.data || transaction.data === '0x') {
       return EthImpl.gasTxBaseCost;
     } else {

--- a/packages/server/src/validator/objectTypes.ts
+++ b/packages/server/src/validator/objectTypes.ts
@@ -4,70 +4,90 @@ import { predefined } from '@hashgraph/json-rpc-relay';
 export const OBJECTS_VALIDATIONS = {
   "blockHashObject": {
     "blockHash": {
-      type: "blockHash"
+      type: "blockHash",
+      nullable: false
     }
   },
   "blockNumberObject": {
     "blockNumber": {
-      type: "blockNumber"
+      type: "blockNumber",
+      nullable: false
     }
   },
   "filter": {
     "blockHash": {
-      type: "blockHash"
+      type: "blockHash",
+      nullable: false
     },
     "fromBlock": {
-      type: "blockNumber"
+      type: "blockNumber",
+      nullable: false
     },
     "toBlock": {
-      type: "blockNumber"
+      type: "blockNumber",
+      nullable: false
     },
     "address": {
-      type: "addressFilter"
+      type: "addressFilter",
+      nullable: false
     },
     "topics": {
-      type: "topics"
+      type: "topics",
+      nullable: false
     }
   },
   "transaction": {
     "from": {
-      type: "address"
+      type: "address",
+      nullable: false
     },
     "to": {
-      type: "address"
+      type: "address",
+      nullable: false
     },
     "gas": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "gasPrice": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "maxPriorityFeePerGas": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "maxFeePerGas": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "value": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "data": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "type": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "chainId": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "nonce": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "input": {
-      type: "hex"
+      type: "hex",
+      nullable: false
     },
     "accessList": {
-      type: "array"
+      type: "array",
+      nullable: false
     }
   }
 };
@@ -95,6 +115,7 @@ export class TransactionObject {
   }
 
   validate() {
+    console.log(`transaction: ${JSON.stringify(this)}`)
     return Validator.validateObject(this, OBJECTS_VALIDATIONS.transaction);
   }
 

--- a/packages/server/src/validator/objectTypes.ts
+++ b/packages/server/src/validator/objectTypes.ts
@@ -67,7 +67,7 @@ export const OBJECTS_VALIDATIONS = {
     },
     "data": {
       type: "hex",
-      nullable: false
+      nullable: true
     },
     "type": {
       type: "hex",
@@ -115,7 +115,6 @@ export class TransactionObject {
   }
 
   validate() {
-    console.log(`transaction: ${JSON.stringify(this)}`)
     return Validator.validateObject(this, OBJECTS_VALIDATIONS.transaction);
   }
 

--- a/packages/server/src/validator/utils.ts
+++ b/packages/server/src/validator/utils.ts
@@ -31,16 +31,17 @@ export function validateObject(object: any, filters: any) {
       throw predefined.MISSING_REQUIRED_PARAMETER(`'${property}' for ${object.name()}`);
     }
 
-    if (param !== undefined) {
+    console.log(`${object.name()} isValidAndNonNullableParam: property ${property}, value: ${param}, isNullable: ${validation.nullable}`)
+    if (isValidAndNonNullableParam(param, validation.nullable)) {
       try {
         result = Validator.TYPES[validation.type].test(param);
 
         if(!result) {
-          throw predefined.INVALID_PARAMETER(`'${property}' for ${object.name()}`, Validator.TYPES[validation.type].error);
+          throw predefined.INVALID_PARAMETER(`'${property}' for ${object.name()}, value: ${param}`, Validator.TYPES[validation.type].error);
         }
       } catch(error: any) {
         if (error instanceof JsonRpcError) {
-          throw predefined.INVALID_PARAMETER(`'${property}' for ${object.name()}`, Validator.TYPES[validation.type].error);
+          throw predefined.INVALID_PARAMETER(`'${property}' for ${object.name()}, value: ${param}`, Validator.TYPES[validation.type].error);
         }
 
         throw error;
@@ -70,4 +71,8 @@ export function hasUnexpectedParams(actual: any, expected: any, object: string) 
 
 export function requiredIsMissing(param: any, required: boolean) {
   return required && param === undefined;
+}
+
+export function isValidAndNonNullableParam(param: any, nullable: boolean) {
+  return param !== undefined && (param !== null || !nullable);
 }

--- a/packages/server/src/validator/utils.ts
+++ b/packages/server/src/validator/utils.ts
@@ -16,7 +16,7 @@ export function validateParam(index: number | string, param: any, validation: an
   if (param != null) {
     const result = isArray? paramType.test(index, param, validation.type[1]) : paramType.test(param);
     if(result === false) {
-      throw predefined.INVALID_PARAMETER(index, paramType.error);
+      throw predefined.INVALID_PARAMETER(index, `${paramType.error}, value: ${param}`);
     }
   }
 }
@@ -31,17 +31,16 @@ export function validateObject(object: any, filters: any) {
       throw predefined.MISSING_REQUIRED_PARAMETER(`'${property}' for ${object.name()}`);
     }
 
-    console.log(`${object.name()} isValidAndNonNullableParam: property ${property}, value: ${param}, isNullable: ${validation.nullable}`)
     if (isValidAndNonNullableParam(param, validation.nullable)) {
       try {
         result = Validator.TYPES[validation.type].test(param);
 
         if(!result) {
-          throw predefined.INVALID_PARAMETER(`'${property}' for ${object.name()}, value: ${param}`, Validator.TYPES[validation.type].error);
+          throw predefined.INVALID_PARAMETER(`'${property}' for ${object.name()}`, `${Validator.TYPES[validation.type].error}, value: ${param}`);
         }
       } catch(error: any) {
         if (error instanceof JsonRpcError) {
-          throw predefined.INVALID_PARAMETER(`'${property}' for ${object.name()}, value: ${param}`, Validator.TYPES[validation.type].error);
+          throw predefined.INVALID_PARAMETER(`'${property}' for ${object.name()}`, `${Validator.TYPES[validation.type].error}, value: ${param}`);
         }
 
         throw error;

--- a/packages/server/tests/acceptance/rpc.spec.ts
+++ b/packages/server/tests/acceptance/rpc.spec.ts
@@ -961,8 +961,8 @@ describe('@api RPC Server Acceptance Tests', function () {
             it('should not be able to execute "eth_estimateGas" with wrong from field', async function () {
                 try {
                     await relay.call('eth_estimateGas', [{
-                        from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
-                        to: '0xae410f34f7487e2cd03396499cebb09b79f45',
+                        from: '0x114f60009ee6b84861c0cdae8829751e517b',
+                        to: '0xae410f34f7487e2cd03396499cebb09b79f45d6e',
                         value: '0xa688906bd8b00000',
                         gas: '0xd97010',
                         accessList: []
@@ -972,7 +972,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                     const err = JSON.parse(error.body);
                     expect(error).to.not.be.null;
                     expect(err.error.name).to.be.equal('Invalid parameter');
-                    expect(err.error.message.endsWith(`Invalid parameter 'to' for TransactionObject: Expected 0x prefixed string representing the address (20 bytes)`)).to.be.true;
+                    expect(err.error.message.endsWith(`Invalid parameter 'from' for TransactionObject: Expected 0x prefixed string representing the address (20 bytes), value: 0x114f60009ee6b84861c0cdae8829751e517b`)).to.be.true;
                 }
             });
 
@@ -990,7 +990,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                     const err = JSON.parse(error.body);
                     expect(error).to.not.be.null;
                     expect(err.error.name).to.be.equal('Invalid parameter');
-                    expect(err.error.message.endsWith(`Invalid parameter 'to' for TransactionObject: Expected 0x prefixed string representing the address (20 bytes)`)).to.be.true;
+                    expect(err.error.message.endsWith(`Invalid parameter 'to' for TransactionObject: Expected 0x prefixed string representing the address (20 bytes), value: 0xae410f34f7487e2cd03396499cebb09b79f45`)).to.be.true;
                 } 
             });
 
@@ -1008,7 +1008,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                     const err = JSON.parse(error.body);
                     expect(error).to.not.be.null;
                     expect(err.error.name).to.be.equal('Invalid parameter');
-                    expect(err.error.message.endsWith(`Invalid parameter 'value' for TransactionObject: Expected 0x prefixed hexadecimal value`)).to.be.true;
+                    expect(err.error.message.endsWith(`Invalid parameter 'value' for TransactionObject: Expected 0x prefixed hexadecimal value, value: 123`)).to.be.true;
                 } 
             });
 
@@ -1026,7 +1026,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                     const err = JSON.parse(error.body);
                     expect(error).to.not.be.null;
                     expect(err.error.name).to.be.equal('Invalid parameter');
-                    expect(err.error.message.endsWith(`Invalid parameter 'gas' for TransactionObject: Expected 0x prefixed hexadecimal value`)).to.be.true;
+                    expect(err.error.message.endsWith(`Invalid parameter 'gas' for TransactionObject: Expected 0x prefixed hexadecimal value, value: 123`)).to.be.true;
                 } 
             });
         });
@@ -1454,7 +1454,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                     await relay.call('eth_call', [callData, 'newest'], requestId);
                     Assertions.expectedError();
                 } catch (error) {
-                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending'));
+                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending, value: newest'));
                 }
             });
 
@@ -1469,7 +1469,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                     await relay.call('eth_call', [callData, '123'], requestId);
                     Assertions.expectedError();
                 } catch (error) {
-                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending'));
+                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending, value: 123'));
                 }
             });
 
@@ -1485,7 +1485,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                     Assertions.expectedError();
                 } catch (error) {
 
-                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(`'blockHash' for BlockHashObject`, 'Expected 0x prefixed string representing the hash (32 bytes) of a block'));
+                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(`'blockHash' for BlockHashObject`, 'Expected 0x prefixed string representing the hash (32 bytes) of a block, value: 0x123'));
                 }
             });
 
@@ -1500,7 +1500,7 @@ describe('@api RPC Server Acceptance Tests', function () {
                     await relay.call('eth_call', [callData, {'blockNumber' : '123'}], requestId);
                     Assertions.expectedError();
                 } catch (error) {
-                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, 'Expected 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending"'));
+                    Assertions.jsonRpcError(error,predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, 'Expected 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: 123'));
                 }
             });
         });

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -406,7 +406,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, "Expected TransactionObject");
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, "Expected TransactionObject, value: 0x0");
         }
       });
 
@@ -421,7 +421,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'to' for TransactionObject: ${Validator.ADDRESS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'to' for TransactionObject: ${Validator.ADDRESS_ERROR}, value: 0x1`);
         }      });
 
       it('validates Transaction `from` param is address', async function() {
@@ -435,7 +435,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'from' for TransactionObject: ${Validator.ADDRESS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'from' for TransactionObject: ${Validator.ADDRESS_ERROR}, value: 0x1`);
         }
       });
 
@@ -450,7 +450,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'gas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'gas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
 
       });
@@ -466,7 +466,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'gasPrice' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'gasPrice' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
 
       });
@@ -482,7 +482,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'maxPriorityFeePerGas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'maxPriorityFeePerGas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
 
       });
@@ -498,7 +498,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'maxFeePerGas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'maxFeePerGas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -513,7 +513,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'value' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'value' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -528,7 +528,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'data' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'data' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -543,7 +543,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
         }
       });
 
@@ -558,7 +558,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
         }
       });
     });
@@ -590,7 +590,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, Validator.ADDRESS_ERROR);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, Validator.ADDRESS_ERROR + ', value: 0x0');
         }
       });
 
@@ -620,7 +620,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
 
         }
       });
@@ -636,7 +636,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
         }
       });
     });
@@ -669,7 +669,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.ADDRESS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.ADDRESS_ERROR}, value: 0xb3b20624f8f0f86eb50dd04688409e5cea4bd02d700bf6e79e9384d47d6a5a35`);
         }
       });
 
@@ -699,7 +699,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
         }
       });
 
@@ -714,7 +714,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
         }
       });
     });
@@ -746,7 +746,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}, value: 1`);
         }
       });
 
@@ -761,7 +761,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
         }
       });
 
@@ -791,7 +791,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: Expected boolean type`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: Expected boolean type, value: true`);
         }
       });
     });
@@ -823,7 +823,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_HASH_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_HASH_ERROR}, value: 0x1`);
         }
       });
 
@@ -853,7 +853,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: Expected boolean type`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: Expected boolean type, value: true`);
         }
       });
     });
@@ -885,7 +885,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.ADDRESS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.ADDRESS_ERROR}, value: 0x0001`);
         }
       });
 
@@ -915,7 +915,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
         }
       });
 
@@ -930,7 +930,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
         }
       });
     });
@@ -962,7 +962,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, "Expected TransactionObject");
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, "Expected TransactionObject, value: 0x0");
         }
       });
 
@@ -977,7 +977,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'to' for TransactionObject: ${Validator.ADDRESS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'to' for TransactionObject: ${Validator.ADDRESS_ERROR}, value: 0x1`);
         }      });
 
       it('validates Transaction `from` param is address', async function() {
@@ -991,7 +991,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'from' for TransactionObject: ${Validator.ADDRESS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'from' for TransactionObject: ${Validator.ADDRESS_ERROR}, value: 0x1`);
         }
       });
 
@@ -1006,7 +1006,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'gas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'gas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -1021,7 +1021,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'gasPrice' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'gasPrice' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -1036,7 +1036,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'maxPriorityFeePerGas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'maxPriorityFeePerGas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -1051,7 +1051,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'maxFeePerGas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'maxFeePerGas' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -1066,7 +1066,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'value' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'value' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -1081,7 +1081,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'data' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'data' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`);
         }
       });
 
@@ -1096,7 +1096,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}, value: 123`);
         }
       });
 
@@ -1111,7 +1111,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_PARAMS_ERROR}, value: newest`);
         }
       });
 
@@ -1126,7 +1126,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for BlockHashObject: ${Validator.BLOCK_HASH_ERROR}, value: 0x123`);
         }
       });
 
@@ -1141,7 +1141,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockNumber' for BlockNumberObject: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
         }
       });
     });
@@ -1173,7 +1173,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.DEFAULT_HEX_ERROR}, value: f868`);
         }
       });
     });
@@ -1252,7 +1252,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: Expected Array`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: Expected Array, value: [object Object]`);
         }
       });
     });
@@ -1284,7 +1284,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_HASH_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_HASH_ERROR}, value: 0x1234`);
         }
       });
     });
@@ -1316,7 +1316,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}, value: 1234`);
         }
       });
 
@@ -1331,7 +1331,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
         }
       });
     });
@@ -1363,7 +1363,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.ADDRESS_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.ADDRESS_ERROR}, value: 0000000000000000000000000000000000000001`);
         }
       });
 
@@ -1393,7 +1393,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.DEFAULT_HEX_ERROR}, value: 1234`);
         }
       });
 
@@ -1408,7 +1408,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
         }
       });
 
@@ -1423,7 +1423,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
         }
       });
     });
@@ -1455,7 +1455,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_HASH_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_HASH_ERROR}, value: 0x1a2b3c`);
         }
       });
 
@@ -1485,7 +1485,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.DEFAULT_HEX_ERROR}, value: 08`);
         }
       });
     });
@@ -1517,7 +1517,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
         }
       });
 
@@ -1532,7 +1532,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
         }
       });
 
@@ -1562,7 +1562,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.DEFAULT_HEX_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.DEFAULT_HEX_ERROR}, value: 08`);
         }
       });
     });
@@ -1579,7 +1579,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.TYPES['filter'].error}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: ${Validator.TYPES['filter'].error}, value: 0x1`);
         }
       });
 
@@ -1594,6 +1594,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
+          console.log(error.response.data)
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: Can't use both blockHash and toBlock/fromBlock`);
         }
       });
@@ -1609,7 +1610,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for FilterObject: ${Validator.BLOCK_HASH_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'blockHash' for FilterObject: ${Validator.BLOCK_HASH_ERROR}, value: 0x123`);
         }
       });
 
@@ -1624,7 +1625,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'toBlock' for FilterObject: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'toBlock' for FilterObject: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
         }
       });
 
@@ -1639,7 +1640,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'fromBlock' for FilterObject: ${Validator.BLOCK_NUMBER_ERROR}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'fromBlock' for FilterObject: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
         }
       });
 
@@ -1654,7 +1655,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'address' for FilterObject: ${Validator.TYPES.addressFilter.error}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'address' for FilterObject: ${Validator.TYPES.addressFilter.error}, value: 0x012345`);
         }
       });
 
@@ -1669,7 +1670,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'topics' for FilterObject: ${Validator.TYPES['topics'].error}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'topics' for FilterObject: ${Validator.TYPES['topics'].error}, value: [object Object]`);
         }
       });
 
@@ -1684,7 +1685,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'topics' for FilterObject: ${Validator.TYPES['topics'].error}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'topics' for FilterObject: ${Validator.TYPES['topics'].error}, value: 123`);
         }
       });
 
@@ -1699,7 +1700,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'topics' for FilterObject: ${Validator.TYPES['topics'].error}`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 'topics' for FilterObject: ${Validator.TYPES['topics'].error}, value: 123`);
         }
       });
     });

--- a/packages/server/tests/integration/validator.spec.ts
+++ b/packages/server/tests/integration/validator.spec.ts
@@ -3,10 +3,16 @@ import { describe, it } from 'mocha';
 import { OBJECTS_VALIDATIONS, TransactionObject, Validator } from '../../src/validator';
 
 describe('Validator', async () => {
-  function expectInvalidParam(index: number | string, message: string, object?: string) {
-    return object
-      ? `Invalid parameter '${index}' for ${object}: ${message}`
-      : `Invalid parameter ${index}: ${message}`;
+  function expectInvalidParam(index: number | string, message: string, paramValue?: string) {
+    return `Invalid parameter ${index}: ${message}${paramValue ? `, value: ${paramValue}` : ''}`;
+  }
+
+  function expectUnknownParam(index: number | string, object: string, message: string) {
+    return `Invalid parameter '${index}' for ${object}: ${message}`;
+  }
+
+  function expectInvalidObject(index: number | string, message: string, object: string, paramValue: string) {
+    return `Invalid parameter '${index}' for ${object}: ${message}, value: ${paramValue}`;
   }
 
   describe('validates Address type correctly', async () => {
@@ -14,34 +20,34 @@ describe('Validator', async () => {
 
     it('throws an error if address hash is smaller than 20bytes', async () => {
       expect(() => Validator.validateParams(['0x4422E9088662'], validation)).to.throw(
-        expectInvalidParam(0, Validator.ADDRESS_ERROR)
+        expectInvalidParam(0, Validator.ADDRESS_ERROR, '0x4422E9088662')
       );
     });
 
     it('throws an error if address is larger than 20bytes', async () => {
       expect(() => Validator.validateParams(['0x4422E9088662c44604189B2aA3ae8eE282fceBB7b7b7'], validation)).to.throw(
-        expectInvalidParam(0, Validator.ADDRESS_ERROR)
+        expectInvalidParam(0, Validator.ADDRESS_ERROR, '0x4422E9088662c44604189B2aA3ae8eE282fceBB7b7b7')
       );
     });
 
     it('throws an error if address is NOT 0x prefixed', async () => {
       expect(() => Validator.validateParams(['4422E9088662c44604189B2aA3ae8eE282fceBB7'], validation)).to.throw(
-        expectInvalidParam(0, Validator.ADDRESS_ERROR)
+        expectInvalidParam(0, Validator.ADDRESS_ERROR, '4422E9088662c44604189B2aA3ae8eE282fceBB7')
       );
     });
 
     it('throws an error if address is other type', async () => {
       expect(() => Validator.validateParams(['random string'], validation)).to.throw(
-        expectInvalidParam(0, Validator.ADDRESS_ERROR)
+        expectInvalidParam(0, Validator.ADDRESS_ERROR, 'random string')
       );
       expect(() => Validator.validateParams(['123'], validation)).to.throw(
-        expectInvalidParam(0, Validator.ADDRESS_ERROR)
+        expectInvalidParam(0, Validator.ADDRESS_ERROR, '123')
       );
       expect(() => Validator.validateParams([[]], validation)).to.throw(
-        expectInvalidParam(0, Validator.ADDRESS_ERROR)
+        expectInvalidParam(0, Validator.ADDRESS_ERROR, '')
       );
       expect(() => Validator.validateParams([{}], validation)).to.throw(
-        expectInvalidParam(0, Validator.ADDRESS_ERROR)
+        expectInvalidParam(0, Validator.ADDRESS_ERROR, '[object Object]')
       );
     });
 
@@ -64,16 +70,16 @@ describe('Validator', async () => {
 
     it('throws an error if the param is not an array', async () => {
       expect(() => Validator.validateParams(["random string"], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, 'random string')
       );
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '123')
       );
       expect(() => Validator.validateParams([true], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, 'true')
       );
       expect(() => Validator.validateParams([{}], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '[object Object]')
       );
     });
 
@@ -87,34 +93,34 @@ describe('Validator', async () => {
 
     it('throws an error if block hash is smaller than 32bytes', async () => {
       expect(() => Validator.validateParams(['0xdec54931fcfe'], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR, '0xdec54931fcfe')
       );
     });
 
     it('throws an error if block hash is larger than 32bytes', async () => {
       expect(() => Validator.validateParams(['0xdec54931fcfe053f3ffec90c1f7fd20158420b415054f15a4d16b63c528f70a8a8a8'], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR, '0xdec54931fcfe053f3ffec90c1f7fd20158420b415054f15a4d16b63c528f70a8a8a8')
       );
     });
 
     it('throws an error if block hash is NOT 0x prefixed', async () => {
       expect(() => Validator.validateParams(['dec54931fcfe053f3ffec90c1f7fd20158420b415054f15a4d16b63c528f70a8a8a8'], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR, 'dec54931fcfe053f3ffec90c1f7fd20158420b415054f15a4d16b63c528f70a8a8a8')
       );
     });
 
     it('throws an error if block hash is other type', async () => {
       expect(() => Validator.validateParams(['string'], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR, 'string')
       );
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR, '123')
       );
       expect(() => Validator.validateParams([[]], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR, '')
       );
       expect(() => Validator.validateParams([{}], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_HASH_ERROR, '[object Object]')
       );
     });
 
@@ -130,49 +136,49 @@ describe('Validator', async () => {
 
     it('throws error if block number is decimal', async () => {
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, '123')
       );
     });
 
     it('throws error if block number is NOT 0x prefixed hex', async () => {
       expect(() => Validator.validateParams(["000f"], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, '000f')
       );
     });
 
     it('throws error if block number is hex with leading zeros digits', async () => {
       expect(() => Validator.validateParams(["0x00000000000000a"], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, '0x00000000000000a')
       );
     });
 
     it('throws error if block number is greater than (2^53 – 1)', async () => {
       expect(() => Validator.validateParams(["0x20000000000007"], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, '0x20000000000007')
       );
     });
 
     it('throws error if block number contains invalid hex characters', async () => {
       expect(() => Validator.validateParams(["0xg"], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, '0xg')
       );
     });
 
     it('throws error if block number is not correct tag', async () => {
       expect(() => Validator.validateParams(["newest"], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, 'newest')
       );
     });
 
     it('throws error if block number is random type', async () => {
       expect(() => Validator.validateParams(['string'], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, 'string')
       );
       expect(() => Validator.validateParams([[]], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, '')
       );
       expect(() => Validator.validateParams([{}], validation)).to.throw(
-        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR)
+        expectInvalidParam(0, Validator.BLOCK_NUMBER_ERROR, '[object Object]')
       );
     });
 
@@ -197,34 +203,34 @@ describe('Validator', async () => {
 
     it('throws an error if param is string', async () => {
       expect(() => Validator.validateParams(["true"], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, 'true')
       );
       expect(() => Validator.validateParams(["false"], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, 'false')
       );
     });
 
     it('throws an error if param is other type of truthy or falsy value', async () => {
       expect(() => Validator.validateParams([1], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '1')
       );
       expect(() => Validator.validateParams([2], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '2')
       );
     });
 
     it('throws an error if param is another type', async () => {
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '123')
       );
       expect(() => Validator.validateParams(["0x1"], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '0x1')
       );
       expect(() => Validator.validateParams([[]], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '')
       );
       expect(() => Validator.validateParams([{}], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '[object Object]')
       );
     });
   });
@@ -236,16 +242,16 @@ describe('Validator', async () => {
 
     it('throws an error if the param is not an Object', async () => {
       expect(() => Validator.validateParams(["0x1"], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '0x1')
       );
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '123')
       );
       expect(() => Validator.validateParams([[]], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '')
       );
       expect(() => Validator.validateParams([true], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, 'true')
       );
     });
 
@@ -257,22 +263,22 @@ describe('Validator', async () => {
 
     it('throws an error if the Filter Object properties are the wrong type', async () => {
       expect(() => Validator.validateParams([{"blockHash": 123}], validation)).to.throw(
-        expectInvalidParam("blockHash", Validator.BLOCK_HASH_ERROR, object)
+        expectInvalidObject("blockHash", Validator.BLOCK_HASH_ERROR, object, '123')
       );
       expect(() => Validator.validateParams([{"toBlock": 123}], validation)).to.throw(
-        expectInvalidParam("toBlock", Validator.BLOCK_NUMBER_ERROR, object)
+        expectInvalidObject("toBlock", Validator.BLOCK_NUMBER_ERROR, object, '123')
       );
       expect(() => Validator.validateParams([{"fromBlock": 123}], validation)).to.throw(
-        expectInvalidParam("fromBlock", Validator.BLOCK_NUMBER_ERROR, object)
+        expectInvalidObject("fromBlock", Validator.BLOCK_NUMBER_ERROR, object, '123')
       );
       expect(() => Validator.validateParams([{"address": "0x1"}], validation)).to.throw(
-        expectInvalidParam("address", Validator.TYPES.addressFilter.error, object)
+        expectInvalidObject("address", Validator.TYPES.addressFilter.error, object, '0x1')
       );
       expect(() => Validator.validateParams([{"topics": {}}], validation)).to.throw(
-        expectInvalidParam("topics", Validator.TYPES.topics.error, object)
+        expectInvalidObject("topics", Validator.TYPES.topics.error, object, '[object Object]')
       );
       expect(() => Validator.validateParams([{"topics": [123]}], validation)).to.throw(
-        expectInvalidParam("topics", Validator.TYPES.topics.error, object)
+        expectInvalidObject("topics", Validator.TYPES.topics.error, object, '123')
       );
     });
 
@@ -294,31 +300,31 @@ describe('Validator', async () => {
     const topicsError = Validator.TYPES["topics"].error;
     it('throws an error if topics contains hash smaller than 32bytes', async () => {
       expect(() => Validator.validateParams([["0xddf252ad1be2c89", "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]], validation)).to.throw(
-        expectInvalidParam(0, topicsError)
+        expectInvalidParam(0, topicsError, '0xddf252ad1be2c89,0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef')
       );
     });
 
     it('throws an error if topics contains hash larger than 32bytes', async () => {
       expect(() => Validator.validateParams([["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef", "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3effffffffffff"]], validation)).to.throw(
-        expectInvalidParam(0, topicsError)
+        expectInvalidParam(0, topicsError, '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef,0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3effffffffffff')
       );
     });
 
     it('throws an error if topics contains hashes NOT 0x prefixed', async () => {
       expect(() => Validator.validateParams([["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef" ,"ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]], validation)).to.throw(
-        expectInvalidParam(0, topicsError)
+        expectInvalidParam(0, topicsError, '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef,ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef')
       );
     });
 
     it('throws an error if topics is not array', async () => {
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, topicsError)
+        expectInvalidParam(0, topicsError, '123')
       );
       expect(() => Validator.validateParams(["0x1"], validation)).to.throw(
-        expectInvalidParam(0, topicsError)
+        expectInvalidParam(0, topicsError, '0x1')
       );
       expect(() => Validator.validateParams([{}], validation)).to.throw(
-        expectInvalidParam(0, topicsError)
+        expectInvalidParam(0, topicsError, '[object Object]')
       );
     });
 
@@ -348,7 +354,7 @@ describe('Validator', async () => {
 
     it('should correctly validate nested topic arrays', async () => {
       expect(() => Validator.validateParams([[["0x790673a87ac19773537b2553e1dc7c451f659e0f75d1b69a706ad42d25cbdb55"], ["0x790673a87ac19773537b2553e1dc7"]]], validation)).to.throw(
-        expectInvalidParam(0, topicsError)
+        expectInvalidParam(0, topicsError, '0x790673a87ac19773537b2553e1dc7c451f659e0f75d1b69a706ad42d25cbdb55,0x790673a87ac19773537b2553e1dc7')
       );
     });
   });
@@ -358,34 +364,34 @@ describe('Validator', async () => {
 
     it('throws an error if topic hash is smaller than 32bytes', async () => {
       expect(() => Validator.validateParams(["0xddf252ad1be2c89"], validation)).to.throw(
-        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR)
+        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR, '0xddf252ad1be2c89')
       );
     });
 
     it('throws an error if topic hash is larger than 32bytes', async () => {
       expect(() => Validator.validateParams(["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3effffff"], validation)).to.throw(
-        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR)
+        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR, '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3effffff')
       );
     });
 
     it('throws an error if topic hash is NOT 0x prefixed', async () => {
       expect(() => Validator.validateParams(["ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"], validation)).to.throw(
-        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR)
+        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR, 'ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef')
       );
     });
 
     it('throws an error if topic hash is other type', async () => {
       expect(() => Validator.validateParams(["string"], validation)).to.throw(
-        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR)
+        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR, 'string')
       );
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR)
+        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR, '123')
       );
       expect(() => Validator.validateParams([[]], validation)).to.throw(
-        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR)
+        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR, '')
       );
       expect(() => Validator.validateParams([{}], validation)).to.throw(
-        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR)
+        expectInvalidParam(0, Validator.TOPIC_HASH_ERROR, '[object Object]')
       );
     });
 
@@ -403,43 +409,43 @@ describe('Validator', async () => {
 
     it('throws an error if the param is not an Object', async () => {
        expect(() => Validator.validateParams(["string"], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, 'string')
       );
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '123')
       );
       expect(() => Validator.validateParams([[]], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, '')
       );
       expect(() => Validator.validateParams([true], validation)).to.throw(
-        expectInvalidParam(0, error)
+        expectInvalidParam(0, error, 'true')
       );
     });
 
     it('throws an error if the Transaction Object properties are the wrong type', async () => {
       expect(() => Validator.validateParams([{"from": "0x1234"}], validation)).to.throw(
-        expectInvalidParam("from", Validator.ADDRESS_ERROR, object)
+        expectInvalidObject("from", Validator.ADDRESS_ERROR, object, '0x1234')
       );
       expect(() => Validator.validateParams([{"to": "0x1234"}], validation)).to.throw(
-        expectInvalidParam("to", Validator.ADDRESS_ERROR, object)
+        expectInvalidObject("to", Validator.ADDRESS_ERROR, object, '0x1234')
       );
       expect(() => Validator.validateParams([{"gas": 123}], validation)).to.throw(
-        expectInvalidParam("gas", Validator.DEFAULT_HEX_ERROR, object)
+        expectInvalidObject("gas", Validator.DEFAULT_HEX_ERROR, object, '123')
       );
       expect(() => Validator.validateParams([{"gasPrice": 123}], validation)).to.throw(
-        expectInvalidParam("gasPrice", Validator.DEFAULT_HEX_ERROR, object)
+        expectInvalidObject("gasPrice", Validator.DEFAULT_HEX_ERROR, object, '123')
       );
       expect(() => Validator.validateParams([{"maxPriorityFeePerGas": 123}], validation)).to.throw(
-        expectInvalidParam("maxPriorityFeePerGas", Validator.DEFAULT_HEX_ERROR, object)
+        expectInvalidObject("maxPriorityFeePerGas", Validator.DEFAULT_HEX_ERROR, object, '123')
       );
       expect(() => Validator.validateParams([{"maxFeePerGas": 123}], validation)).to.throw(
-        expectInvalidParam("maxFeePerGas", Validator.DEFAULT_HEX_ERROR, object)
+        expectInvalidObject("maxFeePerGas", Validator.DEFAULT_HEX_ERROR, object, '123')
       );
       expect(() => Validator.validateParams([{"value": "123456"}], validation)).to.throw(
-        expectInvalidParam("value", Validator.DEFAULT_HEX_ERROR, object)
+        expectInvalidObject("value", Validator.DEFAULT_HEX_ERROR, object, '123456')
       );
       expect(() => Validator.validateParams([{"data": "123456"}], validation)).to.throw(
-        expectInvalidParam("data", Validator.DEFAULT_HEX_ERROR, object)
+        expectInvalidObject("data", Validator.DEFAULT_HEX_ERROR, object, '123456')
       );
     });
   });
@@ -449,34 +455,34 @@ describe('Validator', async () => {
 
     it('throws an error if transactionHash is smaller than 32bytes', async () => {
       expect(() => Validator.validateParams(["0xdec54931fcfe"], validation)).to.throw(
-        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR)
+        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR, '0xdec54931fcfe')
       );
     });
 
     it('throws an error if transactionHash is larger than 32bytes', async () => {
       expect(() => Validator.validateParams(["0x790673a87ac19773537b2553e1dc7c451f659e0f75d1b69a706ad42d25cbdb555555"], validation)).to.throw(
-        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR)
+        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR, '0x790673a87ac19773537b2553e1dc7c451f659e0f75d1b69a706ad42d25cbdb555555')
       );
     });
 
     it('throws an error if transactionHash is NOT 0x prefixed', async () => {
       expect(() => Validator.validateParams(["790673a87ac19773537b2553e1dc7c451f659e0f75d1b69a706ad42d25cbdb55"], validation)).to.throw(
-        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR)
+        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR, '790673a87ac19773537b2553e1dc7c451f659e0f75d1b69a706ad42d25cbdb55')
       );
     });
 
     it('throws an error if transactionHash is other type', async () => {
       expect(() => Validator.validateParams(["string"], validation)).to.throw(
-        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR)
+        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR, 'string')
       );
       expect(() => Validator.validateParams([123], validation)).to.throw(
-        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR)
+        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR, '123')
       );
       expect(() => Validator.validateParams([[]], validation)).to.throw(
-        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR)
+        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR, '')
       );
       expect(() => Validator.validateParams([{}], validation)).to.throw(
-        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR)
+        expectInvalidParam(0, Validator.TRANSACTION_HASH_ERROR, '[object Object]')
       );
     });
 
@@ -508,7 +514,7 @@ describe('Validator', async () => {
       const validation = { 0: { type: 'filter' } };
 
       expect(() => Validator.validateParams([{"formBlock": "0x1"}], validation)).to.throw(
-        expectInvalidParam("formBlock", "Unknown parameter", 'FilterObject')
+        expectUnknownParam("formBlock", 'FilterObject', "Unknown parameter")
       );
     });
 
@@ -516,7 +522,7 @@ describe('Validator', async () => {
       const validation = { 0: { type: 'transaction' } };
 
       expect(() => Validator.validateParams([{"form": "0x1"}], validation)).to.throw(
-        expectInvalidParam("form", "Unknown parameter", 'TransactionObject')
+        expectUnknownParam("form", 'TransactionObject', "Unknown parameter")
       );
     });
   });
@@ -537,7 +543,7 @@ describe('Validator', async () => {
           type: 'hex',
           nullable: false
         }})).to.throw(
-        expectInvalidParam("data", "Expected 0x prefixed hexadecimal value", 'TransactionObject, value: null')
+        expectInvalidObject("data", "Expected 0x prefixed hexadecimal value", 'TransactionObject', 'null')
       );
     });
   });

--- a/packages/server/tests/integration/validator.spec.ts
+++ b/packages/server/tests/integration/validator.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
-import { Validator } from '../../src/validator';
+import { OBJECTS_VALIDATIONS, TransactionObject, Validator } from '../../src/validator';
 
 describe('Validator', async () => {
   function expectInvalidParam(index: number | string, message: string, object?: string) {
@@ -522,16 +522,22 @@ describe('Validator', async () => {
   });
 
   describe('validates validateObject with transaction object', async () => {
-    const transactionFilterObject = { data: null, name() { return 'transaction'; }}
+    const transactionFilterObject = new TransactionObject({from: '0xdd94180d1c8e069fc7e6760d5bf7dee477fe617b', gasPrice: '0x0', value: '0x0', data: null});
+    it('returns true when transaction data is null and is nullable is true', async () => {
+      const result = Validator.validateObject(transactionFilterObject, {...OBJECTS_VALIDATIONS.transaction, data: {
+        type: 'hex',
+        nullable: true
+      }});
+
+      expect(result).to.be.true;
+    });
 
     it('throws an error if Transaction Object data param is null and isnullable is false', async () => {
-      expect(() => Validator.validateObject(transactionFilterObject, {
-        data: {
+      expect(() => Validator.validateObject(transactionFilterObject, {...OBJECTS_VALIDATIONS.transaction, data: {
           type: 'hex',
           nullable: false
-        },
-      })).to.throw(
-        expectInvalidParam("data", "Expected 0x prefixed hexadecimal value", 'transaction, value: null')
+        }})).to.throw(
+        expectInvalidParam("data", "Expected 0x prefixed hexadecimal value", 'TransactionObject, value: null')
       );
     });
   });

--- a/packages/server/tests/integration/validator.spec.ts
+++ b/packages/server/tests/integration/validator.spec.ts
@@ -520,4 +520,54 @@ describe('Validator', async () => {
       );
     });
   });
+
+  describe('validates validateObject with transaction object', async () => {
+    it('returns true when transaction data is null and is nullable is true', async () => {
+      const result = Validator.validateObject({ data: null }, {
+        data: {
+          type: 'hex',
+          nullable: false
+        }
+      });
+
+      expect(result).to.be.true;
+    });
+
+    it('throws an error if Transaction Object data param is null and isnullable is false', async () => {
+      expect(() => Validator.validateObject({ data: null }, {
+        data: {
+          type: 'hex',
+          nullable: false
+        }
+      })).to.throw(
+        expectInvalidParam("data", "Invalid parameter", 'TransactionObject')
+      );
+    });
+  });
+
+  describe('validates isValidAndNonNullableParam', async () => {
+    it('returns false if transaction data is undefined and isnullable is true', async () => {
+      expect(Validator.isValidAndNonNullableParam(undefined, true)).to.be.false;
+    });
+
+    it('returns false if transaction data is undefined and isnullable is false', async () => {
+      expect(Validator.isValidAndNonNullableParam(undefined, false)).to.be.false;
+    });
+
+    it('returns false if transaction data is null and isnullable is true', async () => {
+      expect(Validator.isValidAndNonNullableParam(null, true)).to.be.false;
+    });
+
+    it('returns false if transaction data is null and isnullable is false', async () => {
+      expect(Validator.isValidAndNonNullableParam(null, false)).to.be.true;
+    });
+
+    it('returns false if transaction data is a valid 0x value and isnullable is false', async () => {
+      expect(Validator.isValidAndNonNullableParam('0x', false)).to.be.true;
+    });
+
+    it('returns false if transaction data is a valid 0x value and isnullable is true', async () => {
+      expect(Validator.isValidAndNonNullableParam('0x', true)).to.be.true;
+    });
+  });
 });

--- a/packages/server/tests/integration/validator.spec.ts
+++ b/packages/server/tests/integration/validator.spec.ts
@@ -522,25 +522,16 @@ describe('Validator', async () => {
   });
 
   describe('validates validateObject with transaction object', async () => {
-    it('returns true when transaction data is null and is nullable is true', async () => {
-      const result = Validator.validateObject({ data: null }, {
-        data: {
-          type: 'hex',
-          nullable: false
-        }
-      });
-
-      expect(result).to.be.true;
-    });
+    const transactionFilterObject = { data: null, name() { return 'transaction'; }}
 
     it('throws an error if Transaction Object data param is null and isnullable is false', async () => {
-      expect(() => Validator.validateObject({ data: null }, {
+      expect(() => Validator.validateObject(transactionFilterObject, {
         data: {
           type: 'hex',
           nullable: false
-        }
+        },
       })).to.throw(
-        expectInvalidParam("data", "Invalid parameter", 'TransactionObject')
+        expectInvalidParam("data", "Expected 0x prefixed hexadecimal value", 'transaction, value: null')
       );
     });
   });


### PR DESCRIPTION
Signed-off-by: Nana Essilfie-Conduah <nana@swirldslabs.com>

**Description**:
MM seems to send a null data param in the transaction object.
We should not be validating in that case.

- Expand trace logs to `eth.estimateGas()` to highlight param
- Add nullable concept to validation object params and set data in transaction object to nullable
- Expand `predefined.INVALID_PARAMETER` logs to make failures easier to troubleshoot
- Updated and expanded tests to confirm `isValidAndNonNullableParam` logic
- Updated RPC tests impacted by addition of value to the log

**Related issue(s)**:

Fixes #836 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
