### PR TITLE
Removed the unnecessary call to the mirrornode for the account transa…

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -80,8 +80,6 @@ export class MirrorNodeClient {
 
     private static CONTRACT_RESULT_LOGS_PROPERTY = 'logs';
     private static CONTRACT_STATE_PROPERTY = 'state';
-    private static PAGE_LIMIT = 100;
-
 
 
     private static ORDER = {
@@ -324,7 +322,7 @@ export class MirrorNodeClient {
     }
 
     public async getAccountPageLimit(idOrAliasOrEvmAddress: string, requestId?: string) {
-        return this.get(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}?limit=${MirrorNodeClient.PAGE_LIMIT}`,
+        return this.get(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}?limit=${constants.MIRROR_NODE_QUERY_LIMIT}`,
             MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
             [400, 404],
             requestId);

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -80,6 +80,7 @@ export class MirrorNodeClient {
 
     private static CONTRACT_RESULT_LOGS_PROPERTY = 'logs';
     private static CONTRACT_STATE_PROPERTY = 'state';
+    private static PAGE_LIMIT = 100;
 
 
 
@@ -317,6 +318,13 @@ export class MirrorNodeClient {
 
     public async getAccount(idOrAliasOrEvmAddress: string, requestId?: string) {
         return this.get(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}`,
+            MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
+            [400, 404],
+            requestId);
+    }
+
+    public async getAccountPageLimit(idOrAliasOrEvmAddress: string, requestId?: string) {
+        return this.get(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}?limit=${MirrorNodeClient.PAGE_LIMIT}`,
             MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
             [400, 404],
             requestId);

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -669,12 +669,9 @@ export class EthImpl implements Eth {
                   currentTimestamp = mirrorAccount.balance.timestamp;
                 }
 
-                let transactionsInTimeWindow = await this.mirrorNodeClient.getTransactionsForAccount(
-                  mirrorAccount.account,
-                  block.timestamp.to,
-                  currentTimestamp,
-                  requestId
-                );
+                const transactionsInTimeWindow: any = mirrorAccount.transactions.filter((tx: any) => {
+                  return tx.consensus_timestamp >= block.timestamp.to && tx.consensus_timestamp <= currentTimestamp;
+                });
 
                 for(const tx of transactionsInTimeWindow) {
                   for (const transfer of tx.transfers) {
@@ -1584,7 +1581,7 @@ export class EthImpl implements Eth {
     const logs = logResults.flatMap(logResult => logResult ? logResult : [] );
     logs.sort((a: any, b: any) => {
       return a.timestamp >= b.timestamp ? 1 : -1;
-    })
+    });
 
     return logs;
   }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1698,7 +1698,7 @@ describe('Eth calls using MirrorNode', async function () {
             buildCryptoTransferTransaction("0.0.98", contractId1, 50, {"timestamp":`${timestamp4}.060890954`}),
           ],
           links: {
-            next: `transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${timestamp4}.060890940&page=2`
+            next: `/api/v1/accounts/${contractId1}?limit=100&timestamp=lt:${timestamp4}.060890940&page=2`
           }
         });        
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1315,7 +1315,7 @@ describe('Eth calls using MirrorNode', async function () {
           number: 10000
         }]
       });
-      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {
           balance: defBalance
@@ -1332,7 +1332,7 @@ describe('Eth calls using MirrorNode', async function () {
           number: 10000
         }]
       });
