### PR TITLE
Add simple eth_call cache

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -480,6 +480,16 @@ export class MirrorNodeClient {
         return this.getContractResultsByAddress(address, contractResultsParams, limitOrderParams, requestId);
     }
 
+    public async getContractCurrentStateByAddress(address: string, requestId?: string) {
+        return this.getPaginatedResults(
+            `${MirrorNodeClient.GET_CONTRACT_ENDPOINT}${address}${MirrorNodeClient.GET_STATE_ENDPOINT}`,
+            MirrorNodeClient.GET_STATE_ENDPOINT,
+            MirrorNodeClient.CONTRACT_STATE_PROPERTY,
+            [400, 404],
+            requestId
+        );
+    }
+
     public async getContractCurrentStateByAddressAndSlot(address: string, slot: string, requestId?: string) {
         const limitOrderParams: ILimitOrderParams = this.getLimitOrderQueryParam(constants.MIRROR_NODE_QUERY_LIMIT, constants.ORDER.DESC);
         const queryParamObject = {};

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -34,6 +34,7 @@ import { formatRequestIdMessage } from '../formatters';
 const LRU = require('lru-cache');
 const _ = require('lodash');
 const createHash = require('keccak');
+import crypto from 'crypto';
 
 /**
  * Implementation of the "eth_" methods from the Ethereum JSON-RPC API.
@@ -981,7 +982,9 @@ export class EthImpl implements Eth {
 
     try {
       // check cache if contract has since been updated then query node
-      const cachedLabel = `call.${call.to}`;
+      const dataHash = crypto.createHash('md5').update(call.data).digest(); /// call data may be large so hash to reduce key size.
+      // cache response by method, contract and call data
+      const cachedLabel = `call.${call.to}.${dataHash}`;
       const cachedResponse = this.cache.get(cachedLabel);
 
       // cache is object comprising of response data and timestamp of latest update. 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2413,6 +2413,36 @@ describe('Eth calls using MirrorNode', async function () {
       expect(result).to.equal("0x00");
     });
 
+    it('eth_call with all fields is cached', async function () {
+      sdkClientStub.submitContractCallQuery.returns({
+            asBytes: function () {
+              return Uint8Array.of(1);
+            }
+          }
+      );
+
+      const result = await ethImpl.call({
+        "from": contractAddress1,
+        "to": contractAddress2,
+        "data": contractCallData,
+        "gas": maxGasLimitHex
+      }, 'latest');
+
+      sinon.assert.calledWith(sdkClientStub.submitContractCallQuery, contractAddress2, contractCallData, maxGasLimit, contractAddress1, 'eth_call');
+      expect(result).to.equal("0x01");
+
+
+      const result2 = await ethImpl.call({
+        "from": contractAddress1,
+        "to": contractAddress2,
+        "data": contractCallData,
+        "gas": maxGasLimitHex
+      }, 'latest');
+
+      expect(result2).to.equal("0x01");
+      sinon.assert.calledOnce(sdkClientStub.submitContractCallQuery);
+    });
+
     describe('with gas > 15_000_000', async function() {
       it('caps gas at 15_000_000', async function () {
         sdkClientStub.submitContractCallQuery.returns({

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -529,6 +529,16 @@ describe('MirrorNodeClient', async function () {
     expect(firstResult.index).equal(log.index);
   });
 
+
+  it('`getContractCurrentStateByAddress`', async () => {
+    mock.onGet(`contracts/${contractAddress}/state`).reply(200, defaultCurrentContractState);
+    const result = await mirrorNodeInstance.getContractCurrentStateByAddress(contractAddress);
+
+    expect(result).to.exist;
+    expect(result.state).to.exist;
+    expect(result.state[0].value).to.eq(defaultCurrentContractState.state[0].value);
+  });
+
   it('`getContractCurrentStateByAddressAndSlot`', async () => {
     mock.onGet(`contracts/${contractAddress}/state?slot=${defaultCurrentContractState.state[0].slot}&limit=100&order=desc`).reply(200, defaultCurrentContractState);
     const result = await mirrorNodeInstance.getContractCurrentStateByAddressAndSlot(contractAddress, defaultCurrentContractState.state[0].slot);


### PR DESCRIPTION
**Description**:
Add simple cache to eth_call method

- Add `getContractCurrentStateByAddress()` to `MirrornNodeClient.ts`
- Add `hasContractStateSeenAnUpdate()` to `eth.ts` to check if a contract state has seen a change
- Update `eth_call` to utilize a cache and call `hasContractStateSeenAnUpdate()` to decide if to return cache. Idea is on a successful call the timestamp and response are cached. On successive calls if the timestamp from mirror is greater than the cache then make the complete state call

**Related issue(s)**:

Fixes #877 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
