### PR TITLE
Cherry-Pick: Add `eth_call` workaround for mirror-node empty response (#1132)

### DIFF
--- a/packages/relay/src/lib/errors/MirrorNodeClientError.ts
+++ b/packages/relay/src/lib/errors/MirrorNodeClientError.ts
@@ -32,7 +32,8 @@ export class MirrorNodeClientError extends Error {
     };
 
     static statusCodes = {
-      NOT_FOUND: 404
+      NOT_FOUND: 404,
+      NO_CONTENT: 204
     };
 
     constructor(error: any, statusCode: number) {
@@ -66,6 +67,10 @@ export class MirrorNodeClientError extends Error {
 
     public isNotSupported(): boolean {
         return this.statusCode === MirrorNodeClientError.ErrorCodes.NOT_SUPPORTED;
+    }
+
+    public isEmpty(): boolean {
+      return this.statusCode === MirrorNodeClientError.statusCodes.NO_CONTENT;
     }
 
     public isNotSupportedSystemContractOperaton(): boolean {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1021,7 +1021,7 @@ export class EthImpl implements Eth {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     this.logger.trace(`${requestIdPrefix} call(hash=${JSON.stringify(call)}, blockParam=${blockParam})`, call, blockParam);
 
-    await this.performCallChecks(call, requestId);
+    const to = await this.performCallChecks(call, requestId);
 
     // Get a reasonable value for "gas" if it is not specified.
     let gas = this.getCappedBlockGasLimit(call.gas);
@@ -1032,7 +1032,7 @@ export class EthImpl implements Eth {
       if (process.env.ETH_CALL_DEFAULT_TO_CONSENSUS_NODE == 'false') {
         //temporary workaround until precompiles are implemented in Mirror node evm module
         // Execute the call and get the response
-        return await this.callMirrorNode(call, gas, value, requestId);
+        return await this.callMirrorNode(call, to, gas, value, requestId);
       }
       
       return await this.callConsensusNode(call, gas, requestId);
@@ -1042,9 +1042,14 @@ export class EthImpl implements Eth {
     }
   }
 
-  async callMirrorNode(call: any, gas: number, value: string | null, requestId?: string): Promise<string | JsonRpcError> {
+  async callMirrorNode(call: any, to: any, gas: number, value: string | null, requestId?: string): Promise<string | JsonRpcError> {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     try {
+      if (to?.type === constants.TYPE_CONTRACT && to?.entity.runtime_bytecode === EthImpl.emptyHex) {
+        this.logger.trace(`${requestIdPrefix} Contract runtime_bytecode equals to 0x and mirror-node will return 0x as well, retrying with consensus node`);
+        throw new MirrorNodeClientError({ message: "Empty Response" }, MirrorNodeClientError.statusCodes.NO_CONTENT);
+      }
+
       this.logger.debug(`${requestIdPrefix} Making eth_call on contract ${call.to} with gas ${gas} and call data "${call.data}" from "${call.from}" using mirror-node.`, call.to, gas, call.data, call.from);
       const callData = {
         ...call,
@@ -1133,6 +1138,8 @@ export class EthImpl implements Eth {
     if(!(toEntityType?.type === constants.TYPE_CONTRACT || toEntityType?.type === constants.TYPE_TOKEN)) {
       throw predefined.NON_EXISTING_CONTRACT(call.to);
     }
+
+    return toEntityType;
   }
 
   /**

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -542,6 +542,30 @@ describe('Eth calls using MirrorNode', async function () {
     "contract_id": contractId2,
   };
 
+  const defaultContract3EmptyBytecode = {
+    "address": contractAddress2,
+    "contract_id": contractId2,
+    "admin_key": null,
+    "auto_renew_account": null,
+    "auto_renew_period": 7776000,
+    "created_timestamp": "1659622477.294172233",
+    "deleted": false,
+    "evm_address": null,
+    "expiration_timestamp": null,
+    "file_id": "0.0.1051",
+    "max_automatic_token_associations": 0,
+    "memo": "",
+    "obtainer_id": null,
+    "permanent_removal": null,
+    "proxy_account_id": null,
+    "timestamp": {
+      "from": "1659622477.294172233",
+      "to": null
+    },
+    "bytecode": "0x123456",
+    "runtime_bytecode": "0x"
+  };
+
   const defaultHTSToken =
     {
       "admin_key": null,
@@ -2820,6 +2844,28 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet(`tokens/${defaultContractResults.results[1].contract_id}`).reply(404, null);
     });
 
+    it('eth_call with all fields, but mirror-node returns empty response', async function () {
+      const callData = {
+        ...defaultCallData,
+        "from": accountAddress1,
+        "to": contractAddress2,
+        "data": contractCallData,
+        "gas": maxGasLimit
+      };
+      restMock.onGet(`contracts/${contractAddress2}`).reply(200, defaultContract3EmptyBytecode);
+
+      sdkClientStub.submitContractCallQueryWithRetry.returns({
+          asBytes: function () {
+            return Uint8Array.of(0);
+          }
+        }
+      );
+
+      const result = await ethImpl.call(callData, 'latest');
+      sinon.assert.calledWith(sdkClientStub.submitContractCallQueryWithRetry, contractAddress2, contractCallData, 15_000_000, accountAddress1, 'eth_call');
+      expect(result).to.equal("0x00");
+    });
+    
     it('eth_call with no gas', async function () {
       const callData = {
         ...defaultCallData,


### PR DESCRIPTION
**Description**:
Cherry-Pick PR #1132 