### PR TITLE
docs: changed HEDERA_NETWORK values to lowercase + sample for testnet

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,23 +83,40 @@ Unless you need to set a non-default value, it is recommended to only populate o
 | `WS_CONNECTION_LIMIT_PER_IP`    | "10"     | Maximum amount of connections from a single IP address                                  |
 | `WS_MULTIPLE_ADDRESSES_ENABLED` | "false"  | If enabled eth_subscribe will allow subscription to multiple contract address.          |
 
-## Sample for connecting to Hedera Testnet
+## Sample for connecting to Hedera Environments
+
+Hedera Mainnet
+
+```.env
+HEDERA_NETWORK=mainnet
+OPERATOR_ID_MAIN=<...redacted...>
+OPERATOR_KEY_MAIN=<...redacted...>
+CHAIN_ID=0x127
+MIRROR_NODE_URL=https://mainnet-public.mirrornode.hedera.com/
+```
+
+Hedera Testnet
 
 ```.env
 HEDERA_NETWORK=testnet
 OPERATOR_ID_MAIN=<...redacted...>
 OPERATOR_KEY_MAIN=<...redacted...>
-OPERATOR_ID_ETH_SENDRAWTRANSACTION=
-OPERATOR_KEY_ETH_SENDRAWTRANSACTION=
 CHAIN_ID=0x128
 MIRROR_NODE_URL=https://testnet.mirrornode.hedera.com/
-E2E_RELAY_HOST=https://testnet.hashio.io/api
-LOCAL_NODE=false
 ```
 
-- **_NOTE:_** Replace the operator ID and keys that have been redacted with your own.
-- **_NOTE 2:_** `E2E_RELAY_HOST` and `LOCAL_NODE` are optional.
-- **_NOTE 3:_** Default values for all other keys are sufficient, no need to set them.
+Hedera Previewnet
+
+```.env
+HEDERA_NETWORK=previewnet
+OPERATOR_ID_MAIN=<...redacted...>
+OPERATOR_KEY_MAIN=<...redacted...>
+CHAIN_ID=0x129
+MIRROR_NODE_URL=https://previewnet.mirrornode.hedera.com/
+```
+
+- **_NOTE:_** Replace the redacted operator ID and keys with your own.
+- **_NOTE 2:_** Default values for all other keys are sufficient, no need to set them.
 
 ## Testing
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@ Unless you need to set a non-default value, it is recommended to only populate o
 | `CHAIN_ID`                 | ""             | The network chain id. Local and previewnet envs should use `0x12a` (298). Previewnet, Testnet and Mainnet should use `0x129` (297), `0x128` (296) and `0x127` (295) respectively.                                   |
 | `HBAR_RATE_LIMIT_DURATION` | "60000"        | hbar budget limit duration. This creates a timestamp, which resets all limits, when it's reached. Default is to 60000 (1 minute).                                                                                   |
 | `HBAR_RATE_LIMIT_TINYBAR`  | "5000_000_000" | total hbar budget in tinybars.                                                                                                                                                                                      |
