### PR TITLE
Cherry-pick: Expand eth_call mirror node consensus retry scenarios (#1122)

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -282,7 +282,6 @@ export class SDKClient {
         let retries = 0;
         let resp;
         while (parseInt(process.env.CONTRACT_QUERY_TIMEOUT_RETRIES || '1') > retries) {
-            console.log(retries)
             try {
                 resp = await this.submitContractCallQuery(to, data, gas, from, callerName, requestId);
                 return resp;
@@ -294,6 +293,9 @@ export class SDKClient {
                     retries++;
                     await new Promise(r => setTimeout(r, delay));
                     continue;
+                }
+                if (e instanceof JsonRpcError) {
+                    throw e;
                 }
                 throw sdkClientError;
             }
@@ -397,7 +399,6 @@ export class SDKClient {
             if (sdkClientError.isGrpcTimeout()) {
                 throw predefined.REQUEST_TIMEOUT;
             }
-
             throw sdkClientError;
         }
     };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1024,52 +1024,48 @@ export class EthImpl implements Eth {
     await this.performCallChecks(call, requestId);
 
     // Get a reasonable value for "gas" if it is not specified.
-    let gas = Number(call.gas) || 400_000;
-
-    let value: string | null = null;
-    if (typeof call.value === 'string') {
-      value = (new BN(call.value)).toString();
-    }
-
-    // Gas limit for `eth_call` is 50_000_000, but the current Hedera network limit is 15_000_000
-    // With values over the gas limit, the call will fail with BUSY error so we cap it at 15_000_000
-    if (gas > constants.BLOCK_GAS_LIMIT) {
-      this.logger.trace(`${requestIdPrefix} eth_call gas amount (${gas}) exceeds network limit, capping gas to ${constants.BLOCK_GAS_LIMIT}`);
-      gas = constants.BLOCK_GAS_LIMIT;
-    }
+    let gas = this.getCappedBlockGasLimit(call.gas);
+    let value: string | null = EthImpl.toNullableBigNumber(call.value);
     
     try {
       // ETH_CALL_DEFAULT_TO_CONSENSUS_NODE = false enables the use of Mirror node
       if (process.env.ETH_CALL_DEFAULT_TO_CONSENSUS_NODE == 'false') {
         //temporary workaround until precompiles are implemented in Mirror node evm module
         // Execute the call and get the response
-        this.logger.debug(`${requestIdPrefix} Making eth_call on contract ${call.to} with gas ${gas} and call data "${call.data}" from "${call.from}" using mirror-node.`, call.to, gas, call.data, call.from);
-        const callData = {
-          ...call,
-          gas,
-          value,
-          estimate: false
-        }
-        const contractCallResponse = await this.mirrorNodeClient.postContractCall(callData, requestId);
-        if (contractCallResponse && contractCallResponse.result) {
-          return EthImpl.prepend0x(contractCallResponse.result);
-        }
-        return EthImpl.emptyHex;
+        return await this.callMirrorNode(call, gas, value, requestId);
       }
       
       return await this.callConsensusNode(call, gas, requestId);
     } catch (e: any) {
-      // Temporary workaround until mirror node web3 module implements the support of precompiles
-      // If mirror node throws NOT_SUPPORTED or precompile is not supported, rerun eth_call and force it to go through the Consensus network
-      if (e instanceof MirrorNodeClientError && (e.isNotSupported() || e.isNotSupportedSystemContractOperaton())) {
-        return await this.callConsensusNode(call, gas, requestId);
+      this.logger.error(e, `${requestIdPrefix} Failed to successfully submit eth_call`);
+      return e instanceof JsonRpcError ? e : predefined.INTERNAL_ERROR();
+    }
+  }
+
+  async callMirrorNode(call: any, gas: number, value: string | null, requestId?: string): Promise<string | JsonRpcError> {
+    const requestIdPrefix = formatRequestIdMessage(requestId);
+    try {
+      this.logger.debug(`${requestIdPrefix} Making eth_call on contract ${call.to} with gas ${gas} and call data "${call.data}" from "${call.from}" using mirror-node.`, call.to, gas, call.data, call.from);
+      const callData = {
+        ...call,
+        gas,
+        value,
+        estimate: false
       }
 
-      this.logger.error(e, `${requestIdPrefix} Failed to successfully submit contractCallQuery`);
-      if (e instanceof JsonRpcError) {
-        return e;
-      }
-      return predefined.INTERNAL_ERROR();
+      const contractCallResponse = await this.mirrorNodeClient.postContractCall(callData, requestId);
+      return contractCallResponse && contractCallResponse.result ? EthImpl.prepend0x(contractCallResponse.result) : EthImpl.emptyHex;
+    } catch (e: any) {
+      // Temporary workaround until mirror node web3 module implements the support of precompiles
+      // If mirror node throws, rerun eth_call and force it to go through the Consensus network
+      if (e) {
+        const errorTypeMessage = e instanceof MirrorNodeClientError && (e.isNotSupported() || e.isNotSupportedSystemContractOperaton()) ? 'Unsupported' : 'Unhandled';
+        this.logger.trace(`${requestIdPrefix} ${errorTypeMessage} mirror node eth_call request, retrying with consensus node`);
+
+        return await this.callConsensusNode(call, gas, requestId);
+      } 
+      this.logger.error(e, `${requestIdPrefix} Failed to successfully submit eth_call`);
+      return e instanceof JsonRpcError ? e : predefined.INTERNAL_ERROR();
     }
   }
 
@@ -1292,6 +1288,14 @@ export class EthImpl implements Eth {
     return value.substring(0, 66);
   }
 
+  static toNullableBigNumber(value: string): string | null {
+    if (typeof value === 'string') {
+      return (new BN(value)).toString();
+    }
+
+    return null;
+  }
+
   private static toNullIfEmptyHex(value: string): string | null {
     return value === EthImpl.emptyHex ? null : value;
   }
@@ -1328,6 +1332,22 @@ export class EthImpl implements Eth {
     } else {
       return Number(tag);
     }
+  }
+
+  private getCappedBlockGasLimit(gasString: string, requestIdPrefix?: string): number {
+    if (!gasString) {
+      return 400_000;
+    }
+
+    // Gas limit for `eth_call` is 50_000_000, but the current Hedera network limit is 15_000_000
+    // With values over the gas limit, the call will fail with BUSY error so we cap it at 15_000_000
+    let gas = Number.parseInt(gasString);
+    if (gas > constants.BLOCK_GAS_LIMIT) {
+      this.logger.trace(`${requestIdPrefix} eth_call gas amount (${gas}) exceeds network limit, capping gas to ${constants.BLOCK_GAS_LIMIT}`);
+      return constants.BLOCK_GAS_LIMIT;
+    }
+
+    return gas;
   }
 
   /**

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2903,6 +2903,38 @@ describe('Eth calls using MirrorNode', async function () {
       expect(result).to.equal("0x00");
     });
 
+    it('eth_call with all fields, but mirror node throws CONTRACT_REVERTED', async function () {
+      const callData = {
+        ...defaultCallData,
+        "from": accountAddress1,
+        "to": contractAddress2,
+        "data": contractCallData,
+        "gas": maxGasLimit
+      };
+
+      web3Mock.onPost('contracts/call', {...callData, estimate: false}).reply(400, {
+        '_status': {
+          'messages': [
+            {
+              'message': 'Contract reverted execution'
+            }
+          ]
+        }
+      });
+
+      sdkClientStub.submitContractCallQueryWithRetry.returns({
+            asBytes: function () {
+              return Uint8Array.of(0);
+            }
+          }
+      );
+
+      const result = await ethImpl.call(callData, 'latest');
+
+      sinon.assert.calledWith(sdkClientStub.submitContractCallQueryWithRetry, contractAddress2, contractCallData, maxGasLimit, accountAddress1, 'eth_call');
+      expect(result).to.equal("0x00");
+    });
+
     it('caps gas at 15_000_000', async function () {
       const callData = {
         ...defaultCallData,

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -393,8 +393,8 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                             expect(res).to.eq('0x00000000000000000000000000000000000000000000000000000000000003e8');
                         });
 
-
-                        it("011 Should fail when calling msgValue with more value than available balance", async function () {
+                        // test is pending until fallback workflow to consensus node is removed, because this flow works when calling to consensus
+                        xit("011 Should fail when calling msgValue with more value than available balance", async function () {
                             const callData = {
                                 ...defaultCallData,
                                 data: '0xddf363d7',
@@ -407,7 +407,6 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                             } catch (e) {
                                 Assertions.jsonRpcError(e, predefined.CONTRACT_REVERT());
                             }
-
                         });
                     }
                 });


### PR DESCRIPTION
**Description**:
CHerry pick #1122 

Expand eth_call mirror node consensus retry scenarios

- Move consensusNode call in catch out to apply to all error cases 
- Split mirror node call case into separate method with catch including consensus call 
- Add toNullableBigNumber to manage value conversion 
- Add getCappedBlockGasLimit to manage block gas limit max

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
