### PR TITLE
Remove consensus node call from eth_getTransactionCount

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -82,6 +82,7 @@ export class EthImpl implements Eth {
   static blockLatest = 'latest';
   static blockEarliest = 'earliest';
   static blockPending = 'pending';
+  static firstBlockNumber = (process.env.HEDERA_NETWORK || '').toLowerCase() === 'mainnet' ? 0 : 1; // non mainnet blocks are currently 1-indexed
 
   /**
    * Configurable options used when initializing the cache.
@@ -901,7 +902,7 @@ export class EthImpl implements Eth {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     this.logger.trace(`${requestIdPrefix} getTransactionCount(address=${address}, blockNumOrTag=${blockNumOrTag})`);
     const blockNumber = Number(blockNumOrTag);
-    if (!isNaN(blockNumber) && blockNumber <= 1) {
+    if (!isNaN(blockNumber) && blockNumber <= EthImpl.firstBlockNumber) {
       return EthImpl.zeroHex;
     } 
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3133,6 +3133,76 @@ describe('Eth calls using MirrorNode', async function () {
       expect(hasError).to.be.true;
     });
   });
+
+  describe('eth_getTranactionCount', async function() {
+    it('should return 0x0 on blockNumOrTag equal to 0 regardless of address', async function() {
+      const result = await ethImpl.getTransactionCount('', '0x0');
+      expect(result).to.exist;
+      expect(result).to.eq('0x0');
+    });
+
+    it('should return 0x0 on blockNumOrTag equal to 1 regardless of address', async function() {
+      const result = await ethImpl.getTransactionCount('', '0x1');
+      expect(result).to.exist;
+      expect(result).to.eq('0x0');
+    });
+
+
+    it('should return 0x0 on non existing address', async function() {
+      restMock.onGet(`accounts/${contractAddress1}`).reply(404);
+
+      const result = await ethImpl.getTransactionCount(contractAddress1, 'latest');
+
+      expect(result).to.exist;
+      expect(result).to.eq('0x0');
+    });
+
+    it('should return 0x0 on null nonce on existing address', async function() {
+      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+        account: contractAddress1,
+        ethereum_nonce: null
+      });
+
+      const result = await ethImpl.getTransactionCount(contractAddress1, 'latest');
+
+      expect(result).to.exist;
+      expect(result).to.eq('0x0');
+    });
+
+    it('should return valid count on existing address with valid nonce', async function() {
+      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+        account: contractAddress1,
+        ethereum_nonce: 7
+      });
+
+      const result = await ethImpl.getTransactionCount(contractAddress1, 'latest');
+
+      expect(result).to.exist;
+      expect(result).to.eq('0x7');
+    });
+
+    it('should ignore blockNumTag until implemented', async function() {
+      restMock.onGet(`accounts/${contractAddress1}`).reply(200, {
+        account: contractAddress1,
+        ethereum_nonce: 7
+      });
+
+      const result = await ethImpl.getTransactionCount(contractAddress1, '0x123');
+
+      expect(result).to.exist;
+      expect(result).to.eq('0x7');
+
+
+      const resultLatest = await ethImpl.getTransactionCount(contractAddress1, 'latest');
+      expect(resultLatest).to.eq(result);
+
+      const resultPending = await ethImpl.getTransactionCount(contractAddress1, 'pending');
+      expect(resultPending).to.eq(result);
+
+      const resultEarliest = await ethImpl.getTransactionCount(contractAddress1, 'earliest');
+      expect(resultEarliest).to.eq(result);
+    });
+  });
 });
 
 describe('Eth', async function () {

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -833,38 +833,38 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             });
 
             it('@release should execute "eth_getTransactionCount" primary', async function () {
-                const res = await relay.call('eth_getTransactionCount', [mirrorPrimaryAccount.evm_address, EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+                const res = await relay.call('eth_getTransactionCount', [mirrorPrimaryAccount.evm_address, EthImpl.blockLatest], requestId);
                 expect(res).to.be.equal('0x0');
             });
 
             it('should execute "eth_getTransactionCount" secondary', async function () {
-                const res = await relay.call('eth_getTransactionCount', [mirrorSecondaryAccount.evm_address, EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+                const res = await relay.call('eth_getTransactionCount', [mirrorSecondaryAccount.evm_address, EthImpl.blockLatest], requestId);
                 expect(res).to.be.equal('0x0');
             });
 
             it('@release should execute "eth_getTransactionCount" contract', async function () {
-                const res = await relay.call('eth_getTransactionCount', [mirrorContract.evm_address, EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+                const res = await relay.call('eth_getTransactionCount', [mirrorContract.evm_address, EthImpl.blockLatest], requestId);
                 expect(res).to.be.equal('0x1');
             });
 
             it('@release should execute "eth_getTransactionCount" for account with id converted to evm_address', async function () {
-                const res = await relay.call('eth_getTransactionCount', [Utils.idToEvmAddress(mirrorPrimaryAccount.account), EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+                const res = await relay.call('eth_getTransactionCount', [Utils.idToEvmAddress(mirrorPrimaryAccount.account), EthImpl.blockLatest], requestId);
                 expect(res).to.be.equal('0x0');
             });
 
             it('@release should execute "eth_getTransactionCount" contract with id converted to evm_address', async function () {
-                const res = await relay.call('eth_getTransactionCount', [Utils.idToEvmAddress(contractId.toString()), EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+                const res = await relay.call('eth_getTransactionCount', [Utils.idToEvmAddress(contractId.toString()), EthImpl.blockLatest], requestId);
                 expect(res).to.be.equal('0x1');
             });
 
             it('should execute "eth_getTransactionCount" for non-existing address', async function () {
-                const res = await relay.call('eth_getTransactionCount', [NON_EXISTING_ADDRESS, EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+                const res = await relay.call('eth_getTransactionCount', [NON_EXISTING_ADDRESS, EthImpl.blockLatest], requestId);
                 expect(res).to.be.equal('0x0');
             });
 
             it('should execute "eth_getTransactionCount" from hollow account', async function() {
                 const hollowAccount = ethers.Wallet.createRandom();
-                const resBeforeCreation = await relay.call('eth_getTransactionCount', [hollowAccount.address, 'latest'], requestId);
+                const resBeforeCreation = await relay.call('eth_getTransactionCount', [hollowAccount.address, EthImpl.blockLatest], requestId);
                 expect(resBeforeCreation).to.be.equal('0x0');
 
                 const signedTxHollowAccountCreation = await accounts[2].wallet.signTransaction({
@@ -884,7 +884,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const txHashHA = await relay.call('eth_sendRawTransaction', [signTxFromHollowAccount], requestId);
                 await mirrorNode.get(`/contracts/results/${txHashHA}`, requestId);
 
-                const resAfterCreation = await relay.call('eth_getTransactionCount', [hollowAccount.address, 'latest'], requestId);
+                const resAfterCreation = await relay.call('eth_getTransactionCount', [hollowAccount.address, EthImpl.blockLatest], requestId);
                 expect(resAfterCreation).to.be.equal('0x1');
             });
 
@@ -904,7 +904,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 // Wait for the transaction to be processed and imported in the mirror node with axios-retry
                 await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
 
-                const res = await relay.call('eth_getTransactionCount', ['0x' + account.address, 'latest'], requestId);
+                const res = await relay.call('eth_getTransactionCount', ['0x' + account.address, EthImpl.blockLatest], requestId);
                 expect(res).to.be.equal('0x1');
             });
 


### PR DESCRIPTION
**Description**:
Remove consensus node call from eth_getTransactionCount 

- Check for block 0 or 1. Return `0x0` on these blocks as no account details are applicable here
- Call mirror node with address and callback of `0x0`

**Related issue(s)**:

Addresses #1102

**Notes for reviewer**:
Currently blocked since it seems contracts nonces are only exposed on the consensus node so tests are now failing as mirror doesn't have the details

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
