### PR TITLE
Acceptance Tests for eth_subscribe, connect, disconnect, subscribe, unsubscribe and multiple subscriptions at once

### DIFF
--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -25,8 +25,10 @@ import WebSocket from 'ws';
 chai.use(solidity);
 
 import {Utils} from '../../helpers/utils';
+import {AliasAccount} from "../../clients/servicesClient";
 import {predefined} from '../../../../../packages/relay';
 const {ethers} = require('ethers');
+const LogContractJson = require('../../contracts/Logs.json');
 
 const FOUR_TWENTY_NINE_RESPONSE = 'Unexpected server response: 429';
 const WS_RELAY_URL = `ws://localhost:${process.env.WEB_SOCKET_PORT}`;
@@ -72,10 +74,20 @@ describe('@web-socket Acceptance Tests', async function() {
     this.timeout(240 * 1000); // 240 seconds
     const CHAIN_ID = process.env.CHAIN_ID || 0;
     let server;
+    // @ts-ignore
+    const {servicesNode, relay} = global;
 
     // cached entities
     let requestId;
     let wsProvider;
+    const accounts: AliasAccount[] = [];
+    let logContractSigner;
+
+    this.beforeAll(async () => {
+        accounts[0] = await servicesNode.createAliasAccount(30, relay.provider, requestId);
+        // Deploy Log Contract
+        logContractSigner = await Utils.deployContractWithEthers([], LogContractJson, accounts[0].wallet, relay);
+    });
 
     this.beforeEach(async () => {
         const { socketServer } = global;
@@ -115,6 +127,78 @@ describe('@web-socket Acceptance Tests', async function() {
             expect(server._connections).to.equal(2);
 
             secondProvider.destroy();
+        });
+
+        it('Subscribe and Unsubscribe', async function () {
+            // subscribe
+            const subId = await wsProvider.send('eth_subscribe',["logs", {"address":logContractSigner.address}]);
+            // unsubscribe
+            const result = await wsProvider.send('eth_unsubscribe', [subId]);
+
+            expect(subId).to.be.length(34);
+            expect(subId.substring(0,2)).to.be.eq("0x");
+            expect(result).to.be.eq(true);
+        });
+
+        it('Subscribe and receive log event and unsubscribe', async function () {
+            const loggerContractWS = new ethers.Contract(logContractSigner.address, LogContractJson.abi, wsProvider);
+            let eventReceived;
+            loggerContractWS.once("Log1", (val) => {
+                eventReceived = val;
+            });
+
+            // perform an action on the SC that emits a Log1 event
+            await logContractSigner.log1(100);
+            // wait 1s to expect the message
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+            expect(eventReceived).to.be.eq(100);
+        });
+
+        it('Multiple ws connections and multiple subscriptions per connection', async function () {
+            const wsConn1 = new ethers.providers.WebSocketProvider(
+                `ws://localhost:${process.env.WEB_SOCKET_PORT}`
+            );
+
+            const wsConn2 = new ethers.providers.WebSocketProvider(
+                `ws://localhost:${process.env.WEB_SOCKET_PORT}`
+            );
+
+            // using WS providers with LoggerContract
+            const loggerContractWS1 = new ethers.Contract(logContractSigner.address, LogContractJson.abi, wsConn1);
+            const loggerContractWS2 = new ethers.Contract(logContractSigner.address, LogContractJson.abi, wsConn2);
+
+            // subscribe to Log1 of LoggerContract for all connections
+            let eventReceivedWS1;
+            loggerContractWS1.once("Log1", (val) => {
+                eventReceivedWS1 = val;
+            });
+
+            //Subscribe to Log3 of LoggerContract for 2 connections
+            let param1Log3ReceivedWS2;
+            let param2Log3ReceivedWS2;
+            let param3Log3ReceivedWS2;
+            loggerContractWS2.once("Log3", (val1, val2, val3) => {
+                param1Log3ReceivedWS2 = val1;
+                param2Log3ReceivedWS2 = val2;
+                param3Log3ReceivedWS2 = val3;
+            });
+
+            //Generate the Logs.
+            await logContractSigner.log1(100);
+            await logContractSigner.log3(4, 6, 7);
+            // wait 2s to expect the message
+            await new Promise(resolve => setTimeout(resolve, 3000));
+
+            // validate we received everything as expected
+            expect(eventReceivedWS1).to.be.eq(100);
+            expect(param1Log3ReceivedWS2).to.be.eq(4);
+            expect(param2Log3ReceivedWS2).to.be.eq(6);
+            expect(param3Log3ReceivedWS2).to.be.eq(7);
+
+            // destroy all WS connections
+            wsConn1.destroy();
+            wsConn2.destroy();
         });
 
         it('When JSON is invalid, expect INVALID_REQUEST Error message', async function() {


### PR DESCRIPTION
**Description**:
Acceptance Tests for eth_subscribe, connect, disconnect, subscribe, unsubscribe and multiple subscriptions at once

**Related issue(s)**:

Fixes #944 

**Notes for reviewer**:
Right now that latest test case is failing, due to what I believe is a [bug](https://github.com/hashgraph/hedera-json-rpc-relay/issues/988), will work on that and update the PR.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
