### PR TITLE
1045 eth subscribe sanity check2

### DIFF
--- a/packages/server/src/validator/objectTypes.ts
+++ b/packages/server/src/validator/objectTypes.ts
@@ -89,6 +89,17 @@ export const OBJECTS_VALIDATIONS = {
       type: "array",
       nullable: false
     }
+  },
+  "ethSubscribeLogsParams": {
+    "address" : {
+      type: "addressFilter",
+      nullable: false,
+      required: true
+    },
+    "topics" : {
+        type: "topics",
+        nullable: false
+    }
   }
 };
 
@@ -186,3 +197,27 @@ export class BlockNumberObject {
   }
 };
 
+export class EthSubscribeLogsParamsObject {
+    address?: string | string[];
+    topics?: string[] | string[][];
+
+    constructor (param: any) {
+        Validator.hasUnexpectedParams(param, OBJECTS_VALIDATIONS.ethSubscribeLogsParams, this.name());
+        this.address = param.address;
+        this.topics = param.topics;
+    }
+
+    validate() {
+        const valid = Validator.validateObject(this, OBJECTS_VALIDATIONS.ethSubscribeLogsParams);
+        // address and is not an empty array
+        if(valid && Array.isArray(this.address) && this.address.length === 0 && OBJECTS_VALIDATIONS.ethSubscribeLogsParams.address.required){
+          throw predefined.MISSING_REQUIRED_PARAMETER(`'address' for ${this.name()}`);
+        }
+
+        return valid;
+    }
+
+    name() {
+        return this.constructor.name;
+    }
+}

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -553,6 +553,66 @@ describe('@web-socket Acceptance Tests', async function() {
                 expect(errorsHandled).to.eq(0);
             });
         });
+
+        describe('ethSubscribe Logs Params Validations', async function() {
+            it('Calling eth_subscribe Logs with a non existent address should fail', async function() {
+                const missingContract = "0xea4168c4cbb744ec22dea4a4bfc5f74b6fe27816";
+                let actualError: any = null;
+                try {
+                    await wsProvider.send('eth_subscribe', ["logs", {"address": missingContract}]);
+                } catch (e: any) {
+                    actualError = JSON.parse(e.response);
+                }
+
+                const expectedError = predefined.INVALID_PARAMETER(`filters.address`, `${missingContract} is not a valid contract type or does not exists`);
+                expect(actualError.error.code).to.be.eq(expectedError.code);
+                expect(actualError.error.name).to.be.eq(expectedError.name);
+                expect(actualError.error.message).to.contains(expectedError.message);
+            });
+
+            it('Calling eth_subscribe Logs with an empty address should fail', async function() {
+                const missingContract = "";
+                let actualError: any = null;
+                try {
+                    await wsProvider.send('eth_subscribe', ["logs", {"address": missingContract}]);
+                } catch (e: any) {
+                    actualError = JSON.parse(e.response);
+                }
+
+                const expectedError = predefined.INVALID_PARAMETER(`'address' for EthSubscribeLogsParamsObject`, `Expected 0x prefixed string representing the address (20 bytes) or an array of addresses, value: `);
+                expect(actualError.error.code).to.be.eq(expectedError.code);
+                expect(actualError.error.name).to.be.eq(expectedError.name);
+                expect(actualError.error.message).to.contains(expectedError.message);
+            });
+
+            it('Calling eth_subscribe Logs with params without address should fail', async function() {
+                let actualError: any = null;
+                try {
+                    await wsProvider.send('eth_subscribe', ["logs", {}]);
+                } catch (e: any) {
+                    actualError = JSON.parse(e.response);
+                }
+
+                const expectedError = predefined.MISSING_REQUIRED_PARAMETER(`'address' for EthSubscribeLogsParamsObject`);
+                expect(actualError.error.code).to.be.eq(expectedError.code);
+                expect(actualError.error.name).to.be.eq(expectedError.name);
+                expect(actualError.error.message).to.contains(expectedError.message);
+            });
+
+            it('Calling eth_subscribe Logs with an invalid topics should fail', async function() {
+                let actualError: any = null;
+                try {
+                    await wsProvider.send('eth_subscribe', ["logs", {"address": logContractSigner.address, "topics": ["0x000"]}]);
+                } catch (e: any) {
+                    actualError = JSON.parse(e.response);
+                }
+
+                const expectedError = predefined.INVALID_PARAMETER(`'topics' for EthSubscribeLogsParamsObject`, `Expected an array or array of arrays containing 0x prefixed string representing the hash (32 bytes) of a topic, value: 0x000`);
+                expect(actualError.error.code).to.be.eq(expectedError.code);
+                expect(actualError.error.name).to.be.eq(expectedError.name);
+                expect(actualError.error.message).to.contains(expectedError.message);
+            });
+        });
     });
 });
 

