### PR TITLE
Enhance logs when calling eth_sendRawTransaction to include from and …

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -930,8 +930,6 @@ export class EthImpl implements Eth {
       throw this.genericErrorHandler(e);
     }
 
-
-
     const transactionBuffer = Buffer.from(EthImpl.prune0x(transaction), 'hex');
     try {
       const contractExecuteResponse = await this.sdkClient.submitEthereumTransaction(transactionBuffer, EthImpl.ethSendRawTransaction, requestId);

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -926,9 +926,11 @@ export class EthImpl implements Eth {
       const gasPrice = Number(await this.gasPrice(requestId));
       await this.precheck.sendRawTransactionCheck(parsedTx, gasPrice, requestId);
     } catch (e: any) {
-      this.logger.trace(`${requestIdPrefix} sendRawTransaction(from=${originatingAddress}, to=${interactingEntity}, transaction=${transaction})`);
+      this.logger.warn(`${requestIdPrefix} Error on precheck sendRawTransaction(from=${originatingAddress}, to=${interactingEntity}, transaction=${transaction})`);
       throw this.genericErrorHandler(e);
     }
+
+
 
     const transactionBuffer = Buffer.from(EthImpl.prune0x(transaction), 'hex');
     try {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -916,13 +916,17 @@ export class EthImpl implements Eth {
   async sendRawTransaction(transaction: string, requestId?: string): Promise<string | JsonRpcError> {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     let interactingEntity = '';
-    this.logger.trace(`${requestIdPrefix} sendRawTransaction(transaction=${transaction})`);
+    let originatingAddress = '';
     try {
       const parsedTx = Precheck.parseTxIfNeeded(transaction);
       interactingEntity = parsedTx.to ? parsedTx.to.toString() : '';
+      originatingAddress = parsedTx.from ? parsedTx.from.toString() : '';
+      this.logger.trace(`${requestIdPrefix} sendRawTransaction(from=${originatingAddress}, to=${interactingEntity}, transaction=${transaction})`);
+
       const gasPrice = Number(await this.gasPrice(requestId));
       await this.precheck.sendRawTransactionCheck(parsedTx, gasPrice, requestId);
     } catch (e: any) {
+      this.logger.trace(`${requestIdPrefix} sendRawTransaction(from=${originatingAddress}, to=${interactingEntity}, transaction=${transaction})`);
       throw this.genericErrorHandler(e);
     }
 


### PR DESCRIPTION
**Description**:
Enhance logs when calling eth_sendRawTransaction to include from and to fields besides the raw transaction

**Related issue(s)**:

Fixes #965 

**Notes for reviewer**:

**Example of how the log is being emmited:**

`[Request ID: 7ae06193-cb99-4801-9d08-ba58c93b2d97] sendRawTransaction(from=0x13212A14deaf2775a5b3bEcC857806D5c719d3f2, to=0xCbc6Dd75DF500dC07baD5eF67374aBbb3c8586F9, transaction=0x02f8d4820128038459682f008601e4a3116f0083061a8094cbc6dd75df500dc07bad5ef67374abbb3c8586f980b864a41368620000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d48656c6c6f204675747572652100000000000000000000000000000000000000c001a07ce36254e2d9e7d122016d2948ecf217ab1ad730f240b0e24bee7d2e083ff312a02618a524e5fd5a421ab76dad4f71cd376be0c6bee9bcca4bcbf5967bd18b1526)`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
