### PR TITLE
Invalid Json Crashes WS-Server Fix

### DIFF
--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -21,11 +21,11 @@
 // external resources
 import { solidity } from "ethereum-waffle";
 import chai, {assert, expect} from "chai";
+import WebSocket from 'ws';
 chai.use(solidity);
 
 import {Utils} from '../../helpers/utils';
-import { finished } from "stream";
-import bodyParser from "koa-bodyparser";
+import {predefined} from "@hashgraph/json-rpc-relay";
 const {ethers} = require('ethers');
 
 const FOUR_TWENTY_NINE_RESPONSE = 'Unexpected server response: 429';
@@ -117,6 +117,25 @@ describe('@web-socket Acceptance Tests', async function() {
             secondProvider.destroy();
         });
 
+        it('When JSON is invalid, expect INVALID_REQUEST Error message', async function() {
+
+            const webSocket = new WebSocket(WS_RELAY_URL);
+            let response = "";
+            webSocket.on('message', function incoming(data) {
+                response = data;
+            });
+            webSocket.on('open', function open() {
+                webSocket.send('{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1');
+            });
+            await new Promise(resolve => setTimeout(resolve, 200));
+
+            expect(JSON.parse(response).code).to.eq(predefined.INVALID_REQUEST.code);
+            expect(JSON.parse(response).name).to.eq(predefined.INVALID_REQUEST.name);
+            expect(JSON.parse(response).message).to.eq(predefined.INVALID_REQUEST.message);
+
+            webSocket.close();
+        });
+
         it('Does not allow more connections than the connection limit', async function() {
             // We already have one connection
             for (let i = 1; i < parseInt(process.env.CONNECTION_LIMIT); i++) {
@@ -128,7 +147,6 @@ describe('@web-socket Acceptance Tests', async function() {
             await expectedErrorAndConnections(server);
 
             await new Promise(resolve => setTimeout(resolve, 1000));
- 
         });
     });
 });

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -25,7 +25,7 @@ import WebSocket from 'ws';
 chai.use(solidity);
 
 import {Utils} from '../../helpers/utils';
-import {predefined} from "@hashgraph/json-rpc-relay";
+import {predefined} from '../../../../../packages/relay';
 const {ethers} = require('ethers');
 
 const FOUR_TWENTY_NINE_RESPONSE = 'Unexpected server response: 429';


### PR DESCRIPTION
**Description**:
Handles `JSON.parse(msg.toString('ascii'))` Exception, so the ws-server does not crash due to an invalid request that is not a parseable JSON.

Return INVALID_REQUEST that is existing in current JsonRpcError Collection
```json
{
  "code": -32600,
  "name": "Invalid request",
  "message": "Invalid request"
}
```

**Related issue(s)**:

Fixes #985 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
