### PR TITLE
Optimize eth_getBalance queries

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -19,7 +19,6 @@
  */
 
 import { AccountId } from '@hashgraph/sdk';
-// import ContractId from "@hashgraph/sdk/lib/contract/ContractId";
 import constants from "./lib/constants";
 
 const hashNumber = (num) => {

--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -18,8 +18,8 @@
  *
  */
 
-import AccountId from "@hashgraph/sdk/lib/account/AccountId";
-import ContractId from "@hashgraph/sdk/lib/contract/ContractId";
+import { AccountId } from '@hashgraph/sdk';
+// import ContractId from "@hashgraph/sdk/lib/contract/ContractId";
 import constants from "./lib/constants";
 
 const hashNumber = (num) => {
@@ -75,4 +75,4 @@ const convertLongZeroAddressToHederaAccountId = (evmAddress: string): string | n
     return AccountId.fromSolidityAddress(evmAddress).toString();
 }
 
-export { hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId, convertLongZeroAddressToHederaAccountId };
+export { hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId, convertLongZeroAddressToHederaAccountId, AccountId };

--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -18,6 +18,8 @@
  *
  */
 
+import AccountId from "@hashgraph/sdk/lib/account/AccountId";
+import ContractId from "@hashgraph/sdk/lib/contract/ContractId";
 import constants from "./lib/constants";
 
 const hashNumber = (num) => {
@@ -65,4 +67,12 @@ const formatTransactionId = (transactionId: string): string | null => {
     return `${payer}-${timestamp}`;
 }
 
-export { hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId };
+const convertLongZeroAddressToHederaAccountId = (evmAddress: string): string | null => {
+    if (!evmAddress.startsWith("0x00000000000")) {
+        return null;
+    }
+
+    return AccountId.fromSolidityAddress(evmAddress).toString();
+}
+
+export { hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId, convertLongZeroAddressToHederaAccountId };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -565,11 +565,27 @@ export class EthImpl implements Eth {
    */
   async getBalance(account: string, blockNumberOrTag: string | null, requestId?: string) {
     const requestIdPrefix = formatRequestIdMessage(requestId);
-    // const latestBlockTolerance = 1;
+    const latestBlockTolerance = 1;
 
     if (this.logger.isLevelEnabled('trace')) {
       this.logger.trace(`${requestIdPrefix} getBalance(account=${account}, blockNumberOrTag=${blockNumberOrTag})`);
     }
+
+    // this check is required, because some tools like Metamask pass for parameter latest block, with a number (ex 0x30ea)
+    // tolerance is needed, because there is a small delay between requesting latest block from blockNumber and passing it here
+    if (!EthImpl.blockTagIsLatestOrPending(blockNumberOrTag)) {
+      const latestBlock = await this.blockNumber(requestId);
+      const blockDiff = Number(latestBlock) - Number(blockNumberOrTag);
+
+      if (blockDiff <= latestBlockTolerance) {
+        blockNumberOrTag = EthImpl.blockLatest;
+      }
+    }
+
+    let blockNumber = null;
+    let balanceFound = false;
+    let weibars: BigInt = BigInt(0);
+    const mirrorAccount = await this.mirrorNodeClient.getAccount(account, requestId);
 
     try {
       // check balance cache first for high load scenarios
@@ -580,40 +596,77 @@ export class EthImpl implements Eth {
         return cachedBalance;
       }
 
-      let hexWeibars;
-      if (blockNumberOrTag) {
-        // get block details to find timestamp range for account balance query
+      if (!EthImpl.blockTagIsLatestOrPending(blockNumberOrTag)) {
         const block = await this.getHistoricalBlockResponse(blockNumberOrTag, true, requestId);
+        if (block) {
+          blockNumber = block.number;
 
-        // get Hedera AccountId format until the mirror node balance API supports evm address
-        let accountId = await this.getAccountIdFromAddress(account, requestIdPrefix);
-        if (!accountId) {
-          this.logger.debug(`${requestIdPrefix} Unable to find account ${account} in block ${blockNumberOrTag}, returning 0x0 balance`);
-          return EthImpl.zeroHex;
+          // A blockNumberOrTag has been provided. If it is `latest` or `pending` retrieve the balance from /accounts/{account.id}
+          if (mirrorAccount) {
+            const latestBlock = await this.getHistoricalBlockResponse(EthImpl.blockLatest, true, requestId);
+
+            // If the parsed blockNumber is the same as the one from the latest block retrieve the balance from /accounts/{account.id}
+            if (latestBlock && block.number !== latestBlock.number) {
+              const latestTimestamp = Number(latestBlock.timestamp.from.split('.')[0]);
+              const blockTimestamp = Number(block.timestamp.from.split('.')[0]);
+              const timeDiff = latestTimestamp - blockTimestamp;
+              // The block is from the last 15 minutes, therefore the historical balance hasn't been imported in the Mirror Node yet
+              if (timeDiff < constants.BALANCES_UPDATE_INTERVAL) {
+                let currentBalance = 0;
+                let currentTimestamp;
+                let balanceFromTxs = 0;
+                if (mirrorAccount.balance) {
+                  currentBalance = mirrorAccount.balance.balance;
+                  currentTimestamp = mirrorAccount.balance.timestamp;
+                }
+
+                const transactionsInTimeWindow = await this.mirrorNodeClient.getTransactionsForAccount(
+                  mirrorAccount.account,
+                  block.timestamp.to,
+                  currentTimestamp,
+                  requestId
+                );
+
+                for(const tx of transactionsInTimeWindow) {
+                  for (const transfer of tx.transfers) {
+                    if (transfer.account === mirrorAccount.account && !transfer.is_approval) {
+                      balanceFromTxs += transfer.amount;
+                    }
+                  }
+                }
+
+                balanceFound = true;
+                weibars = BigInt(currentBalance - balanceFromTxs) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+              }
+
+              // The block is NOT from the last 15 minutes, use /balances rest API
+              else {
+                const balance = await this.mirrorNodeClient.getBalanceAtTimestamp(mirrorAccount.account, block.timestamp.from, requestId);
+                balanceFound = true;
+                if (balance.balances?.length) {
+                  weibars = BigInt(balance.balances[0].balance) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+                }
+              }
+            }
+          }
         }
+      }
 
-        const balance = await this.mirrorNodeClient.getBalanceAtTimestamp(accountId!, block.timestamp.from, requestId);
-        if (balance.balances?.length) {
-          hexWeibars = EthImpl.numberTo0x(BigInt(balance.balances[0].balance) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF));
-        } else {
-          // Mirror Node returns an empty array if there is no balance for the account at the given timestamp
-          hexWeibars = EthImpl.zeroHex;
-        }        
-      } else {
-        // if blockNumberOrTag is null, then get latest account balance from mirror node account endpoint
-        const mirrorAccount = await this.mirrorNodeClient.getAccount(account, requestId);
-        if (mirrorAccount?.balance) {
-          hexWeibars = EthImpl.numberTo0x(BigInt(mirrorAccount.balance.balance) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF));
-        } else {
-          hexWeibars = EthImpl.zeroHex;
-        } 
-      } 
+      if (!balanceFound && mirrorAccount?.balance) {
+        balanceFound = true;
+        weibars = BigInt(mirrorAccount.balance.balance) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+      }
+
+      if (!balanceFound) {
+        this.logger.debug(`${requestIdPrefix} Unable to find account ${account} in block ${JSON.stringify(blockNumber)}(${blockNumberOrTag}), returning 0x0 balance`);
+        return EthImpl.zeroHex;
+      }
 
       // save in cache the current balance for the account and blockNumberOrTag
-      this.cache.set(cacheKey, hexWeibars, {ttl: EthImpl.ethGetBalanceCacheTtlMs});
-      this.logger.trace(`${requestIdPrefix} caching ${cacheKey}:${hexWeibars} for ${EthImpl.ethGetBalanceCacheTtlMs} ms`);
+      this.cache.set(cacheKey, EthImpl.numberTo0x(weibars), {ttl: EthImpl.ethGetBalanceCacheTtlMs});
+      this.logger.trace(`${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(cachedBalance)} for ${EthImpl.ethGetBalanceCacheTtlMs} ms`);
 
-      return hexWeibars;
+      return EthImpl.numberTo0x(weibars);
     } catch (error: any) {
       throw this.genericErrorHandler(error, `${requestIdPrefix} Error raised during getBalance for account ${account}`);
     }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -582,70 +582,72 @@ export class EthImpl implements Eth {
       }
     }
 
+    // check balance cache first for high load scenarios
+    const cacheKey = `${constants.CACHE_KEY.ETH_GET_BALANCE}-${account}-${blockNumberOrTag}`;
+    const cachedBalance = this.cache.get(cacheKey);
+    if (cachedBalance) {
+      this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(cachedBalance)}`);
+      return cachedBalance;
+    }
+
     let blockNumber = null;
     let balanceFound = false;
     let weibars: BigInt = BigInt(0);
     const mirrorAccount = await this.mirrorNodeClient.getAccount(account, requestId);
 
     try {
-      // check balance cache first for high load scenarios
-      const cacheKey = `${constants.CACHE_KEY.ETH_GET_BALANCE}-${account}-${blockNumberOrTag}`;
-      const cachedBalance = this.cache.get(cacheKey);
-      if (cachedBalance) {
-        this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(cachedBalance)}`);
-        return cachedBalance;
-      }
+      const block = await this.getHistoricalBlockResponse(blockNumberOrTag, true, requestId);
+      if (block) {
+        blockNumber = block.number;
 
-      if (!EthImpl.blockTagIsLatestOrPending(blockNumberOrTag)) {
-        const block = await this.getHistoricalBlockResponse(blockNumberOrTag, true, requestId);
-        if (block) {
-          blockNumber = block.number;
+        // A blockNumberOrTag has been provided. If it is `latest` or `pending` retrieve the balance from /accounts/{account.id}
+        if (mirrorAccount) {
+          const latestBlock = await this.getHistoricalBlockResponse(EthImpl.blockLatest, true, requestId);
 
-          // A blockNumberOrTag has been provided. If it is `latest` or `pending` retrieve the balance from /accounts/{account.id}
-          if (mirrorAccount) {
-            const latestBlock = await this.getHistoricalBlockResponse(EthImpl.blockLatest, true, requestId);
-
-            // If the parsed blockNumber is the same as the one from the latest block retrieve the balance from /accounts/{account.id}
-            if (latestBlock && block.number !== latestBlock.number) {
-              const latestTimestamp = Number(latestBlock.timestamp.from.split('.')[0]);
-              const blockTimestamp = Number(block.timestamp.from.split('.')[0]);
-              const timeDiff = latestTimestamp - blockTimestamp;
-              // The block is from the last 15 minutes, therefore the historical balance hasn't been imported in the Mirror Node yet
-              if (timeDiff < constants.BALANCES_UPDATE_INTERVAL) {
-                let currentBalance = 0;
-                let currentTimestamp;
-                let balanceFromTxs = 0;
-                if (mirrorAccount.balance) {
-                  currentBalance = mirrorAccount.balance.balance;
-                  currentTimestamp = mirrorAccount.balance.timestamp;
-                }
-
-                const transactionsInTimeWindow = await this.mirrorNodeClient.getTransactionsForAccount(
-                  mirrorAccount.account,
-                  block.timestamp.to,
-                  currentTimestamp,
-                  requestId
-                );
-
-                for(const tx of transactionsInTimeWindow) {
-                  for (const transfer of tx.transfers) {
-                    if (transfer.account === mirrorAccount.account && !transfer.is_approval) {
-                      balanceFromTxs += transfer.amount;
-                    }
-                  }
-                }
-
-                balanceFound = true;
-                weibars = BigInt(currentBalance - balanceFromTxs) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+          // If the parsed blockNumber is the same as the one from the latest block retrieve the balance from /accounts/{account.id}
+          if (latestBlock && block.number !== latestBlock.number) {
+            const latestTimestamp = Number(latestBlock.timestamp.from.split('.')[0]);
+            const blockTimestamp = Number(block.timestamp.from.split('.')[0]);
+            const timeDiff = latestTimestamp - blockTimestamp;
+            // The block is from the last 15 minutes, therefore the historical balance hasn't been imported in the Mirror Node yet
+            if (timeDiff < constants.BALANCES_UPDATE_INTERVAL) {
+              let currentBalance = 0;
+              let currentTimestamp;
+              let balanceFromTxs = 0;
+              if (mirrorAccount.balance) {
+                currentBalance = mirrorAccount.balance.balance;
+                currentTimestamp = mirrorAccount.balance.timestamp;
               }
 
-              // The block is NOT from the last 15 minutes, use /balances rest API
-              else {
-                const balance = await this.mirrorNodeClient.getBalanceAtTimestamp(mirrorAccount.account, block.timestamp.from, requestId);
-                balanceFound = true;
-                if (balance.balances?.length) {
-                  weibars = BigInt(balance.balances[0].balance) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+              const transactionsInTimeWindow = await this.mirrorNodeClient.getTransactionsForAccount(
+                mirrorAccount.account,
+                block.timestamp.to,
+                currentTimestamp,
+                requestId
+              );
+
+              for (const tx of transactionsInTimeWindow) {
+                for (const transfer of tx.transfers) {
+                  if (transfer.account === mirrorAccount.account && !transfer.is_approval) {
+                    balanceFromTxs += transfer.amount;
+                  }
                 }
+              }
+
+              balanceFound = true;
+              weibars = BigInt(currentBalance - balanceFromTxs) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+            }
+
+            // The block is NOT from the last 15 minutes, use /balances rest API
+            else {
+              const balance = await this.mirrorNodeClient.getBalanceAtTimestamp(
+                mirrorAccount.account,
+                block.timestamp.from,
+                requestId
+              );
+              balanceFound = true;
+              if (balance.balances?.length) {
+                weibars = BigInt(balance.balances[0].balance) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
               }
             }
           }
@@ -658,13 +660,21 @@ export class EthImpl implements Eth {
       }
 
       if (!balanceFound) {
-        this.logger.debug(`${requestIdPrefix} Unable to find account ${account} in block ${JSON.stringify(blockNumber)}(${blockNumberOrTag}), returning 0x0 balance`);
+        this.logger.debug(
+          `${requestIdPrefix} Unable to find account ${account} in block ${JSON.stringify(
+            blockNumber
+          )}(${blockNumberOrTag}), returning 0x0 balance`
+        );
         return EthImpl.zeroHex;
       }
 
       // save in cache the current balance for the account and blockNumberOrTag
-      this.cache.set(cacheKey, EthImpl.numberTo0x(weibars), {ttl: EthImpl.ethGetBalanceCacheTtlMs});
-      this.logger.trace(`${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(cachedBalance)} for ${EthImpl.ethGetBalanceCacheTtlMs} ms`);
+      this.cache.set(cacheKey, EthImpl.numberTo0x(weibars), { ttl: EthImpl.ethGetBalanceCacheTtlMs });
+      this.logger.trace(
+        `${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(cachedBalance)} for ${
+          EthImpl.ethGetBalanceCacheTtlMs
+        } ms`
+      );
 
       return EthImpl.numberTo0x(weibars);
     } catch (error: any) {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1338,6 +1338,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet(`accounts/${contractAddress1}`).reply(404, {});
 
       const resBalanceCached = await ethImpl.getBalance(contractAddress1, null);
+      // await new Promise(resolve => setTimeout(resolve, 10000));
       expect(resBalanceCached).to.equal(resBalance);
 
       // Third call should return new number using mirror node
@@ -1381,6 +1382,24 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('should return balance from mirror node with block number passed as param, one behind latest', async () => {
       const blockNumber = "0x270F";
+
+      restMock.onGet(`blocks?limit=1&order=desc`).reply(200, {
+        blocks: [{
+          number: 10000,
+          'timestamp': {
+            'from': `1651560383.060890949`,
+            'to': '1651560385.060890949'
+          }
+        }]
+      });
+
+      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+        account: contractAddress1,
+        balance: {
+          balance: defBalance
+        }
+      });
+
       restMock.onGet(`blocks/9999`).reply(200, {
           number: 9999,
           'timestamp': {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1359,25 +1359,19 @@ describe('Eth calls using MirrorNode', async function () {
     it('should return balance from mirror node with block number passed as param the same as latest', async () => {
       const blockNumber = "0x2710";
      
-      restMock.onGet(`blocks/10000`).reply(200, {
+      restMock.onGet(`blocks?limit=1&order=desc`).reply(200, {
+        blocks: [{
           number: 10000,
           'timestamp': {
             'from': `1651560393.060890949`,
             'to': '1651560395.060890949'
           }
-      });     
-      
-      restMock.onGet('balances?account.id=0.0.1375&timestamp=1651560393.060890949').reply(200, {
-        "timestamp": `1651560400.060890949`,
-        "balances": [
-          {
-            "account": contractAddress1,
-            "balance": defBalance,
-            "tokens": []
-          }
-        ],
-        "links": {
-          "next": null
+        }]
+      });
+      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+        account: contractAddress1,
+        balance: {
+          balance: defBalance
         }
       });
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1358,15 +1358,26 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('should return balance from mirror node with block number passed as param the same as latest', async () => {
       const blockNumber = "0x2710";
-      restMock.onGet(`blocks?limit=1&order=desc`).reply(200, {
-        blocks: [{
-          number: 10000
-        }]
-      });
-      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
-        account: contractAddress1,
-        balance: {
-          balance: defBalance
+     
+      restMock.onGet(`blocks/10000`).reply(200, {
+          number: 10000,
+          'timestamp': {
+            'from': `1651560393.060890949`,
+            'to': '1651560395.060890949'
+          }
+      });     
+      
+      restMock.onGet('balances?account.id=0.0.1375&timestamp=1651560393.060890949').reply(200, {
+        "timestamp": `1651560400.060890949`,
+        "balances": [
+          {
+            "account": contractAddress1,
+            "balance": defBalance,
+            "tokens": []
+          }
+        ],
+        "links": {
+          "next": null
         }
       });
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1387,15 +1387,25 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('should return balance from mirror node with block number passed as param, one behind latest', async () => {
       const blockNumber = "0x270F";
-      restMock.onGet(`blocks?limit=1&order=desc`).reply(200, {
-        blocks: [{
-          number: 10000
-        }]
+      restMock.onGet(`blocks/9999`).reply(200, {
+          number: 9999,
+          'timestamp': {
+            'from': `1651560393.060890949`,
+            'to': '1651560395.060890949'
+          }          
       });
-      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
-        account: contractAddress1,
-        balance: {
-          balance: defBalance
+ 
+      restMock.onGet('balances?account.id=0.0.1375&timestamp=1651560393.060890949').reply(200, {
+        "timestamp": `1651560400.060890949`,
+        "balances": [
+          {
+            "account": contractAddress1,
+            "balance": defBalance,
+            "tokens": []
+          }
+        ],
+        "links": {
+          "next": null
         }
       });
 


### PR DESCRIPTION
**Description**:
`eth_getBalance` logic around queries is outdated and in some cases we're making calls that don't need to be called

New logic should be
- check for a cache balance entry. Return if exists but do not cache as this is for high load
- consider blockNumberOrTag
  - if valid blockNumberOrTag get the account balance from `api/v1/balances` which is now real time. Note, this endpoint only takes a Hedera AccountId so a conversion from address is needed. For long zero we can convert, for evmAddress we must consult Mirror Node for mapping
  - if no blockNumberOrTag call the `api/v1/accounts` endpoint for most recent balance. Not 404 may occur for recent creations so retry should be covered in client
- cache balance and return

To achieve the above
- Add a `getAccountIdFromAddress()` to the eth.ts to isolate address to HederaAccountId logic.
- Update `getBalance()` to utilize above flow and method
- Add a `convertLongZeroAddressToHederaAccountId()` to the formatter.ts

**Related issue(s)**:

Fixes #1085

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
