### PR TITLE
 Add default seconds to liveness and readiness probes

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -41,14 +41,8 @@ spec:
         ports:
           - containerPort: {{ .Values.ports.containerPort }}
             name: {{ .Values.ports.name  }}
-        livenessProbe:
-          httpGet:
-            path: /health/liveness
-            port: jsonrpcrelay
-        readinessProbe:
-          httpGet:
-            path: /health/readiness
-            port: jsonrpcrelay
+        livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
+        readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
         resources:
           {{- toYaml .Values.resources | indent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -137,3 +137,20 @@ test:
   enabled: false
   schedule: '@daily'
   baseUrl: "http://127.0.0.1:7546"
+
+livenessProbe:
+  httpGet:
+    path: /health/liveness
+    port: jsonrpcrelay
+  initialDelaySeconds: 50
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  httpGet:
+    path: /health/readiness
+    port: jsonrpcrelay
+  initialDelaySeconds: 40
+  timeoutSeconds: 5
+  failureThreshold: 5

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -139,18 +139,18 @@ test:
   baseUrl: "http://127.0.0.1:7546"
 
 livenessProbe:
+  failureThreshold: 5
   httpGet:
     path: /health/liveness
     port: jsonrpcrelay
-  initialDelaySeconds: 50
+  initialDelaySeconds: 20
   periodSeconds: 10
   timeoutSeconds: 5
-  failureThreshold: 5
 
 readinessProbe:
+  failureThreshold: 5
   httpGet:
     path: /health/readiness
     port: jsonrpcrelay
-  initialDelaySeconds: 40
+  initialDelaySeconds: 20
   timeoutSeconds: 5
-  failureThreshold: 5


### PR DESCRIPTION
**Description**:
 Currently liveness and readiness probes where missing default seconds

To the liveness and readiness probes
- Add initialDelaySeconds
- Add periodSeconds
- Add timeoutSeconds
- Add failureThreshold

**Related issue(s)**:

Fixes #1092 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
