### PR TITLE
Extract and Log Contract Revert Reason (#1043)

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -54,4 +54,15 @@ const decodeErrorMessage = (message?: string): string => {
     return hexToASCII(resultCodeHex);
 };
 
-export { hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage };
+const formatTransactionId = (transactionId: string): string | null => {
+    if (!constants.TRANSACTION_ID_REGEX.test(transactionId)) {
+        return null;
+    }
+    
+    var transactionSplit = transactionId.split("@");
+    const payer = transactionSplit[0];
+    const timestamp = transactionSplit[1].replace(".","-");
+    return `${payer}-${timestamp}`;
+}
+
+export { hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId };

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -23,7 +23,7 @@ import { MirrorNodeClientError } from './../errors/MirrorNodeClientError';
 import { Logger } from "pino";
 import constants from './../constants';
 import { Histogram, Registry } from 'prom-client';
-import { formatRequestIdMessage } from '../../formatters';
+import { formatRequestIdMessage, formatTransactionId } from '../../formatters';
 import axiosRetry from 'axios-retry';
 import { predefined } from "../errors/JsonRpcError";
 const LRU = require('lru-cache');
@@ -541,6 +541,20 @@ export class MirrorNodeClient {
 
     public async postContractCall(callData: string, requestId?: string) {
         return this.post(MirrorNodeClient.CONTRACT_CALL_ENDPOINT, callData, MirrorNodeClient.CONTRACT_CALL_ENDPOINT, [], requestId);
+    }
+
+    public async getTransactionById(transactionId: string, nonce: number | undefined, requestId?: string) {
+        const formattedId = formatTransactionId(transactionId);
+        if (formattedId == null) {
+            return formattedId;
+        }
+        const queryParamObject = {};
+        this.setQueryParam(queryParamObject, 'nonce', nonce);
+        const queryParams = this.getQueryParams(queryParamObject);
+        return this.get(`${MirrorNodeClient.GET_TRANSACTIONS_ENDPOINT}/${formattedId}${queryParams}`,
+        MirrorNodeClient.GET_STATE_ENDPOINT,
+        [400, 404],
+        requestId);
     }
 
     getQueryParams(params: object) {

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -22,8 +22,6 @@ enum CACHE_KEY {
     GAS_PRICE = 'gas_price',
     FEE_HISTORY = 'fee_history',
     GET_CONTRACT_RESULT = 'getContractResult'
-
-
 }
 
 enum CACHE_TTL {
@@ -67,5 +65,7 @@ export default {
     MAX_MIRROR_NODE_PAGINATION: 20,
     MIRROR_NODE_QUERY_LIMIT: 100,
     NEXT_LINK_PREFIX: '/api/v1/',
-    QUERY_COST_INCREMENTATION_STEP: 1.1
+    QUERY_COST_INCREMENTATION_STEP: 1.1,
+
+    TRANSACTION_ID_REGEX: /\d{1}\.\d{1}\.\d{1,10}\@\d{1,10}\.\d{1,9}/
 };

--- a/packages/relay/src/lib/errors/SDKClientError.ts
+++ b/packages/relay/src/lib/errors/SDKClientError.ts
@@ -56,6 +56,10 @@ export class SDKClientError extends Error {
     return this.statusCode === Status.InsufficientTxFee._code;
   }
 
+  public isContractRevertExecuted(): boolean {
+    return this.statusCode == Status.ContractRevertExecuted._code;
+  }
+
   public isGrpcTimeout(): boolean {
     // The SDK uses the same code for Grpc Timeout as INVALID_TRANSACTION_ID
     return this.statusCode === Status.InvalidTransactionId._code;

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { hexToASCII, decodeErrorMessage } from '../../src/formatters';
+import { hexToASCII, decodeErrorMessage, formatTransactionId } from '../../src/formatters';
 
 describe('Formatters', () => {
     describe('hexToASCII', () => {
@@ -43,4 +43,18 @@ describe('Formatters', () => {
             }
         });
     });
+
+    describe('formatTransactionId', () => {
+        const validInputTimestamp = '0.0.2@1234567890.123456789';
+        const validOutputTimestamp = '0.0.2-1234567890-123456789';
+        const invalidInputTimestamp = '0.0.2@12345678222.123456789';
+
+        it('should return correct formated transaction id', () => {
+            expect(formatTransactionId(validInputTimestamp)).to.eq(validOutputTimestamp);
+        });
+
+        it('should return null', () => {
+            expect(formatTransactionId(invalidInputTimestamp)).to.eq(null);
+        })
+    })
 });

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -698,6 +698,77 @@ describe('MirrorNodeClient', async function () {
     });
   });
 
+  describe('getTransactionById', async() => {
+    const defaultTransactionId = '0.0.2@1681130064.409933500';
+    const defaultTransactionIdFormatted = '0.0.2-1681130064-409933500';
+    const invalidTransactionId = '0.0.2@168113222220.409933500';
+    const defaultTransaction = {
+      transactions: [
+        {
+          bytes: null,
+          charged_tx_fee: 56800000,
+          consensus_timestamp: '1681130077.127938923',
+          entity_id: null,
+          max_fee: '1080000000',
+          memo_base64: '',
+          name: 'ETHEREUMTRANSACTION',
+          node: '0.0.3',
+          nonce: 0,
+          parent_consensus_timestamp: null,
+          result: 'CONTRACT_REVERT_EXECUTED',
+          scheduled: false,
+          staking_reward_transfers: [],
+          transaction_hash: 'uUHtwzFBlpHzp20OCJtjk4m6yFi93TZem7pKYrjgaF0v383um84g/Jo+uP2IrRd7',
+          transaction_id: '0.0.2-1681130064-409933500',
+          transfers: [],
+          valid_duration_seconds: '120',
+          valid_start_timestamp: '1681130064.409933500'
+        },
+        {
+          bytes: null,
+          charged_tx_fee: 0,
+          consensus_timestamp: '1681130077.127938924',
+          entity_id: null,
+          max_fee: '0',
+          memo_base64: '',
+          name: 'TOKENCREATION',
+          node: null,
+          nonce: 1,
+          parent_consensus_timestamp: '1681130077.127938923',
+          result: 'INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE',
+          scheduled: false,
+          staking_reward_transfers: [],
+          transaction_hash: 'EkQUvik9b4QUvymTNX90ybTz1SNobpQ5huQmMCKkP3fjOxirLT0nRel+w4bweXyX',
+          transaction_id: '0.0.2-1681130064-409933500',
+          transfers: [],
+          valid_duration_seconds: null,
+          valid_start_timestamp: '1681130064.409933500'
+        }
+      ]
+    };
+
+    it('should be able to fetch transaction by transaction id', async() => {
+      mock.onGet(`transactions/${defaultTransactionIdFormatted}`).reply(200, defaultTransaction);
+      const transaction = await mirrorNodeInstance.getTransactionById(defaultTransactionId);
+      expect(transaction).to.exist;
+      expect(transaction.transactions.length).to.equal(defaultTransaction.transactions.length);
+    });
+
+    it('should be able to fetch transaction by transaction id and nonce', async() => {
+      mock.onGet(`transactions/${defaultTransactionIdFormatted}?nonce=1`).reply(200, defaultTransaction.transactions[1]);
+      const transaction = await mirrorNodeInstance.getTransactionById(defaultTransactionId, 1);
+      expect(transaction).to.exist;
+      expect(transaction.transaction_id).to.equal(defaultTransaction.transactions[1].transaction_id);
+      expect(transaction.result).to.equal(defaultTransaction.transactions[1].result);
+    });
+
+    it('should fail to fetch transaction by wrong transaction id', async() => {
+      mock.onGet(`transactions/${invalidTransactionId}`).reply(404, mockData.notFound);
+      const transaction = await mirrorNodeInstance.getTransactionById(invalidTransactionId);
+      expect(transaction).to.be.null;
+    });
+  })
+
   describe('getPaginatedResults', async() => {
 
     const mockPages = (pages) => {


### PR DESCRIPTION
**Description**:
Cherry picks #1043 

This PR adds a new mirror node request method, to get transaction by transaction id. This way we can get the contract revert reason. Log this error in the relay log. This makes debugging easier as developers won't have to query manually the mirror-node for every failed test.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
