### PR TITLE
865-update-logs-and-metrics.  Added the requestId to the server context.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9591,6 +9591,8 @@
         },
         "node_modules/ganache/node_modules/@trufflesuite/bigint-buffer": {
             "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.10.tgz",
+            "integrity": "sha512-pYIQC5EcMmID74t26GCC67946mgTJFiLXOT/BYozgrd4UEY2JHEGLhWi9cMiQCt5BSqFEvKkCHNnoj82SRjiEw==",
             "dev": true,
             "hasInstallScript": true,
             "inBundle": true,
@@ -9604,6 +9606,8 @@
         },
         "node_modules/ganache/node_modules/@trufflesuite/bigint-buffer/node_modules/node-gyp-build": {
             "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9615,6 +9619,8 @@
         },
         "node_modules/ganache/node_modules/@types/bn.js": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+            "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9624,24 +9630,32 @@
         },
         "node_modules/ganache/node_modules/@types/lru-cache": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/@types/node": {
             "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
+            "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/@types/seedrandom": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.1.tgz",
+            "integrity": "sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/base64-js": {
             "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true,
             "funding": [
                 {
@@ -9662,12 +9676,16 @@
         },
         "node_modules/ganache/node_modules/brorand": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/buffer": {
             "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
             "dev": true,
             "funding": [
                 {
@@ -9705,6 +9723,8 @@
         },
         "node_modules/ganache/node_modules/catering": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.0.tgz",
+            "integrity": "sha512-M5imwzQn6y+ODBfgi+cfgZv2hIUI6oYU/0f35Mdb1ujGeqeoI5tOnl9Q13DTH7LW+7er+NYq8stNOKZD/Z3U/A==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9717,6 +9737,8 @@
         },
         "node_modules/ganache/node_modules/elliptic": {
             "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9732,12 +9754,16 @@
         },
         "node_modules/ganache/node_modules/elliptic/node_modules/bn.js": {
             "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/emittery": {
             "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.0.tgz",
+            "integrity": "sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9750,6 +9776,8 @@
         },
         "node_modules/ganache/node_modules/hash.js": {
             "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9760,6 +9788,8 @@
         },
         "node_modules/ganache/node_modules/hmac-drbg": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9771,6 +9801,8 @@
         },
         "node_modules/ganache/node_modules/ieee754": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true,
             "funding": [
                 {
@@ -9791,12 +9823,16 @@
         },
         "node_modules/ganache/node_modules/inherits": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/ganache/node_modules/is-buffer": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
             "dev": true,
             "funding": [
                 {
@@ -9820,6 +9856,8 @@
         },
         "node_modules/ganache/node_modules/keccak": {
             "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+            "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
             "dev": true,
             "hasInstallScript": true,
             "inBundle": true,
@@ -9835,6 +9873,8 @@
         },
         "node_modules/ganache/node_modules/leveldown": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
+            "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
             "dev": true,
             "hasInstallScript": true,
             "inBundle": true,
@@ -9850,6 +9890,8 @@
         },
         "node_modules/ganache/node_modules/leveldown/node_modules/abstract-leveldown": {
             "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+            "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9867,6 +9909,8 @@
         },
         "node_modules/ganache/node_modules/leveldown/node_modules/level-concat-iterator": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+            "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9879,6 +9923,8 @@
         },
         "node_modules/ganache/node_modules/leveldown/node_modules/level-supports": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+            "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9888,30 +9934,40 @@
         },
         "node_modules/ganache/node_modules/minimalistic-assert": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/ganache/node_modules/minimalistic-crypto-utils": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/napi-macros": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+            "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/node-addon-api": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+            "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/node-gyp-build": {
             "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+            "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9923,6 +9979,8 @@
         },
         "node_modules/ganache/node_modules/queue-microtask": {
             "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
             "funding": [
                 {
@@ -9943,12 +10001,16 @@
         },
         "node_modules/ganache/node_modules/queue-tick": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+            "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/readable-stream": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9963,6 +10025,8 @@
         },
         "node_modules/ganache/node_modules/safe-buffer": {
             "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true,
             "funding": [
                 {
@@ -9983,6 +10047,8 @@
         },
         "node_modules/ganache/node_modules/secp256k1": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+            "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
             "dev": true,
             "hasInstallScript": true,
             "inBundle": true,
@@ -9998,6 +10064,8 @@
         },
         "node_modules/ganache/node_modules/string_decoder": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -10020,6 +10088,8 @@
         },
         "node_modules/ganache/node_modules/util-deprecate": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -18333,7 +18403,8 @@
                 "koa-router": "^10.1.1",
                 "mocha": "^9.2.2",
                 "pino": "^7.11.0",
-                "pino-pretty": "^7.6.1"
+                "pino-pretty": "^7.6.1",
+                "uuid": "^3.3.2"
             },
             "devDependencies": {
                 "@hashgraph/hedera-local": "^2.4.5",
@@ -18366,6 +18437,15 @@
             "dependencies": {
                 "follow-redirects": "^1.14.9",
                 "form-data": "^4.0.0"
+            }
+        },
+        "packages/server/node_modules/uuid": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "bin": {
+                "uuid": "bin/uuid"
             }
         }
     },
