### PR TITLE
936 add a max block number range check

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -80,7 +80,7 @@ export class EthImpl implements Eth {
   static blockLatest = 'latest';
   static blockEarliest = 'earliest';
   static blockPending = 'pending';
-  static fewBlocksGreater = 3;
+  static fewBlocksGreater = 5;
 
   /**
    * Configurable options used when initializing the cache.
@@ -1335,8 +1335,6 @@ export class EthImpl implements Eth {
       return null;
     }
 
-    // If blocknumber requested is more than a few blocks greater than the latest, fail fast. 
-    // const latestBlock = await this.mirrorNodeClient.getLatestBlock(requestId);
     if(!returnLatest){
       const response = await this.mirrorNodeClient.getLatestBlock(requestId);
       blockResponse = response.blocks[0];

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -82,8 +82,6 @@ export class EthImpl implements Eth {
   static blockPending = 'pending';
   static fewBlocksGreater = 3;
 
-
-
   /**
    * Configurable options used when initializing the cache.
    *
@@ -1352,7 +1350,6 @@ export class EthImpl implements Eth {
         const response = await this.mirrorNodeClient.getLatestBlock(requestId);
         blockResponse = response.blocks[0];
       }
-
     } else if (blockNumberOrTag == EthImpl.blockEarliest) {
       blockResponse = await this.mirrorNodeClient.getBlock(0, requestId);
     } else if (blockNumberOrTag.length < 32) {


### PR DESCRIPTION
**Description**:

This PR modifies the block query to the mirror node(eth_getBlockByNumber) by checking if the block number is greater than three above the latest block number.  If so, it returns null immediately.

Fixes #936
