### PR TITLE
bump-version script improvements

### DIFF
--- a/scripts/.bump-version.js
+++ b/scripts/.bump-version.js
@@ -37,7 +37,6 @@ replace({
 // bump only when is not snapshot
 if(!isSnapshot) {
     // bump docker-compose.yml version
-    // bump helm chart versions
     replace({
         regex: 'image: "ghcr.io\\/hashgraph\\/hedera-json-rpc-relay:(main|\\d+\\.\\d+\\.\\d+(-\\w+)?)\\"',
         replacement: `image: "ghcr.io/hashgraph/hedera-json-rpc-relay:${newVersion}"`,

--- a/scripts/.bump-version.js
+++ b/scripts/.bump-version.js
@@ -25,9 +25,12 @@ checkVersion(newVersion);
 
 console.log(`Bumping version to: ${newVersion}`);
 console.log(`is Snapshot: ${isSnapshot}`);
+
 // bumping version using replace for 'packages/relay/package.json', 'packages/server/package.json', 'docs/openrpc.json', 'packages/ws-server/package.json'
+// looking for: "version": "0.20.0-SNAPSHOT", "version": "0.20.0-rc1", "version": "0.20.0"
+const packageRegex = '\"version\": \"\\d+\\.\\d+\\.\\d+(-\\w+)?\"';
 replace({
-    regex: '\"version\": \"\\d+\\.\\d+\\.\\d+(-\\w+)?\"',
+    regex: packageRegex,
     replacement: `"version": "${newVersion}"`,
     paths: ['packages/relay/package.json', 'packages/server/package.json', 'docs/openrpc.json', 'packages/ws-server/package.json'],
     recursive: false,
@@ -37,8 +40,10 @@ replace({
 // bump only when is not snapshot
 if(!isSnapshot) {
     // bump docker-compose.yml version
+    // looking for: image: "ghcr.io/hashgraph/hedera-json-rpc-relay:0.20.0-SNAPSHOT", image: "ghcr.io/hashgraph/hedera-json-rpc-relay:0.20.0-rc1", image: "ghcr.io/hashgraph/hedera-json-rpc-relay:0.20.0", image: "ghcr.io/hashgraph/hedera-json-rpc-relay:main"
+    const dockerComposeRegex = 'image: \"ghcr.io\\/hashgraph\\/hedera-json-rpc-relay:(main|\\d+\\.\\d+\\.\\d+(-\\w+)?)\"';
     replace({
-        regex: 'image: "ghcr.io\\/hashgraph\\/hedera-json-rpc-relay:(main|\\d+\\.\\d+\\.\\d+(-\\w+)?)\\"',
+        regex: dockerComposeRegex,
         replacement: `image: "ghcr.io/hashgraph/hedera-json-rpc-relay:${newVersion}"`,
         paths: ['docker-compose.yml'],
         recursive: false,
@@ -48,8 +53,10 @@ if(!isSnapshot) {
     const majorMinorVersion = `${newVersion.split(".")[0]}.${newVersion.split(".")[1]}`;
 
     // also update README.md using replace
+    //looking for: "/hashgraph/hedera-json-rpc-relay/main/docs/openrpc.json", "/hashgraph/hedera-json-rpc-relay/release/0.20/docs/openrpc.json"
+    const readmeRegex = '(\\/hashgraph\\/hedera-json-rpc-relay\\/){1}(main|(release\\/\\d+.\\d+)){1}(\\/docs\\/openrpc.json){1}';
     replace({
-        regex: '(\\/hashgraph\\/hedera-json-rpc-relay\\/){1}(main|(release\\/\\d+.\\d+)){1}(\\/docs\\/openrpc.json){1}',
+        regex: readmeRegex,
         replacement: `/hashgraph/hedera-json-rpc-relay/release/${majorMinorVersion}/docs/openrpc.json`,
         paths: ['README.md'],
         recursive: false,
@@ -58,15 +65,19 @@ if(!isSnapshot) {
 }
 
 // bump helm chart versions
+// looking for: "version: 0.20.0-SNAPSHOT", "version: 0.20.0-rc1", "version: 0.20.0"
+const helmChartRegex = 'version: \\d+\\.\\d+\\.\\d+(-\\w+)?';
 replace({
-    regex: 'version: \\d+\\.\\d+\\.\\d+(-\\w+)?',
+    regex: helmChartRegex,
     replacement: `version: ${newVersion}`,
     paths: ['helm-chart/Chart.yaml'],
     recursive: false,
     silent: false,
 });
+// looking for: appVersion: "0.20.0-SNAPSHOT", appVersion: "0.20.0-rc1", appVersion: "0.20.0"
+const helmChartAppVersionRegex = 'appVersion: \"\\d+\\.\\d+\\.\\d+(-\\w+)?\"';
 replace({
-    regex: 'appVersion: \"\\d+\\.\\d+\\.\\d+(-\\w+)?\"',
+    regex: helmChartAppVersionRegex,
     replacement: `appVersion: "${newVersion}"`,
     paths: ['helm-chart/Chart.yaml'],
     recursive: false,


### PR DESCRIPTION
**Description**:
Originally the script was bumping files using `js-yaml` library, but that was re-creating the whole file and using its own standards as to where to use ' " or nothing, and in order to avoid unintended changes we decided to use regex and replace for all files, so we don't modify unintended fields on yaml files

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Script was used to modify the files on this 2 PRs:

RC:
```
npm run bump-version --semver=0.20.0-rc1 --snapshot=false
```
https://github.com/hashgraph/hedera-json-rpc-relay/pull/1002

Snapshot:
```
npm run bump-version --semver=0.21.0-SNAPSHOT --snapshot=true
```
https://github.com/hashgraph/hedera-json-rpc-relay/pull/1000