@@ -19903,7 +19983,8 @@
                 "shelljs": "^0.8.5",
                 "ts-mocha": "^9.0.2",
                 "ts-node": "^10.8.1",
-                "typescript": "^4.5.5"
+                "typescript": "^4.5.5",
+                "uuid": "^3.3.2"
             },
             "dependencies": {
                 "@types/node": {
@@ -19916,6 +19997,11 @@
                         "follow-redirects": "^1.14.9",
                         "form-data": "^4.0.0"
                     }
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },
@@ -24626,6 +24712,8 @@
             "dependencies": {
                 "@trufflesuite/bigint-buffer": {
                     "version": "1.1.10",
+                    "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.10.tgz",
+                    "integrity": "sha512-pYIQC5EcMmID74t26GCC67946mgTJFiLXOT/BYozgrd4UEY2JHEGLhWi9cMiQCt5BSqFEvKkCHNnoj82SRjiEw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24634,6 +24722,8 @@
                     "dependencies": {
                         "node-gyp-build": {
                             "version": "4.4.0",
+                            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+                            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
                             "bundled": true,
                             "dev": true
                         }
@@ -24641,6 +24731,8 @@
                 },
                 "@types/bn.js": {
                     "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+                    "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24649,31 +24741,43 @@
                 },
                 "@types/lru-cache": {
                     "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
                     "bundled": true,
                     "dev": true
                 },
                 "@types/node": {
                     "version": "17.0.0",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
+                    "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
                     "bundled": true,
                     "dev": true
                 },
                 "@types/seedrandom": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.1.tgz",
+                    "integrity": "sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==",
                     "bundled": true,
                     "dev": true
                 },
                 "base64-js": {
                     "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+                    "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
                     "bundled": true,
                     "dev": true
                 },
                 "brorand": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+                    "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
                     "bundled": true,
                     "dev": true
                 },
                 "buffer": {
                     "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24691,6 +24795,8 @@
                 },
                 "catering": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.0.tgz",
