### PR TITLE
Return array of numbers in `eth_feeHistory` response

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -160,9 +160,9 @@
                             "description": "An array of gas used ratio.",
                             "type": "array",
                             "items": {
-                                "title": "hex encoded unsigned integer",
-                                "type": "string",
-                                "pattern": "^0x([1-9a-f]+[0-9a-f]*|0|0.8)$"
+                                "title": "floating point number",
+                                "type": "number",
+                                "pattern": "^([0-9].[0-9]*|0)$"
                             }
                         },
                         "baseFeePerGas": {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -55,7 +55,7 @@ export class EthImpl implements Eth {
   static gasTxBaseCost = EthImpl.numberTo0x(constants.TX_BASE_COST);
   static ethTxType = 'EthereumTransaction';
   static ethEmptyTrie = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421';
-  static defaultGasUsedRatio = EthImpl.numberTo0x(0.5);
+  static defaultGasUsedRatio = 0.5;
   static feeHistoryZeroBlockCountResponse = { gasUsedRatio: null, oldestBlock: EthImpl.zeroHex };
   static feeHistoryEmptyResponse = { baseFeePerGas: [], gasUsedRatio: [], reward: [], oldestBlock: EthImpl.zeroHex };
   static redirectBytecodePrefix = '6080604052348015600f57600080fd5b506000610167905077618dc65e';
@@ -221,7 +221,7 @@ export class EthImpl implements Eth {
     const shouldIncludeRewards = Array.isArray(rewardPercentiles) && rewardPercentiles.length > 0;
     const feeHistory = {
       baseFeePerGas: [] as string[],
-      gasUsedRatio: [] as string[],
+      gasUsedRatio: [] as number[],
       oldestBlock: EthImpl.numberTo0x(oldestBlockNumber),
     };
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2041,7 +2041,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(feeHistory['baseFeePerGas'][0]).to.equal('0x870ab1a800');
     expect(feeHistory['baseFeePerGas'][1]).to.equal('0x84b6a5c400');
     expect(feeHistory['baseFeePerGas'][2]).to.equal('0x84b6a5c400');
-    expect(feeHistory['gasUsedRatio'][0]).to.equal(`0x${gasUsedRatio.toString(16)}`);
+    expect(feeHistory['gasUsedRatio'][0]).to.equal(gasUsedRatio);
     expect(feeHistory['oldestBlock']).to.equal(`0x${previousBlock.number.toString(16)}`);
     const rewards = feeHistory['reward'][0];
     expect(rewards[0]).to.equal('0x0');
@@ -2159,7 +2159,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     expect(firstFeeHistory).to.exist;
     expect(firstFeeHistory['baseFeePerGas'][0]).to.equal('0x84b6a5c400');
-    expect(firstFeeHistory['gasUsedRatio'][0]).to.equal(`0x${gasUsedRatio.toString(16)}`);
+    expect(firstFeeHistory['gasUsedRatio'][0]).to.equal(gasUsedRatio);
     expect(firstFeeHistory['oldestBlock']).to.equal(`0x${latestBlock.number.toString(16)}`);
 
     expect(firstFeeHistory).to.equal(secondFeeHistory);
@@ -2184,7 +2184,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(feeHistory).to.exist;
 
     expect(feeHistory['baseFeePerGas'][0]).to.equal(fauxGasWeiBarHex);
-    expect(feeHistory['gasUsedRatio'][0]).to.equal(`0x${gasUsedRatio.toString(16)}`);
+    expect(feeHistory['gasUsedRatio'][0]).to.equal(gasUsedRatio);
     expect(feeHistory['oldestBlock']).to.equal(`0x${latestBlock.number.toString(16)}`);
     const rewards = feeHistory['reward'][0];
     expect(rewards[0]).to.equal('0x0');
@@ -2209,7 +2209,7 @@ describe('Eth calls using MirrorNode', async function () {
     const feeHistory = await ethImpl.feeHistory(1, 'latest', null);
 
     expect(feeHistory['baseFeePerGas'][0]).to.equal(fauxGasWeiBarHex);
-    expect(feeHistory['gasUsedRatio'][0]).to.equal(`0x${gasUsedRatio.toString(16)}`);
+    expect(feeHistory['gasUsedRatio'][0]).to.equal(gasUsedRatio);
     expect(feeHistory['oldestBlock']).to.equal(`0x${latestBlock.number.toString(16)}`);
   });
 

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -185,7 +185,7 @@ export default class Assertions {
 
         expect(res.oldestBlock, "Assert feeHistory: 'oldestBlock' should equal passed expected value").to.equal(expected.oldestBlock);
 
-        res.gasUsedRatio.map((gasRatio: string) => expect(gasRatio, "Assert feeHistory: 'gasRatio' should equal 'defaultGasUsed'").to.equal(`0x${Assertions.defaultGasUsed.toString(16)}`));
+        res.gasUsedRatio.map((gasRatio: string) => expect(gasRatio, "Assert feeHistory: 'gasRatio' should equal 'defaultGasUsed'").to.equal(Assertions.defaultGasUsed));
 
         if (expected.checkReward) {
             expect(res.reward, "Assert feeHistory: 'reward' should exist and be an Array").to.exist.to.be.an('Array');


### PR DESCRIPTION
Signed-off-by: georgi-l95 <glazarov95@gmail.com>

**Description**:
Response from `eth_feeHistory` is a object with several properties, one of which is `gasUsedRatio`. Until now it was returned as array of string (hex encoded integer), which seems to be wrong as tools like Foundry are expecting array of numbers. More so providers like Alchemy and Infura are also returning array of integers.

**Related issue(s)**:

Fixes #835 
Resolves #834 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
