### PR TITLE
Change `v` field in `eth_getTransactionByHash` and `eth_getBlockByHash` to be zeroHex instead of `null`

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1065,7 +1065,7 @@ export class EthImpl implements Eth {
       to: contractResult.to?.substring(0, 42),
       transactionIndex: EthImpl.numberTo0x(contractResult.transaction_index),
       type: EthImpl.nullableNumberTo0x(contractResult.type),
-      v: EthImpl.nullableNumberTo0x(contractResult.v),
+      v: EthImpl.nanOrNumberTo0x(contractResult.v),
       value: EthImpl.nanOrNumberTo0x(contractResult.amount),
     });
   }
@@ -1346,7 +1346,7 @@ export class EthImpl implements Eth {
             to: contractResultDetails.to.substring(0, 42),
             transactionIndex: EthImpl.numberTo0x(contractResultDetails.transaction_index),
             type: EthImpl.nullableNumberTo0x(contractResultDetails.type),
-            v: EthImpl.nullableNumberTo0x(contractResultDetails.v),
+            v: EthImpl.nanOrNumberTo0x(contractResultDetails.v),
             value: EthImpl.nanOrNumberTo0x(contractResultDetails.amount),
           });
         }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3273,6 +3273,24 @@ describe('Eth', async function () {
       expect(result.value).to.eq('0x0');
     });
 
+    it('handles transactions with v as null', async function () {
+      // mirror node request mocks
+      const detailedResultsWithNullNullableValues = {
+        ...defaultDetailedContractResultByHash,
+        v: null
+      };
+
+      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, detailedResultsWithNullNullableValues);
+      restMock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
+        evm_address: `${defaultTransaction.from}`
+      });
+      const result = await ethImpl.getTransactionByHash(defaultTxHash);
+      if (result == null) return;
+
+      expect(result).to.exist;
+      expect(result.v).to.eq('0x0');
+    });
+
     it('returns reverted transactions', async function () {
       restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, defaultDetailedContractResultByHashReverted);
       restMock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR changes the current `eth.ts` behaviour in `getTransactionFromContractResult` and `getTransactionByHash` to return `0x0` instead of `null` when `v` is `null`
**Related issue(s)**:

Fixes #916 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