-      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {
           balance: defBalance
@@ -1343,7 +1343,7 @@ describe('Eth calls using MirrorNode', async function () {
       expect(resBalance).to.equal(defHexBalance);
 
       // next call should use cache
-      restMock.onGet(`accounts/${contractAddress1}`).reply(404, {});
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(404, {});
 
       const resBalanceCached = await ethImpl.getBalance(contractAddress1, null);
       expect(resBalanceCached).to.equal(resBalance);
@@ -1351,7 +1351,7 @@ describe('Eth calls using MirrorNode', async function () {
       // Third call should return new number using mirror node
       const newBalance = 55555;
       const newBalanceHex = EthImpl.numberTo0x(BigInt(newBalance) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
-      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {
           balance: newBalance
@@ -1371,7 +1371,7 @@ describe('Eth calls using MirrorNode', async function () {
           number: 10000
         }]
       });
-      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {
           balance: defBalance
@@ -1389,7 +1389,7 @@ describe('Eth calls using MirrorNode', async function () {
           number: 10000
         }]
       });
-      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {
           balance: defBalance
@@ -1407,7 +1407,7 @@ describe('Eth calls using MirrorNode', async function () {
         }]
       });
       restMock.onGet(`contracts/${contractAddress1}`).reply(200, null);
-      restMock.onGet(`accounts/${contractAddress1}`).reply(404, {
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(404, {
         _status: {
           messages: [{ message: 'Not found' }]
         }
@@ -1423,7 +1423,7 @@ describe('Eth calls using MirrorNode', async function () {
           number: 10000
         }]
       });
-      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {
           balance: defBalance
@@ -1432,7 +1432,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const resNoCache = await ethImpl.getBalance(contractAddress1, null);
 
-      restMock.onGet(`accounts/${contractAddress1}`).reply(404, {
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(404, {
         _status: {
           messages: [{ message: 'Not found' }]
         }
@@ -1485,12 +1485,13 @@ describe('Eth calls using MirrorNode', async function () {
         restMock.onGet(`blocks/2`).reply(200, recentBlock);
         restMock.onGet(`blocks/1`).reply(200, earlierBlock);
 
-        restMock.onGet(`accounts/${contractId1}`).reply(200, {
+        restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
           account: contractId1,
           balance: {
             balance: balance3,
             timestamp: `${timestamp4}.060890949`
-          }
+          },
+          transactions: []
         });
 
         restMock.onGet(`balances?account.id=${contractId1}&timestamp=${earlierBlock.timestamp.from}`).reply(200, {
@@ -1560,27 +1561,63 @@ describe('Eth calls using MirrorNode', async function () {
       });
 
       it('blockNumber is in the latest 15 minutes', async () => {
-        restMock.onGet(`transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${latestBlock.timestamp.to}`).reply(200, {
-          transactions: []
+        restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
+          account: contractId1,
+          balance: {
+            balance: balance3,
+            timestamp: `${blockTimestamp}.060890960`
+          },
+          transactions: [
+            buildCryptoTransferTransaction("0.0.98", contractId1, 100, {"timestamp":`${blockTimestamp}.060890941`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 50, {"timestamp":`${blockTimestamp}.060890940`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 25, {"timestamp":`${blockTimestamp}.060890939`}),
+          ],
+          links: {
+            next: null
+          }          
         });
-
         const resBalance = await ethImpl.getBalance(contractId1, '2');
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3) * TINYBAR_TO_WEIBAR_COEF_BIGINT)
+        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);
       });
 
       it('blockNumber is not in the latest 15 minutes', async () => {
+        restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
+          account: contractId1,
+          balance: {
+            balance: balance3,
+            timestamp: `${timestamp4}.060890949`
+          },
+          transactions: []
+        });
+
         const resBalance = await ethImpl.getBalance(contractId1, '1');
         expect(resBalance).to.equal(hexBalance1);
       });
 
       it('blockNumber is in the latest 15 minutes and there have been several debit transactions', async () => {
-        restMock.onGet(`transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${latestBlock.timestamp.to}`).reply(200, {
+        const recentBlockWithinLastfifteen = Object.assign({}, defaultBlock, {
+          number: 2,
+          'timestamp': {
+            'from': `${blockTimestamp}.060890921`,
+            'to': `${blockTimestamp}.060890941`
+          },
+        });
+        restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);
+        restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
+          account: contractId1,
+          balance: {
+            balance: balance3,
+            timestamp: `${blockTimestamp}.060890960`
+          },
           transactions: [
-            buildCryptoTransferTransaction("0.0.98", contractId1, 100),
-            buildCryptoTransferTransaction("0.0.98", contractId1, 50),
-            buildCryptoTransferTransaction("0.0.98", contractId1, 25),
-          ]
+            buildCryptoTransferTransaction("0.0.98", contractId1, 100, {"timestamp":`${blockTimestamp}.060890954`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 50, {"timestamp":`${blockTimestamp}.060890953`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 25, {"timestamp":`${blockTimestamp}.060890952`}),
+          ],
+          links: {
+            next: null
+          }         
         });
 
         const resBalance = await ethImpl.getBalance(contractId1, '2');
@@ -1589,27 +1626,59 @@ describe('Eth calls using MirrorNode', async function () {
       });
 
       it('blockNumber is in the latest 15 minutes and there have been several credit transactions', async () => {
-        restMock.onGet(`transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${latestBlock.timestamp.to}`).reply(200, {
-          transactions: [
-            buildCryptoTransferTransaction(contractId1, "0.0.98", 100),
-            buildCryptoTransferTransaction(contractId1, "0.0.98", 50),
-            buildCryptoTransferTransaction(contractId1, "0.0.98", 25),
-          ]
+        const recentBlockWithinLastfifteen = Object.assign({}, defaultBlock, {
+          number: 2,
+          'timestamp': {
+            'from': `${blockTimestamp}.060890921`,
+            'to': `${blockTimestamp}.060890941`
+          },
         });
-
+        restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);
+        restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
+          account: contractId1,
+          balance: {
+            balance: balance3,
+            timestamp: `${timestamp4}.060890960`
+          },
+          transactions: [
+            buildCryptoTransferTransaction(contractId1, "0.0.98", 100, {"timestamp":`${timestamp4}.060890954`}),
+            buildCryptoTransferTransaction(contractId1, "0.0.98", 50, {"timestamp":`${timestamp4}.060890953`}),
+            buildCryptoTransferTransaction(contractId1, "0.0.98", 25, {"timestamp":`${timestamp4}.060890952`}),
+          ],
+          links: {
+            next: null
+          }            
+        });
+ 
         const resBalance = await ethImpl.getBalance(contractId1, '2');
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 + 175) * TINYBAR_TO_WEIBAR_COEF_BIGINT)
+        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 + 175) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);
       });
 
       it('blockNumber is in the latest 15 minutes and there have been mixed credit and debit transactions', async () => {
-        restMock.onGet(`transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${latestBlock.timestamp.to}`).reply(200, {
+        const recentBlockWithinLastfifteen = Object.assign({}, defaultBlock, {
+          number: 2,
+          'timestamp': {
+            'from': `${blockTimestamp}.060890921`,
+            'to': `${blockTimestamp}.060890941`
+          },
+        });
+        restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);        
+        restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
+          account: contractId1,
+          balance: {
+            balance: balance3,
+            timestamp: `${timestamp4}.060890960`
+          },
           transactions: [
-            buildCryptoTransferTransaction(contractId1, "0.0.98", 100),
-            buildCryptoTransferTransaction("0.0.98", contractId1, 50),
-            buildCryptoTransferTransaction(contractId1, "0.0.98", 25),
-            buildCryptoTransferTransaction("0.0.98", contractId1, 10),
-          ]
+            buildCryptoTransferTransaction(contractId1, "0.0.98", 100, {"timestamp":`${timestamp4}.060890954`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 50, {"timestamp":`${timestamp4}.060890953`}),
+            buildCryptoTransferTransaction(contractId1, "0.0.98", 25, {"timestamp":`${timestamp4}.060890952`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 10, {"timestamp":`${timestamp4}.060890951`}),
+          ],
+          links: {
+            next: null
+          }              
         });
 
         const resBalance = await ethImpl.getBalance(contractId1, '2');
@@ -1618,20 +1687,35 @@ describe('Eth calls using MirrorNode', async function () {
       });
 
       it('blockNumber is in the latest 15 minutes and there have been mixed credit and debit transactions and transactions are paginated', async () => {
-        restMock.onGet(`transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${latestBlock.timestamp.to}`).reply(200, {
+        restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
+          account: contractId1,
+          balance: {
+            balance: balance3,
+            timestamp: `${timestamp4}.060890960`
+          },
           transactions: [
-            buildCryptoTransferTransaction(contractId1, "0.0.98", 100),
-            buildCryptoTransferTransaction("0.0.98", contractId1, 50)
+            buildCryptoTransferTransaction(contractId1, "0.0.98", 100, {"timestamp":`${timestamp4}.060890955`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 50, {"timestamp":`${timestamp4}.060890954`}),
           ],
           links: {
-            next: `transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${latestBlock.timestamp.to}&page=2`
+            next: `transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${timestamp4}.060890940&page=2`
+          }
+        });        
+
+        restMock.onGet(`transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${timestamp4}.060890960`).reply(200, {
+          transactions: [
+            buildCryptoTransferTransaction(contractId1, "0.0.98", 100, {"timestamp":`${timestamp4}.060890955`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 50, {"timestamp":`${timestamp4}.060890954`})
+          ],
+          links: {
+            next: `transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${timestamp4}.060890940&page=2`
           }
         });
 
-        restMock.onGet(`transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${latestBlock.timestamp.to}&page=2`).reply(200, {
+        restMock.onGet(`transactions?account.id=${contractId1}&timestamp=gte:${recentBlock.timestamp.to}&timestamp=lt:${timestamp4}.060890940&page=2`).reply(200, {
           transactions: [
-            buildCryptoTransferTransaction(contractId1, "0.0.98", 25),
-            buildCryptoTransferTransaction("0.0.98", contractId1, 10),
+            buildCryptoTransferTransaction(contractId1, "0.0.98", 25, {"timestamp":`${timestamp4}.060890952`}),
+            buildCryptoTransferTransaction("0.0.98", contractId1, 10, {"timestamp":`${timestamp4}.060890951`}),
           ],
           links: {
             next: null
@@ -1653,7 +1737,7 @@ describe('Eth calls using MirrorNode', async function () {
   describe('eth_getCode', async function() {
     it('should return cached value', async () => {
       restMock.onGet(`contracts/${contractAddress1}`).reply(404, defaultContract);
-      restMock.onGet(`accounts/${contractAddress1}`).reply(404, null);
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(404, null);
       restMock.onGet(`tokens/0.0.${parseInt(contractAddress1, 16)}`).reply(404, null);
       sdkClientStub.getContractByteCode.throws(new SDKClientError({status: {
         _code: 16
@@ -1668,7 +1752,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('should return the runtime_bytecode from the mirror node', async () => {
       restMock.onGet(`contracts/${contractAddress1}`).reply(200, defaultContract);
-      restMock.onGet(`accounts/${contractAddress1}`).reply(404, null);
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(404, null);
       restMock.onGet(`tokens/0.0.${parseInt(contractAddress1, 16)}`).reply(404, null);
       sdkClientStub.getContractByteCode.returns(Buffer.from(deployedBytecode.replace('0x', ''), 'hex'));
 
@@ -1678,7 +1762,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('should return the bytecode from SDK if Mirror Node returns 404', async () => {
       restMock.onGet(`contracts/${contractAddress2}`).reply(404, defaultContract);
-      restMock.onGet(`accounts/${contractAddress2}`).reply(404, null);
+      restMock.onGet(`accounts/${contractAddress2}?limit=100`).reply(404, null);
       restMock.onGet(`tokens/0.0.${parseInt(contractAddress2, 16)}`).reply(404, null);
       sdkClientStub.getContractByteCode.returns(Buffer.from(deployedBytecode.replace('0x', ''), 'hex'));
       const res = await ethImpl.getCode(contractAddress2, null);
@@ -1690,7 +1774,7 @@ describe('Eth calls using MirrorNode', async function () {
         ...defaultContract,
         runtime_bytecode: EthImpl.emptyHex
       });
-      restMock.onGet(`accounts/${contractAddress3}`).reply(404, null);
+      restMock.onGet(`accounts/${contractAddress3}?limit=100`).reply(404, null);
       restMock.onGet(`tokens/0.0.${parseInt(contractAddress3, 16)}`).reply(404, null);
       sdkClientStub.getContractByteCode.returns(Buffer.from(deployedBytecode.replace('0x', ''), 'hex'));
       const res = await ethImpl.getCode(contractAddress3, null);
@@ -1699,7 +1783,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('should return redirect bytecode for HTS token', async () => {
       restMock.onGet(`contracts/${htsTokenAddress}`).reply(404, null);
-      restMock.onGet(`accounts/${htsTokenAddress}`).reply(404, null);
+      restMock.onGet(`accounts/${htsTokenAddress}?limit=100`).reply(404, null);
       restMock.onGet(`tokens/0.0.${parseInt(htsTokenAddress, 16)}`).reply(200, defaultHTSToken);
       const redirectBytecode = `6080604052348015600f57600080fd5b506000610167905077618dc65e${htsTokenAddress.slice(2)}600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033`;
       const res = await ethImpl.getCode(htsTokenAddress, null);

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -129,9 +129,9 @@ describe("Open RPC Specification", function () {
         mock.onGet(`contracts/${contractId1}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults2);
         mock.onGet(`contracts/${contractId2}/results/${contractTimestamp3}`).reply(200, defaultDetailedContractResults3);
         mock.onGet(`tokens/0.0.${parseInt(defaultCallData.to, 16)}`).reply(404, null);
-        mock.onGet(`accounts/${contractAddress1}`).reply(200, { account: contractAddress1 });
+        mock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, { account: contractAddress1 });
         mock.onGet(`accounts/${contractAddress3}`).reply(200, { account: contractAddress3 });
-        mock.onGet(`accounts/0xbC989b7b17d18702663F44A6004cB538b9DfcBAc`).reply(200, { account: '0xbC989b7b17d18702663F44A6004cB538b9DfcBAc' });
+        mock.onGet(`accounts/0xbC989b7b17d18702663F44A6004cB538b9DfcBAc?limit=100`).reply(200, { account: '0xbC989b7b17d18702663F44A6004cB538b9DfcBAc' });
         mock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
             from: `${defaultEvmAddress}`
           });
@@ -182,7 +182,7 @@ describe("Open RPC Specification", function () {
         let initialEthCallConesneusFF = process.env.ETH_CALL_DEFAULT_TO_CONSENSUS_NODE;
         process.env.ETH_CALL_DEFAULT_TO_CONSENSUS_NODE = 'false';
         mock.onGet(`contracts/${defaultCallData.from}`).reply(404);
-        mock.onGet(`accounts/${defaultCallData.from}`).reply(200, {
+        mock.onGet(`accounts/${defaultCallData.from}?limit=100`).reply(200, {
             account: "0.0.1723",
             evm_address: defaultCallData.from
         });
@@ -197,7 +197,7 @@ describe("Open RPC Specification", function () {
         let initialEthCallConesneusFF = process.env.ETH_CALL_DEFAULT_TO_CONSENSUS_NODE;
         process.env.ETH_CALL_DEFAULT_TO_CONSENSUS_NODE = 'true';
         mock.onGet(`contracts/${defaultCallData.from}`).reply(404);
-        mock.onGet(`accounts/${defaultCallData.from}`).reply(200, {
+        mock.onGet(`accounts/${defaultCallData.from}?limit=100`).reply(200, {
             account: "0.0.1723",
             evm_address: defaultCallData.from
         });
@@ -349,6 +349,7 @@ describe("Open RPC Specification", function () {
     });
 
     it('should execute "eth_getTransactionCount"', async function () {
+        mock.onGet(`accounts/${contractAddress1}`).reply(200, { account: contractAddress1 });
         const response = await ethImpl.getTransactionCount(contractAddress1, 'latest');
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionCount, response);


### PR DESCRIPTION
**Description**:
Removed unnecessary call to the mirrornode to retrieve account transactions.  It removes calls to the mirrornode when considering transaction level transfers when the block requested in the eth_getBalance call is within the last 15 minutes.
The first call to the mirrornode for the account now returns 100 transactions instead of 20.  If there are still transactions that need to be considered, the old pagination functionality is used to fetch them.

### Background
The current functionality of getBalance retrieves the balance from the account balance in the mirrornode.  This balance is updated every 15 minutes.  If the block queried falls within the last 15 minutes, then the transactions endpoint is called to get a list of transactions from the block queried timestamp.to property, to the the current timestamp.  This makes sense from a hedera perspective but does not honor the block queried. The block is a two second time slice in which transactions for that account may have occurred.   This simple fact confuses the optimization and should be resolved before moving forward.

By considering the now 100 transactions available in the initial call to the mirror node for the account information we can remove most calls for the transactions that fall in the fifteen minute window, however this means we need to have a clear understanding of the block timestamps we are querying the mirror node for, and a strategy for paginating the account transactions in the case where more than 100 transaction may have occurred for that account in the last fifteen minutes.

The latest solutions pushed up is "a" solution, but not a clean solution in that it:

1. considers the old timestamp query for transactions to the mirror node that does not honor the blocks.
2. reuses the transactions endpoint for any necessary transaction pagination.

The tests all pass, but this solution smells.  It s a good starting point to illustrate what needs to be done, but the proper solution would address the two points mentioned above.

```

Fixes #1085

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