-| `HEDERA_NETWORK`           | ""             | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `MAINNET`, `PREVIEWNET`, `TESTNET` or a map of network IPs -> node accountIds e.g. `{"127.0.0.1:50211":"0.0.3"}` |
+| `HEDERA_NETWORK`           | ""             | Which network to connect to. Automatically populates the main node & mirror node endpoints. Can be `previewnet`, `testnet`, `mainnet` or a map of network IPs -> node accountIds e.g. `{"127.0.0.1:50211":"0.0.3"}` |
 | `INPUT_SIZE_LIMIT`         | "1mb"          | The [koa-jsonrpc](https://github.com/Bitclimb/koa-jsonrpc) maximum size allowed for requests                                                                                                                        |
 | `OPERATOR_ID_MAIN`         | ""             | Operator account ID used to pay for transactions.                                                                                                                                                                   |
 | `OPERATOR_KEY_MAIN`        | ""             | Operator private key used to sign transactions in hex encoded DER format.                                                                                                                                           |
@@ -82,6 +82,24 @@ Unless you need to set a non-default value, it is recommended to only populate o
 | `WS_SUBSCRIPTION_LIMIT`         | "10"     | Maximum amount of subscriptions per single connection                                   |
 | `WS_CONNECTION_LIMIT_PER_IP`    | "10"     | Maximum amount of connections from a single IP address                                  |
 | `WS_MULTIPLE_ADDRESSES_ENABLED` | "false"  | If enabled eth_subscribe will allow subscription to multiple contract address.          |
+
+## Sample for connecting to Hedera Testnet
+
+```.env
+HEDERA_NETWORK=testnet
+OPERATOR_ID_MAIN=<...redacted...>
+OPERATOR_KEY_MAIN=<...redacted...>
+OPERATOR_ID_ETH_SENDRAWTRANSACTION=
+OPERATOR_KEY_ETH_SENDRAWTRANSACTION=
+CHAIN_ID=0x128
+MIRROR_NODE_URL=https://testnet.mirrornode.hedera.com/
+E2E_RELAY_HOST=https://testnet.hashio.io/api
+LOCAL_NODE=false
+```
+
+- **_NOTE:_** Replace the operator ID and keys that have been redacted with your own.
+- **_NOTE 2:_** `E2E_RELAY_HOST` and `LOCAL_NODE` are optional.
+- **_NOTE 3:_** Default values for all other keys are sufficient, no need to set them.
 
 ## Testing
 

--- a/docs/examples/.env.mainnet.sample
+++ b/docs/examples/.env.mainnet.sample
@@ -1,0 +1,5 @@
+HEDERA_NETWORK=mainnet
+OPERATOR_ID_MAIN=<...redacted...>
+OPERATOR_KEY_MAIN=<...redacted...>
+CHAIN_ID=0x127
+MIRROR_NODE_URL=https://mainnet-public.mirrornode.hedera.com/

--- a/docs/examples/.env.previewnet.sample
+++ b/docs/examples/.env.previewnet.sample
@@ -1,0 +1,5 @@
+HEDERA_NETWORK=previewnet
+OPERATOR_ID_MAIN=<...redacted...>
+OPERATOR_KEY_MAIN=<...redacted...>
+CHAIN_ID=0x129
+MIRROR_NODE_URL=https://previewnet.mirrornode.hedera.com/

--- a/docs/examples/.env.testnet.sample
+++ b/docs/examples/.env.testnet.sample
@@ -1,0 +1,5 @@
+HEDERA_NETWORK=testnet
+OPERATOR_ID_MAIN=<...redacted...>
+OPERATOR_KEY_MAIN=<...redacted...>
+CHAIN_ID=0x128
+MIRROR_NODE_URL=https://testnet.mirrornode.hedera.com/

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -48,7 +48,7 @@ export class RelayImpl implements Relay {
     dotenv.config({ path: findConfig('.env') || '' });
     logger.info('Configurations successfully loaded');
 
-    const hederaNetwork: string = process.env.HEDERA_NETWORK || '{}';
+    const hederaNetwork: string = (process.env.HEDERA_NETWORK || '{}').toLowerCase();
 
     const configuredChainId =
       process.env.CHAIN_ID || RelayImpl.chainIds[hederaNetwork] || '298';
@@ -102,7 +102,7 @@ export class RelayImpl implements Relay {
 
   initClient(logger: Logger, hederaNetwork: string, type: string | null = null): Client {
     let client: Client;
-    if (hederaNetwork.toLowerCase() in RelayImpl.chainIds) {
+    if (hederaNetwork in RelayImpl.chainIds) {
       client = Client.forName(hederaNetwork);
     } else {
       client = Client.forNetwork(JSON.parse(hederaNetwork));


### PR DESCRIPTION
**Description**:

This PR modifies `docs/configuration.md` in order to support devs who would like to configure the RPC relay server for testnet
* Use lowercase values for `HEDERA_NETWORK` config property (uppercase results in [this error](https://stackoverflow.com/q/76069712/194982)
* Added a sample complete `.env` file required to connect to Hedera Testnet

**Related issue(s)**:

* N/A

**Notes for reviewer**:

* [internal discussion](https://swirldslabs.slack.com/archives/C0361991PGD/p1682042148026939)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
  - tested manually