--- a/packages/server/tests/integration/validator.spec.ts
+++ b/packages/server/tests/integration/validator.spec.ts
@@ -573,4 +573,129 @@ describe('Validator', async () => {
       expect(Validator.isValidAndNonNullableParam('0x', true)).to.be.true;
     });
   });
+
+  describe('validates ethSubscribeLogsParams Object type correctly', async () => {
+    it("throws an error if 'address' is null", async () => {
+      expect(() => {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: null});
+        validatorObject.validate();
+      }).to.throw(
+          `Invalid parameter 'address' for EthSubscribeLogsParamsObject: Expected 0x prefixed string representing the address (20 bytes) or an array of addresses, value: null`
+      );
+    });
+
+    it("throws an error if 'address' is undefined", async () => {
+      expect(() => {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: undefined});
+        validatorObject.validate();
+      }).to.throw(
+          `Missing value for required parameter 'address' for EthSubscribeLogsParamsObject`
+      );
+    });
+
+    it("throws an error if 'address' is empty array", async () => {
+      expect(() => {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: []});
+        validatorObject.validate();
+      }).to.throw(
+          `Missing value for required parameter 'address' for EthSubscribeLogsParamsObject`
+      );
+    });
+
+    it("throws an error if 'topics' values are not 0x prefixed", async () => {
+      expect(() => {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: "0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816", topics: ["NotHEX"]});
+        validatorObject.validate();
+      }).to.throw(
+          `Invalid parameter 'topics' for EthSubscribeLogsParamsObject: Expected an array or array of arrays containing 0x prefixed string representing the hash (32 bytes) of a topic, value: NotHEX`
+      );
+    });
+
+    it("throws an error if 'topics' values are null", async () => {
+      expect(() => {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: "0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816", topics: null});
+        validatorObject.validate();
+      }).to.throw(
+          `Invalid parameter 'topics' for EthSubscribeLogsParamsObject: Expected an array or array of arrays containing 0x prefixed string representing the hash (32 bytes) of a topic, value: null`
+      );
+    });
+
+    it("does not throw an error if 'topics' values are 0x prefixed and 32 bytes", async () => {
+      let errorOccurred = false;
+      try {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: "0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816", topics: ["0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902", "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"]});
+        validatorObject.validate();
+      } catch (error){
+        errorOccurred = true;
+      }
+
+      expect(errorOccurred).to.be.eq(false);
+    });
+
+    it("does not throw an error if 'topics' value is empty array", async () => {
+      let errorOccurred = false;
+      try {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: "0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816", topics: []});
+        validatorObject.validate();
+      } catch (error){
+        errorOccurred = true;
+      }
+
+      expect(errorOccurred).to.be.eq(false);
+    });
+
+    it("does not throw an error if 'address' is valid and topics is undefined", async () => {
+      let errorOccurred = false;
+      try {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: "0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816", topics: undefined});
+        validatorObject.validate();
+      } catch (error){
+        errorOccurred = true;
+      }
+
+      expect(errorOccurred).to.be.eq(false);
+    });
+
+    it("does not throw an error if 'address' is valid and topics is missing", async () => {
+      let errorOccurred = false;
+      try {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: "0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816"});
+        validatorObject.validate();
+      } catch (error){
+        errorOccurred = true;
+      }
+
+      expect(errorOccurred).to.be.eq(false);
+    });
+
+    it("does not throw an error if 'address' is valid array and topics is missing", async () => {
+      let errorOccurred = false;
+      try {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({address: ["0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816", "0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816"]});
+        validatorObject.validate();
+      } catch (error){
+        errorOccurred = true;
+      }
+
+      expect(errorOccurred).to.be.eq(false);
+    });
+
+    it("does not throw an error if 'address' is valid array and topics is valid array", async () => {
+      let errorOccurred = false;
+      try {
+        const validatorObject = new Validator.EthSubscribeLogsParamsObject({
+          address: ["0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816", "0xea4168c4cbb733ec22dea4a4bfc5f74b6fe27816"],
+          "topics": [
+            "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902",
+            "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902",
+            "0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"
+          ]});
+        validatorObject.validate();
+      } catch (error){
+        errorOccurred = true;
+      }
+
+      expect(errorOccurred).to.be.eq(false);
+    });
+  });
 });


### PR DESCRIPTION
**Description**:
Added objectTypes ethSubscribeLogsParams that contains the logic for validation of ethSubscribe method logs params.

Unit tests for new validation ObjectType

Acceptance test for new validations


**Related issue(s)**:

Fixes #1045 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
