### PR TITLE
Add `eth_call` workaround for mirror-node empty response

### DIFF
--- a/packages/relay/src/lib/errors/MirrorNodeClientError.ts
+++ b/packages/relay/src/lib/errors/MirrorNodeClientError.ts
@@ -32,7 +32,8 @@ export class MirrorNodeClientError extends Error {
     };
 
     static statusCodes = {
-      NOT_FOUND: 404
+      NOT_FOUND: 404,
+      NO_CONTENT: 204
     };
 
     constructor(error: any, statusCode: number) {
@@ -66,6 +67,10 @@ export class MirrorNodeClientError extends Error {
 
     public isNotSupported(): boolean {
         return this.statusCode === MirrorNodeClientError.ErrorCodes.NOT_SUPPORTED;
+    }
+
+    public isEmpty(): boolean {
+      return this.statusCode === MirrorNodeClientError.statusCodes.NO_CONTENT;
     }
 
     public isNotSupportedSystemContractOperaton(): boolean {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1055,7 +1055,10 @@ export class EthImpl implements Eth {
 
       const contractCallResponse = await this.mirrorNodeClient.postContractCall(callData, requestId);
       if (contractCallResponse && contractCallResponse.result) {
-        return contractCallResponse.result == EthImpl.emptyHex ? await this.callConsensusNode(call, gas, requestId) : EthImpl.prepend0x(contractCallResponse.result)
+        if (contractCallResponse.result == EthImpl.emptyHex) {
+          throw new MirrorNodeClientError({ message: "Empty Response" }, MirrorNodeClientError.statusCodes.NO_CONTENT);
+        }
+        return EthImpl.prepend0x(contractCallResponse.result);
       }
       return EthImpl.emptyHex;
     } catch (e: any) {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1054,7 +1054,10 @@ export class EthImpl implements Eth {
       }
 
       const contractCallResponse = await this.mirrorNodeClient.postContractCall(callData, requestId);
-      return contractCallResponse && contractCallResponse.result ? EthImpl.prepend0x(contractCallResponse.result) : EthImpl.emptyHex;
+      if (contractCallResponse && contractCallResponse.result) {
+        return contractCallResponse.result == EthImpl.emptyHex ? await this.callConsensusNode(call, gas, requestId) : EthImpl.prepend0x(contractCallResponse.result)
+      }
+      return EthImpl.emptyHex;
     } catch (e: any) {
       // Temporary workaround until mirror node web3 module implements the support of precompiles
       // If mirror node throws, rerun eth_call and force it to go through the Consensus network


### PR DESCRIPTION
**Description**:
This PR adds a temporary workaround for empty response from mirror-node `eth_call`. If `result: 0x` is returned, we fallback to consensus-node.

**Related issue(s)**:

Fixes #1130 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
