### PR TITLE
RPC API Batch 1 - Acceptance Test - Improvement (#1050)

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -281,7 +281,13 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 //for the purpose of the test, we are settings limit to 2, and fetching all.
                 //setting mirror node limit to 2 for this test only
                 process.env['MIRROR_NODE_LIMIT_PARAM'] = '2';
-                const blocksBehindLatest = Number(await relay.call('eth_blockNumber', [], requestId)) - 40;
+                // calculate blocks behind latest, so we can fetch logs from the past.
+                // if current block is less than 10, we will fetch logs from the beginning otherwise we will fetch logs from 10 blocks behind latest
+                const currentBlock = Number(await relay.call('eth_blockNumber', [], requestId));
+                let blocksBehindLatest = 0;
+                if(currentBlock > 10) {
+                    blocksBehindLatest = currentBlock - 10;
+                }
                 const logs = await relay.call('eth_getLogs', [{
                     'fromBlock': EthImpl.numberTo0x(blocksBehindLatest),
                     'toBlock': 'latest'


### PR DESCRIPTION




---------

**Description**:
Cherry pick #1050 
* changed the hardcoded value of "blocksBehindLatest" from 40 to 10, since is enough for the purpose of the test and gives higher chances that even if the tests and the hardware used to run the tests improves in the future, the test will continue to work.

* adding comments to change

* further improve test to fetch from beginning in case currentBlock is less than 10

* avoid double call of eth_blockNumber

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
