### PR TITLE
Bump Acceptance Tests network images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "root",
             "dependencies": {
-                "@hashgraph/hedera-local": "^2.6.0",
+                "@hashgraph/hedera-local": "^2.7.0",
                 "@open-rpc/schema-utils-js": "^1.16.1",
                 "@types/find-config": "^1.0.1",
                 "keyv-file": "^0.2.0",
@@ -408,7 +408,8 @@
         },
         "node_modules/@balena/dockerignore": {
             "version": "1.0.2",
-            "license": "Apache-2.0"
+            "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+            "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
         },
         "node_modules/@colors/colors": {
             "version": "1.5.0",
@@ -2329,15 +2330,15 @@
             }
         },
         "node_modules/@hashgraph/hedera-local": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.6.0.tgz",
-            "integrity": "sha512-jL/aybK6tANTKr0YglVN9kJfkHka+LVN1GQ+Qsyy3fqkNrlazUvX5+Bs24+f0OvsvrDM56IUbQymPBo0mVGVww==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.7.0.tgz",
+            "integrity": "sha512-SH5AhBJbRepB97GbUgiMwA0jbmfM25aDyZ7eanZ1DR6q2QelVS8NbC2Om+sZ/IYDq/afJ6d307vFFh6J1gduJQ==",
             "dependencies": {
                 "@hashgraph/hethers": "^1.2.6",
-                "@hashgraph/sdk": "^2.22.0",
+                "@hashgraph/sdk": "^2.24.0",
                 "blessed": "^0.1.81",
                 "blessed-terminal": "^0.1.22",
-                "dockerode": "^3.3.4",
+                "dockerode": "^3.3.5",
                 "dotenv": "^16.0.3",
                 "ethers": "^5.7.2",
                 "js-yaml": "^4.1.0",
@@ -2555,9 +2556,9 @@
             }
         },
         "node_modules/@hashgraph/sdk": {
-            "version": "2.23.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.23.0.tgz",
-            "integrity": "sha512-P/hv/mz1vmNLvQxtSzE6ptHaqmtDJtmM69FhJPEYf8fBklSPPWnBrA/jYEHm2lNSZwM1HyODEWcNfV+h44iA6w==",
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.24.0.tgz",
+            "integrity": "sha512-P4sig7LAIi0xfwm+FTZkMlxnNrykOTBLHX5IKWPAYbKWCZ4le0Hhb09oBF7sw2g7NWxJLfvkxpmRvVlC41Qjag==",
             "dependencies": {
                 "@ethersproject/rlp": "^5.7.0",
                 "@grpc/grpc-js": "^1.7.3",
@@ -6927,6 +6928,8 @@
         },
         "node_modules/buildcheck": {
             "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
+            "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
             "optional": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -7740,6 +7743,8 @@
         },
         "node_modules/cpu-features": {
             "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
+            "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
             "hasInstallScript": true,
             "optional": true,
             "dependencies": {
@@ -8077,8 +8082,9 @@
             }
         },
         "node_modules/docker-modem": {
-            "version": "3.0.6",
-            "license": "Apache-2.0",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.8.tgz",
+            "integrity": "sha512-f0ReSURdM3pcKPNS30mxOHSbaFLcknGmQjwSfmbcdOw1XWKXVhukM3NJHhr7NpY9BIyyWQb0EBo3KQvvuU5egQ==",
             "dependencies": {
                 "debug": "^4.1.1",
                 "readable-stream": "^3.5.0",
@@ -8090,8 +8096,9 @@
             }
         },
         "node_modules/dockerode": {
-            "version": "3.3.4",
-            "license": "Apache-2.0",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
+            "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
             "dependencies": {
                 "@balena/dockerignore": "^1.0.2",
                 "docker-modem": "^3.0.0",
@@ -13492,7 +13499,8 @@
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "node_modules/mkdirp-infer-owner": {
             "version": "2.0.0",
@@ -13719,7 +13727,8 @@
         },
         "node_modules/nan": {
             "version": "2.17.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+            "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
             "optional": true
         },
         "node_modules/nanoid": {
@@ -17067,7 +17076,8 @@
         },
         "node_modules/split-ca": {
             "version": "1.0.1",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+            "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
         },
         "node_modules/split2": {
             "version": "3.2.2",
@@ -17082,6 +17092,8 @@
         },
         "node_modules/ssh2": {
             "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
+            "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
             "hasInstallScript": true,
             "dependencies": {
                 "asn1": "^0.2.4",
@@ -17459,7 +17471,8 @@
         },
         "node_modules/tar-fs": {
             "version": "2.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+            "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -17469,7 +17482,8 @@
         },
         "node_modules/tar-fs/node_modules/chownr": {
             "version": "1.1.4",
-            "license": "ISC"
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "node_modules/tar-stream": {
             "version": "2.2.0",
@@ -18972,8 +18986,8 @@
                 "uuid": "^3.3.2"
             },
             "devDependencies": {
-                "@hashgraph/hedera-local": "^2.4.5",
-                "@hashgraph/sdk": "^2.19.2",
+                "@hashgraph/hedera-local": "^2.7.0",
+                "@hashgraph/sdk": "^2.24.0",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
                 "@types/cors": "^2.8.12",
@@ -19319,7 +19333,9 @@
             }
         },
         "@balena/dockerignore": {
-            "version": "1.0.2"
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+            "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
         },
         "@colors/colors": {
             "version": "1.5.0",
@@ -20488,15 +20504,15 @@
             }
         },
         "@hashgraph/hedera-local": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.6.0.tgz",
-            "integrity": "sha512-jL/aybK6tANTKr0YglVN9kJfkHka+LVN1GQ+Qsyy3fqkNrlazUvX5+Bs24+f0OvsvrDM56IUbQymPBo0mVGVww==",
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.7.0.tgz",
+            "integrity": "sha512-SH5AhBJbRepB97GbUgiMwA0jbmfM25aDyZ7eanZ1DR6q2QelVS8NbC2Om+sZ/IYDq/afJ6d307vFFh6J1gduJQ==",
             "requires": {
                 "@hashgraph/hethers": "^1.2.6",
-                "@hashgraph/sdk": "^2.22.0",
+                "@hashgraph/sdk": "^2.24.0",
                 "blessed": "^0.1.81",
                 "blessed-terminal": "^0.1.22",
-                "dockerode": "^3.3.4",
+                "dockerode": "^3.3.5",
                 "dotenv": "^16.0.3",
                 "ethers": "^5.7.2",
                 "js-yaml": "^4.1.0",
@@ -20570,9 +20586,9 @@
         "@hashgraph/json-rpc-server": {
             "version": "file:packages/server",
             "requires": {
-                "@hashgraph/hedera-local": "^2.4.5",
+                "@hashgraph/hedera-local": "^2.7.0",
                 "@hashgraph/json-rpc-relay": "file:../relay",
-                "@hashgraph/sdk": "^2.19.2",
+                "@hashgraph/sdk": "^2.24.0",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
                 "@types/cors": "^2.8.12",
@@ -20795,9 +20811,9 @@
             }
         },
         "@hashgraph/sdk": {
-            "version": "2.23.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.23.0.tgz",
-            "integrity": "sha512-P/hv/mz1vmNLvQxtSzE6ptHaqmtDJtmM69FhJPEYf8fBklSPPWnBrA/jYEHm2lNSZwM1HyODEWcNfV+h44iA6w==",
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.24.0.tgz",
+            "integrity": "sha512-P4sig7LAIi0xfwm+FTZkMlxnNrykOTBLHX5IKWPAYbKWCZ4le0Hhb09oBF7sw2g7NWxJLfvkxpmRvVlC41Qjag==",
             "requires": {
                 "@ethersproject/rlp": "^5.7.0",
                 "@grpc/grpc-js": "^1.7.3",
@@ -23797,6 +23813,8 @@
         },
         "buildcheck": {
             "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.3.tgz",
+            "integrity": "sha512-pziaA+p/wdVImfcbsZLNF32EiWyujlQLwolMqUQE8xpKNOH7KmZQaY8sXN7DGOEzPAElo9QTaeNRfGnf3iOJbA==",
             "optional": true
         },
         "builtins": {
@@ -24336,6 +24354,8 @@
         },
         "cpu-features": {
             "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.4.tgz",
+            "integrity": "sha512-fKiZ/zp1mUwQbnzb9IghXtHtDoTMtNeb8oYGx6kX2SYfhnG0HNdBEBIzB9b5KlXu5DQPhfy3mInbBxFcgwAr3A==",
             "optional": true,
             "requires": {
                 "buildcheck": "0.0.3",
@@ -24534,7 +24554,9 @@
             }
         },
         "docker-modem": {
-            "version": "3.0.6",
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-3.0.8.tgz",
+            "integrity": "sha512-f0ReSURdM3pcKPNS30mxOHSbaFLcknGmQjwSfmbcdOw1XWKXVhukM3NJHhr7NpY9BIyyWQb0EBo3KQvvuU5egQ==",
             "requires": {
                 "debug": "^4.1.1",
                 "readable-stream": "^3.5.0",
@@ -24543,7 +24565,9 @@
             }
         },
         "dockerode": {
-            "version": "3.3.4",
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.3.5.tgz",
+            "integrity": "sha512-/0YNa3ZDNeLr/tSckmD69+Gq+qVNhvKfAHNeZJBnp7EOP6RGKV8ORrJHkUn20So5wU+xxT7+1n5u8PjHbfjbSA==",
             "requires": {
                 "@balena/dockerignore": "^1.0.2",
                 "docker-modem": "^3.0.0",
@@ -28034,7 +28058,9 @@
             }
         },
         "mkdirp-classic": {
-            "version": "0.5.3"
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "mkdirp-infer-owner": {
             "version": "2.0.0",
@@ -28175,6 +28201,8 @@
         },
         "nan": {
             "version": "2.17.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+            "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
             "optional": true
         },
         "nanoid": {
@@ -30344,7 +30372,9 @@
             }
         },
         "split-ca": {
-            "version": "1.0.1"
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+            "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ=="
         },
         "split2": {
             "version": "3.2.2",
@@ -30357,6 +30387,8 @@
         },
         "ssh2": {
             "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
+            "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
             "requires": {
                 "asn1": "^0.2.4",
                 "bcrypt-pbkdf": "^1.0.2",
@@ -30613,6 +30645,8 @@
         },
         "tar-fs": {
             "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+            "integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
             "requires": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -30621,7 +30655,9 @@
             },
             "dependencies": {
                 "chownr": {
-                    "version": "1.1.4"
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+                    "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "bump-version": "SEM_VER=${npm_config_semver} SNAPSHOT=${npm_config_snapshot} node scripts/.bump-version.js"
     },
     "dependencies": {
-        "@hashgraph/hedera-local": "^2.6.0",
+        "@hashgraph/hedera-local": "^2.7.0",
         "@open-rpc/schema-utils-js": "^1.16.1",
         "@types/find-config": "^1.0.1",
         "keyv-file": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,8 +21,8 @@
         "uuid": "^3.3.2"
     },
     "devDependencies": {
-        "@hashgraph/hedera-local": "^2.4.5",
-        "@hashgraph/sdk": "^2.19.2",
+        "@hashgraph/hedera-local": "^2.7.0",
+        "@hashgraph/sdk": "^2.24.0",
         "@koa/cors": "^3.1.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -132,9 +132,9 @@ describe('RPC Server Acceptance Tests', function () {
 
     function runLocalHederaNetwork() {
         // set env variables for docker images until local-node is updated
-        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.36.0-alpha.2';
-        process.env['HAVEGED_IMAGE_TAG'] = '0.36.0-alpha.2';
-        process.env['MIRROR_IMAGE_TAG'] = '0.77.0-rc3';
+        process.env['NETWORK_NODE_IMAGE_TAG'] = '0.37.0-alpha.0';
+        process.env['HAVEGED_IMAGE_TAG'] = '0.37.0-alpha.0';
+        process.env['MIRROR_IMAGE_TAG'] = '0.78.0-beta1';
 
         console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 

--- a/packages/server/tests/helpers/prerequisite.ts
+++ b/packages/server/tests/helpers/prerequisite.ts
@@ -11,9 +11,9 @@ const RELAY_URL = process.env.E2E_RELAY_HOST || LOCAL_RELAY_URL;
 
 (function () {
   if (USE_LOCAL_NODE) {
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.36.0-alpha.2';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.36.0-alpha.2';
-    process.env['MIRROR_IMAGE_TAG'] = '0.77.0-rc3';
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.37.0-alpha.0';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.37.0-alpha.0';
+    process.env['MIRROR_IMAGE_TAG'] = '0.78.0-beta1';
 
     console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 


### PR DESCRIPTION
**Description**:
This PR bumps acceptance test network image to `0.37.0-alpha.0` and mirror-node images to `0.78.0-beta.1` . 
Also bump local-node and sdk packages

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
