### PR TITLE
ga release for 0.16.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   relay:
     container_name:  hedera-jspn-rpc-relay
-    image: "ghcr.io/hashgraph/hedera-json-rpc-relay:0.16.0-rc4"
+    image: "ghcr.io/hashgraph/hedera-json-rpc-relay:0.16.0"
     restart: "unless-stopped"
     ports:
       - 7546:7546

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -3,7 +3,7 @@
     "info": {
         "title": "Hedera JSON-RPC Specification",
         "description": "A specification of the implemented Ethereum JSON RPC APIs interface for Hedera clients and adheres to the Ethereum execution APIs schema.",
-        "version": "0.16.0-rc4"
+        "version": "0.16.0"
     },
     "methods": [
         {

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: hedera-json-rpc-relay
 description: Helm chart deployment of the hashgraph/hedera-json-rpc-relay
 type: application
-version: 0.16.0-rc4
-appVersion: "0.16.0-rc4"
+version: 0.16.0
+appVersion: "0.16.0"
 home: https://github.com/hashgraph/hedera-json-rpc-relay

--- a/package-lock.json
+++ b/package-lock.json
@@ -22782,7 +22782,7 @@
         },
         "packages/relay": {
             "name": "@hashgraph/json-rpc-relay",
-            "version": "0.16.0-rc4",
+            "version": "0.16.0",
             "dependencies": {
                 "@hashgraph/sdk": "^2.19.0",
                 "@keyvhq/core": "^1.6.9",
@@ -22852,7 +22852,7 @@
         },
         "packages/server": {
             "name": "@hashgraph/json-rpc-server",
-            "version": "0.16.0-rc4",
+            "version": "0.16.0",
             "dependencies": {
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "axios": "^0.27.2",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/json-rpc-relay",
-    "version": "0.16.0-rc4",
+    "version": "0.16.0",
     "description": "Hedera Hashgraph implementation of Ethereum JSON RPC APIs. Utilises both the Hedera Consensus Nodes and the Mirror Nodes for transaction management and information retrieval",
     "types": "dist/index.d.ts",
     "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/json-rpc-server",
-    "version": "0.16.0-rc4",
+    "version": "0.16.0",
     "description": "Hedera Hashgraph Ethereum JSON RPC server. Accepts requests for Ethereum JSON RPC 2.0 APIs",
     "main": "dist/index.js",
     "keywords": [],


### PR DESCRIPTION
Signed-off-by: lukelee-sl <luke.lee@swirldslabs.com>

Bump version to 0.16.0 for general availability release
