### PR TITLE
Enable `eth_getStorageAt` to return older state

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -513,10 +513,13 @@ export class MirrorNodeClient {
         return this.getContractResultsByAddress(address, contractResultsParams, limitOrderParams, requestId);
     }
 
-    public async getContractCurrentStateByAddressAndSlot(address: string, slot: string, requestId?: string) {
+    public async getContractStateByAddressAndSlot(address: string, slot: string, blockEndTimestamp?: string, requestId?: string) {
         const limitOrderParams: ILimitOrderParams = this.getLimitOrderQueryParam(constants.MIRROR_NODE_QUERY_LIMIT, constants.ORDER.DESC);
         const queryParamObject = {};
-
+        
+        if (blockEndTimestamp) {
+            this.setQueryParam(queryParamObject, 'timestamp', blockEndTimestamp);
+        }
         this.setQueryParam(queryParamObject, 'slot', slot);
         this.setLimitOrderParams(queryParamObject, limitOrderParams);
         const queryParams = this.getQueryParams(queryParamObject);

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -572,7 +572,7 @@ describe('MirrorNodeClient', async function () {
 
   it('`getContractCurrentStateByAddressAndSlot`', async () => {
     mock.onGet(`contracts/${contractAddress}/state?slot=${defaultCurrentContractState.state[0].slot}&limit=100&order=desc`).reply(200, defaultCurrentContractState);
-    const result = await mirrorNodeInstance.getContractCurrentStateByAddressAndSlot(contractAddress, defaultCurrentContractState.state[0].slot);
+    const result = await mirrorNodeInstance.getContractStateByAddressAndSlot(contractAddress, defaultCurrentContractState.state[0].slot);
 
     expect(result).to.exist;
     expect(result.state).to.exist;
@@ -582,7 +582,7 @@ describe('MirrorNodeClient', async function () {
   it('`getContractCurrentStateByAddressAndSlot` - incorrect address', async () => {
     mock.onGet(`contracts/${contractAddress}/state?slot=${defaultCurrentContractState.state[0].slot}&limit=100&order=desc`).reply(200, defaultCurrentContractState);
     try {
-      expect(await mirrorNodeInstance.getContractCurrentStateByAddressAndSlot(contractAddress+'1', defaultCurrentContractState.state[0].slot)).to.throw();
+      expect(await mirrorNodeInstance.getContractStateByAddressAndSlot(contractAddress+'1', defaultCurrentContractState.state[0].slot)).to.throw();
     } catch (error) {
       expect(error).to.exist;
     }
@@ -591,7 +591,7 @@ describe('MirrorNodeClient', async function () {
   it('`getContractCurrentStateByAddressAndSlot` - incorrect slot', async () => {
     mock.onGet(`contracts/${contractAddress}/state?slot=${defaultCurrentContractState.state[0].slot}&limit=100&order=desc`).reply(200, defaultCurrentContractState);
     try {
-      expect(await mirrorNodeInstance.getContractCurrentStateByAddressAndSlot(contractAddress, defaultCurrentContractState.state[0].slot+'1')).to.throw();
+      expect(await mirrorNodeInstance.getContractStateByAddressAndSlot(contractAddress, defaultCurrentContractState.state[0].slot+'1')).to.throw();
     } catch (error) {
       expect(error).to.exist;
     }

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -134,7 +134,7 @@ describe('RPC Server Acceptance Tests', function () {
         // set env variables for docker images until local-node is updated
         process.env['NETWORK_NODE_IMAGE_TAG'] = '0.36.0-alpha.2';
         process.env['HAVEGED_IMAGE_TAG'] = '0.36.0-alpha.2';
-        process.env['MIRROR_IMAGE_TAG'] = '0.76.1';
+        process.env['MIRROR_IMAGE_TAG'] = '0.77.0-rc2';
 
         console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -627,8 +627,9 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
             const signedTx = await accounts[1].wallet.signTransaction(transaction);
             const transactionHash = await relay.call('eth_sendRawTransaction', [signedTx], requestId);
-            const blockNumber = (await relay.call('eth_getTransactionReceipt', [transactionHash], requestId)).blockNumber;
-
+            const txReceipt = await relay.call('eth_getTransactionReceipt', [transactionHash], requestId);
+            const blockNumber = txReceipt.blockNumber;
+            
             // wait for the transaction to propogate to mirror node
             await new Promise(r => setTimeout(r, 4000));
 

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -606,6 +606,40 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             expect(storageVal).to.eq(END_EXPECTED_STORAGE_VAL);
         });
 
+        it('should execute "eth_getStorageAt" request to get old state with passing specific block', async function() {
+            const END_EXPECTED_STORAGE_VAL = "0x0000000000000000000000000000000000000000000000000000000000000008";
+
+            const beginStorageVal = await relay.call('eth_getStorageAt', [evmAddress, '0x0000000000000000000000000000000000000000000000000000000000000000', 'latest'], requestId);
+
+            const gasPrice = await relay.gasPrice();
+            const transaction = {
+                value: 0,
+                gasLimit: 50000,
+                chainId: Number(CHAIN_ID),
+                to: evmAddress,
+                nonce: await relay.getAccountNonce('0x' + accounts[1].address),
+                gasPrice: gasPrice,
+                data: STORAGE_CONTRACT_UPDATE,
+                maxPriorityFeePerGas: gasPrice,
+                maxFeePerGas: gasPrice,
+                type: 2
+            };
+
+            const signedTx = await accounts[1].wallet.signTransaction(transaction);
+            const transactionHash = await relay.call('eth_sendRawTransaction', [signedTx], requestId);
+            const blockNumber = (await relay.call('eth_getTransactionReceipt', [transactionHash], requestId)).blockNumber;
+
+            // wait for the transaction to propogate to mirror node
+            await new Promise(r => setTimeout(r, 4000));
+
+            const latestStorageVal = await relay.call('eth_getStorageAt', [evmAddress, '0x0000000000000000000000000000000000000000000000000000000000000000', 'latest'], requestId);
+            const blockNumberBeforeChange = `0x${(blockNumber - 1).toString(16)}`;
+            const storageValBeforeChange = await relay.call('eth_getStorageAt', [evmAddress, '0x0000000000000000000000000000000000000000000000000000000000000000', blockNumberBeforeChange], requestId);
+
+            expect(latestStorageVal).to.eq(END_EXPECTED_STORAGE_VAL);
+            expect(storageValBeforeChange).to.eq(beginStorageVal);
+        });
+
         it('should execute "eth_getStorageAt" request to get current state changes without passing block', async function () {
             const BEGIN_EXPECTED_STORAGE_VAL = "0x000000000000000000000000000000000000000000000000000000000000000f";
             const END_EXPECTED_STORAGE_VAL = "0x0000000000000000000000000000000000000000000000000000000000000008";

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -13,7 +13,7 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
   if (USE_LOCAL_NODE) {
     process.env['NETWORK_NODE_IMAGE_TAG'] = '0.36.0-alpha.2';
     process.env['HAVEGED_IMAGE_TAG'] = '0.36.0-alpha.2';
-    process.env['MIRROR_IMAGE_TAG'] = '0.76.1';
+    process.env['MIRROR_IMAGE_TAG'] = '0.77.0-rc2';
 
     console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 


### PR DESCRIPTION
**Description**:
With the extension of state endpoint in the mirror-node, we can now fetch and return not only the current state, but older. This PR makes the necessary changes to enable this and removes the usage of the old endpoint as it is no longer needed.
Bump mirror-node version, because the needed change for this feature is in 0.77

**Related issue(s)**:

Fixes #790 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
