### PR TITLE
Optimize eth_feeHistory API calls

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -83,7 +83,7 @@ export class MirrorNodeClient {
 
 
 
-    private static ORDER = {
+    public static ORDER = {
         ASC: 'asc',
         DESC: 'desc'
     };
@@ -361,6 +361,18 @@ export class MirrorNodeClient {
         this.setQueryParam(queryParamObject, 'block.number', blockNumber);
         this.setQueryParam(queryParamObject, 'timestamp', timestamp);
         this.setLimitOrderParams(queryParamObject, limitOrderParams);
+        const queryParams = this.getQueryParams(queryParamObject);
+        return this.get(`${MirrorNodeClient.GET_BLOCKS_ENDPOINT}${queryParams}`,
+            MirrorNodeClient.GET_BLOCKS_ENDPOINT,
+            [400, 404],
+            requestId);
+    }
+
+    public async getBlocksInTimestampRange(startTimestamp: string, endTimestamp: string, limit: number, requestId?: string) {
+        const queryParamObject = {};
+        this.setQueryParam(queryParamObject, 'timestamp', startTimestamp);
+        this.setQueryParam(queryParamObject, 'timestamp', endTimestamp);
+        this.setLimitOrderParams(queryParamObject, this.getLimitOrderQueryParam(limit, MirrorNodeClient.ORDER.ASC));
         const queryParams = this.getQueryParams(queryParamObject);
         return this.get(`${MirrorNodeClient.GET_BLOCKS_ENDPOINT}${queryParams}`,
             MirrorNodeClient.GET_BLOCKS_ENDPOINT,

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -24,10 +24,12 @@ enum CACHE_KEY {
     GET_CONTRACT_RESULT = 'getContractResult',
     ETH_BLOCK_NUMBER = 'eth_block_number',
     ETH_GET_BALANCE = 'eth_get_balance',
+    NETWORK_FEE_WEI_BARS = 'network_fee_wei_bars',
 }
 
 enum CACHE_TTL {
-    ONE_HOUR = 3_600_000
+    ONE_HOUR = 3_600_000,
+    ONE_DAY = 86_400_000,
 }
 
 enum ORDER {


### PR DESCRIPTION
**Description**:
Optimize eth_feeHistory API calls

Restructure logic to pull out perf savings where network fees and blocks are in the optimal range

- Add `getBlocksInTimestampRange()` to mirrorNodeClient to allow getting a list of blocks instead of calling multiple times
- Add `CACHE_TTL.ONE_DAY` for use with network fees
- Add `getAndCacheLatestNetworkFeeChangeBlock()` to `eth.ts` to allow for networkFee and block retrieval on first call
- Add `getFeeByTimestamp()` to allow for fee retrieval without having to call for block again
- Add `getRepeatedFeeHistory()` to create a feeHistory object that is full of repeated cached values

**Related issue(s)**:

Fixes #1087 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