+                    "integrity": "sha512-M5imwzQn6y+ODBfgi+cfgZv2hIUI6oYU/0f35Mdb1ujGeqeoI5tOnl9Q13DTH7LW+7er+NYq8stNOKZD/Z3U/A==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24699,6 +24805,8 @@
                 },
                 "elliptic": {
                     "version": "6.5.4",
+                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+                    "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24713,6 +24821,8 @@
                     "dependencies": {
                         "bn.js": {
                             "version": "4.12.0",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
                             "bundled": true,
                             "dev": true
                         }
@@ -24720,11 +24830,15 @@
                 },
                 "emittery": {
                     "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.0.tgz",
+                    "integrity": "sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "hash.js": {
                     "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+                    "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24734,6 +24848,8 @@
                 },
                 "hmac-drbg": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+                    "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24744,21 +24860,29 @@
                 },
                 "ieee754": {
                     "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
                     "bundled": true,
                     "dev": true
                 },
                 "inherits": {
                     "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "is-buffer": {
                     "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "keccak": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+                    "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24769,6 +24893,8 @@
                 },
                 "leveldown": {
                     "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
+                    "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24779,6 +24905,8 @@
                     "dependencies": {
                         "abstract-leveldown": {
                             "version": "7.2.0",
+                            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+                            "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
                             "bundled": true,
                             "dev": true,
                             "requires": {
@@ -24792,6 +24920,8 @@
                         },
                         "level-concat-iterator": {
                             "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+                            "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
                             "bundled": true,
                             "dev": true,
                             "requires": {
@@ -24800,6 +24930,8 @@
                         },
                         "level-supports": {
                             "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+                            "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
                             "bundled": true,
                             "dev": true
                         }
@@ -24807,41 +24939,57 @@
                 },
                 "minimalistic-assert": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+                    "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
                     "bundled": true,
                     "dev": true
                 },
                 "minimalistic-crypto-utils": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+                    "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
                     "bundled": true,
                     "dev": true
                 },
                 "napi-macros": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+                    "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
                     "bundled": true,
                     "dev": true
                 },
                 "node-addon-api": {
                     "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+                    "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
                     "bundled": true,
                     "dev": true
                 },
                 "node-gyp-build": {
                     "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+                    "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
                     "bundled": true,
                     "dev": true
                 },
                 "queue-microtask": {
                     "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+                    "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
                     "bundled": true,
                     "dev": true
                 },
                 "queue-tick": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+                    "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "readable-stream": {
                     "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24852,11 +25000,15 @@
                 },
                 "safe-buffer": {
                     "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "secp256k1": {
                     "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+                    "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24867,6 +25019,8 @@
                 },
                 "string_decoder": {
                     "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24883,6 +25037,8 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "bundled": true,
                     "dev": true
                 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,7 +17,8 @@
         "koa-router": "^10.1.1",
         "mocha": "^9.2.2",
         "pino": "^7.11.0",
-        "pino-pretty": "^7.6.1"
+        "pino-pretty": "^7.6.1",
+        "uuid": "^3.3.2"
     },
     "devDependencies": {
         "@hashgraph/hedera-local": "^2.4.5",

--- a/packages/server/src/formatters.ts
+++ b/packages/server/src/formatters.ts
@@ -1,0 +1,30 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+/**
+* Format message prefix for logger.
+*/
+const formatRequestIdMessage = (requestId?: string): string => {
+    return requestId ? `[Request ID: ${requestId}]` : '';
+};
+
+
+export { formatRequestIdMessage };

--- a/packages/server/src/formatters.ts
+++ b/packages/server/src/formatters.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/server/src/rateLimit/index.ts
+++ b/packages/server/src/rateLimit/index.ts
@@ -19,6 +19,7 @@
  */
 
 import { Logger } from 'pino';
+import { formatRequestIdMessage } from '../formatters';
 import { Counter, Registry } from 'prom-client';
 
 export default class RateLimit {
@@ -42,7 +43,7 @@ export default class RateLimit {
     });
   }
 
-  shouldRateLimit(ip: string, methodName: string, total: number): boolean {
+  shouldRateLimit(ip: string, methodName: string, total: number, requestId: string): boolean {
     if (process.env.RATE_LIMIT_DISABLED && process.env.RATE_LIMIT_DISABLED === 'true') return false;
     this.precheck(ip, methodName, total);
     if (!this.shouldReset(ip)) {
@@ -51,8 +52,12 @@ export default class RateLimit {
         return false;
       }
 
+
+      const requestIdPrefix = requestId ? formatRequestIdMessage(requestId) : '';
+      this.logger.warn(`${requestIdPrefix}, Rate limit call to ${methodName}, ${this.database[ip].methodInfo[methodName].remaining} out of ${total} calls remaining`);
+
       this.ipRateLimitCounter.labels(methodName).inc(1);
-      this.logger.warn(`Rate limit call to ${methodName}, ${this.database[ip].methodInfo[methodName].remaining} out of ${total} calls remaining`);
+     
       return true;
     } else {
       this.reset(ip, methodName, total);


### PR DESCRIPTION
This PR modifies rate limited logs in order to include the requestId in a standard log message.

Adds a Koa requestId package that supports storing the requestId in the application context.
Fixes https://github.com/hashgraph/hedera-json-rpc-relay/pull/885

Notes for reviewer:
Provides the request ID in the logs right as the rateLimit for a given IP is triggered, in the standard log format.

Existing tests cover rateLimited requests.