### PR TITLE
Add cache to Mirror Node Client getContractResult method.

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -339,7 +339,7 @@ export class MirrorNodeClient {
             [400, 404],
             requestId);
 
-        if(response != undefined && response.result === "SUCCESS") {
+        if(response != undefined && response.transaction_index != undefined && response.result === "SUCCESS") {
             this.cache.set(cacheKey, response);
         }
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -327,7 +327,7 @@ export class MirrorNodeClient {
 
     public async getContractResult(transactionIdOrHash: string, requestId?: string) {
         const requestIdPrefix = formatRequestIdMessage(requestId);
-        const cacheKey = `getContractResult.${transactionIdOrHash}`;
+        const cacheKey = `${constants.CACHE_KEY.GET_CONTRACT_RESULT}.${transactionIdOrHash}`;
         const cachedResponse = this.cache.get(cacheKey);
         const path = `${MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT}${transactionIdOrHash}`;
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -326,20 +326,23 @@ export class MirrorNodeClient {
     }
 
     public async getContractResult(transactionIdOrHash: string, requestId?: string) {
-
+        const requestIdPrefix = formatRequestIdMessage(requestId);
         const cacheKey = `getContractResult.${transactionIdOrHash}`;
         const cachedResponse = this.cache.get(cacheKey);
+        const path = `${MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT}${transactionIdOrHash}`;
 
         if(cachedResponse != undefined) {
+            this.logger.trace(`${requestIdPrefix} returning cached response for ${path}:${JSON.stringify(cachedResponse)}`);
             return cachedResponse;
         }
 
-        const response = await this.get(`${MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT}${transactionIdOrHash}`,
+        const response = await this.get(path,
             MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT,
             [400, 404],
             requestId);
 
         if(response != undefined && response.transaction_index != undefined && response.result === "SUCCESS") {
+            this.logger.trace(`${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(response)} for ${constants.CACHE_TTL.ONE_HOUR} ms`);
             this.cache.set(cacheKey, response);
         }
 

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -20,7 +20,10 @@
 
 enum CACHE_KEY {
     GAS_PRICE = 'gas_price',
-    FEE_HISTORY = 'fee_history'
+    FEE_HISTORY = 'fee_history',
+    GET_CONTRACT_RESULT = 'getContractResult'
+
+
 }
 
 enum CACHE_TTL {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3113,9 +3113,11 @@ describe('Eth', async function () {
         max_fee_per_gas: null
       };
 
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, contractResult);
+      const uniqueTxHash = '0x07cdd7b820375d10d73af57a6a3e84353645fdb1305ea58ff52daa53ec640533';
+
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, contractResult);
       restMock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
-      const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
+      const receipt = await ethImpl.getTransactionReceipt(uniqueTxHash);
 
       expect(receipt).to.exist;
       if (receipt == null) return;
@@ -3143,9 +3145,12 @@ describe('Eth', async function () {
         error_message: defaultErrorMessage
       };
 
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, receiptWithErrorMessage);
+      // fake unique hash so request dont re-use the cached value but the mock defined
+      const uniqueTxHash = '0x04cad7b827375d10d73af57b6a3e843536457d31305ea58ff52dda53ec640533';
+
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, receiptWithErrorMessage);
       restMock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
-      const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
+      const receipt = await ethImpl.getTransactionReceipt(uniqueTxHash);
 
       expect(receipt).to.exist;
       expect(receipt.revertReason).to.eq(defaultErrorMessage);
@@ -3156,9 +3161,12 @@ describe('Eth', async function () {
         ...defaultDetailedContractResultByHash,
         gas_used: null
       };
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, receiptWithNullGasUsed);
+
+      // fake unique hash so request dont re-use the cached value but the mock defined
+      const uniqueTxHash = '0x08cad7b827375d12d73af57b6a3e84353645fd31305ea59ff52dda53ec640533';
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, receiptWithNullGasUsed);
       restMock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
-      const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
+      const receipt = await ethImpl.getTransactionReceipt(uniqueTxHash);
 
       expect(receipt).to.exist;
       if (receipt == null) return;
@@ -3166,8 +3174,11 @@ describe('Eth', async function () {
     });
 
     it('handles missing transaction index', async function() {
+      // fake unique hash so request dont re-use the cached value but the mock defined
+      const uniqueTxHash = '0x17cad7b827375d12d73af57b6a3e84353645fd31305ea58ff52dda53ec640533';
+
       // mirror node request mocks
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, {
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, {
         ...defaultDetailedContractResultByHash, ...{
           transaction_index: undefined
         }
@@ -3175,7 +3186,7 @@ describe('Eth', async function () {
       restMock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(200, {
         evm_address: contractEvmAddress
       });
-      const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
+      const receipt = await ethImpl.getTransactionReceipt(uniqueTxHash);
 
       expect(receipt).to.exist;
 
@@ -3185,9 +3196,12 @@ describe('Eth', async function () {
   });
 
   describe('eth_getTransactionByHash', async function () {
+    // fake unique hash so request dont re-use the cached value but the mock defined
+    const uniqueTxHash = '0x27cad7b827375d12d73af57b6a3e84353645fd31305ea58ff52dda53ec640533';
+
     it('returns `null` for non-existing hash', async function () {
       // mirror node request mocks
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(404, {
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(404, {
         '_status': {
           'messages': [
             {
@@ -3197,7 +3211,7 @@ describe('Eth', async function () {
         }
       });
 
-      const result = await ethImpl.getTransactionByHash(defaultTxHash);
+      const result = await ethImpl.getTransactionByHash(uniqueTxHash);
       expect(result).to.equal(null);
     });
 
@@ -3255,11 +3269,14 @@ describe('Eth', async function () {
         s: null
       };
 
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, detailedResultsWithNullNullableValues);
+      // fake unique hash so request dont re-use the cached value but the mock defined
+      const uniqueTxHash = '0x97cad7b827375d12d73af57b6a3f84353645fd31305ea58ff52dda53ec640533';
+
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, detailedResultsWithNullNullableValues);
       restMock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
         evm_address: `${defaultTransaction.from}`
       });
-      const result = await ethImpl.getTransactionByHash(defaultTxHash);
+      const result = await ethImpl.getTransactionByHash(uniqueTxHash);
       if (result == null) return;
 
       expect(result).to.exist;
@@ -3291,11 +3308,14 @@ describe('Eth', async function () {
         gas_used: null
       };
 
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, detailedResultsWithNullNullableValues);
+      // fake unique hash so request dont re-use the cached value but the mock defined
+      const uniqueTxHash = '0x14aad7b827375d12d73af57b6a3e84353645fd31305ea58ff52dda53ec640533';
+
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, detailedResultsWithNullNullableValues);
       restMock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
         evm_address: `${defaultTransaction.from}`
       });
-      const result = await ethImpl.getTransactionByHash(defaultTxHash);
+      const result = await ethImpl.getTransactionByHash(uniqueTxHash);
       if (result == null) return;
 
       expect(result).to.exist;
@@ -3309,11 +3329,14 @@ describe('Eth', async function () {
         amount: null
       };
 
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, detailedResultsWithNullNullableValues);
+      // fake unique hash so request dont re-use the cached value but the mock defined
+      const uniqueTxHash = '0x0aaad7b827375d12d73af57b6a3e84353645fd31305ea58ff52dda53ec640533';
+
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, detailedResultsWithNullNullableValues);
       restMock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
         evm_address: `${defaultTransaction.from}`
       });
-      const result = await ethImpl.getTransactionByHash(defaultTxHash);
+      const result = await ethImpl.getTransactionByHash(uniqueTxHash);
       if (result == null) return;
 
       expect(result).to.exist;
@@ -3327,11 +3350,14 @@ describe('Eth', async function () {
         v: null
       };
 
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, detailedResultsWithNullNullableValues);
+      // fake unique hash so request dont re-use the cached value but the mock defined
+      const uniqueTxHash = '0xb4cad7b827375d12d73af57b6a3e84353645fd31305ea58ff52dda53ec640533';
+
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, detailedResultsWithNullNullableValues);
       restMock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
         evm_address: `${defaultTransaction.from}`
       });
-      const result = await ethImpl.getTransactionByHash(defaultTxHash);
+      const result = await ethImpl.getTransactionByHash(uniqueTxHash);
       if (result == null) return;
 
       expect(result).to.exist;
@@ -3374,13 +3400,16 @@ describe('Eth', async function () {
       const initialDevModeValue = process.env.DEV_MODE;
       process.env.DEV_MODE = 'true';
 
-      restMock.onGet(`contracts/results/${defaultTxHash}`).reply(200, defaultDetailedContractResultByHashReverted);
+      // fake unique hash so request dont re-use the cached value but the mock defined
+      const uniqueTxHash = '0xa8cad7b827375d12d73af57b6a3f84353645fd31305ea58ff52dda53ec640533';
+
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, defaultDetailedContractResultByHashReverted);
       restMock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
         evm_address: `${defaultTransaction.from}`
       });
 
       try {
-        const result = await ethImpl.getTransactionByHash(defaultTxHash);
+        const result = await ethImpl.getTransactionByHash(uniqueTxHash);
         expect(true).to.eq(false);
       }
       catch(error) {

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -398,7 +398,7 @@ describe('MirrorNodeClient', async function () {
   });
 
   it('`getContractResults` by hash', async () => {
-    const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392';
+    const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6391';
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
     const result = await mirrorNodeInstance.getContractResult(hash);
@@ -409,7 +409,7 @@ describe('MirrorNodeClient', async function () {
   });
 
   it('`getContractResults` by hash using cache', async () => {
-    const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392';
+    const hash = '0x07cad7b827375d10d73af57b6a3e84353645fdb1305ea58ff52dda53ec640533';
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
     const resultBeforeCached = await mirrorNodeInstance.getContractResult(hash);
 
@@ -420,7 +420,7 @@ describe('MirrorNodeClient', async function () {
   });
 
   it('`getContractResultsWithRetry` by hash', async () => {
-    const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392';
+    const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6399';
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
     const result = await mirrorNodeInstance.getContractResultWithRetry(hash);
@@ -433,7 +433,7 @@ describe('MirrorNodeClient', async function () {
   });
 
   it('`getContractResultsWithRetry` by hash retries once', async () => {
-    const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392';
+    const hash = '0x2a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6397';
     mock.onGet(`contracts/results/${hash}`).replyOnce(200, {...detailedContractResult, transaction_index: undefined});
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -49,11 +49,11 @@ describe('MirrorNodeClient', async function () {
       timeout: 20 * 1000
     });
     mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
-  })
+  });
 
   beforeEach(() => {
     mock = new MockAdapter(instance);
-  })
+  });
 
   it('it should have a `request` method ', async () => {
     expect(mirrorNodeInstance).to.exist;
@@ -384,7 +384,7 @@ describe('MirrorNodeClient', async function () {
         'value': '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'
       }
     ]
-  }
+  };
 
   it('`getContractResults` by transactionId', async () => {
     const transactionId = '0.0.10-167654-000123456';
@@ -406,6 +406,17 @@ describe('MirrorNodeClient', async function () {
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
     expect(result.v).equal(detailedContractResult.v);
+  });
+
+  it('`getContractResults` by hash using cache', async () => {
+    const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392';
+    mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
+    const resultBeforeCached = await mirrorNodeInstance.getContractResult(hash);
+
+    mock.onGet(`contracts/results/${hash}`).reply(400, null);
+    const resultAfterCached = await mirrorNodeInstance.getContractResult(hash);
+
+    expect(resultBeforeCached).to.eq(resultAfterCached);
   });
 
   it('`getContractResultsWithRetry` by hash', async () => {
@@ -704,7 +715,7 @@ describe('MirrorNodeClient', async function () {
       }
 
       return mockedResults;
-    }
+    };
 
     it('works when there is only 1 page', async () => {
       const mockedResults = [{
@@ -726,7 +737,7 @@ describe('MirrorNodeClient', async function () {
       expect(results).to.exist;
       expect(results).to.deep.equal(mockedResults);
 
-    })
+    });
 
     it('works when there are several pages', async () => {
       const pages = 5;

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -84,7 +84,7 @@ describe('RPC Server', async function() {
         'id': '2',
         'jsonrpc': '2.0',
         'method': 'eth_getTransactionByHash',
-        'params': ['0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6392']
+        'params': ['0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7237170ae5e5e7957eb6392']
       });
       Assertions.expectedError();
     } catch (error) {


### PR DESCRIPTION
**Description**:
Added LRU in memory cache to mirrorNodeClient --> getContractResult method, so when calling /contracts/results/ of the mirror node the relay can save the response on cache for subsequent uses by both getTransactionByHash and getTransactionReceipt

**Related issue(s)**:

Fixes #900 

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
