### PR TITLE
Return existing SubId for repeated subscriptions from same connection and same tag/filters.

### DIFF
--- a/packages/relay/src/lib/subscriptionController.ts
+++ b/packages/relay/src/lib/subscriptionController.ts
@@ -66,6 +66,13 @@ export class SubscriptionController {
             this.subscriptions[tag] = [];
         }
 
+        // Check if the connection is already subscribed to this event
+        const existingSub = this.subscriptions[tag].find(sub => sub.connection.id === connection.id);
+        if (existingSub) {
+            this.logger.info(`${LOGGER_PREFIX} Connection ${connection.id} already subscribed to ${tag}`);
+            return existingSub.subscriptionId;
+        }
+
         const subId = this.generateId();
 
         this.logger.info(`${LOGGER_PREFIX} New subscription ${subId}, listening for ${tag}`);

--- a/packages/relay/tests/lib/subscriptionController.spec.ts
+++ b/packages/relay/tests/lib/subscriptionController.spec.ts
@@ -221,4 +221,14 @@ describe("subscriptionController", async function() {
         expect(status).to.be.eq(true);
     });
 
+    it('Subscribing to the same event and filters should return the same subscription id', async function () {
+        const wsConnection = new MockWsConnection("7");
+        const tag1 = { event: "logs", filters:{"topics": ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]}};
+        const subId = subscriptionController.subscribe(wsConnection, tag1.event);
+        const subId2 = subscriptionController.subscribe(wsConnection, tag1.event);
+
+        expect(subId).to.be.eq(subId2);
+    });
+
+
 });


### PR DESCRIPTION
**Description**:
When receiving repeated subscriptions from the same connection, for the same Tag, return the already existing subId instead of a new one.

**Related issue(s)**:

Fixes #987 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
