### PR TITLE
Test fix for release 0.21.0-rc1.  Updated test to use invalid account

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -354,7 +354,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                     it("007 'data' from request body with wrong encoded parameter", async function () {
                         const callData = {
                             ...defaultCallData,
-                            data: '0x3ec4de350000000000000000000000000000000000000000000000000000000000000005'
+                            data: '0x3ec4de350000000000000000000000000000000000000000000000000000000000000000'
                         };
 
                         const res = await relay.call('eth_call', [callData, 'latest'], requestId);


### PR DESCRIPTION
**Description**:
This PR updates the rcp_batch3.spec, "007 'data' from request body with wrong encoded parameter" to use an invalid address in the "wrong encoded parameter" as the old address on previewnet was getting used accumulating a balance.

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
