### PR TITLE
Load Test

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -36,20 +36,21 @@ npm run k6
 ```
 
 #### Environment Variables
-| Parameter | Description                                                                                                                                                                                                                                                                                                                                                                     | Default Value | Required |
-|-------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
-| PRIVATE_KEY | The Private Key (ECDSA) to use when preparing the tests and signing the txs                                                                                                                                                                                                                                                                                                     |               | true     |
-| MIRROR_BASE_URL | The URL for the mirror node to use. e.g. https://testnet.mirrornode.hedera.com                                                                                                                                                                                                                                                                                                  |               | true     |
-| RELAY_BASE_URL | The URL of the RCP-Relay to perform the Tests against. e.g. https://testnet.hashio.io/api                                                                                                                                                                                                                                                                                       |               | true     | 
+| Parameter | Description                                                                                                                                                                                                                                                                                                                                                                      | Default Value | Required |
+|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
+| PRIVATE_KEY | The Private Key (ECDSA) to use when preparing the tests and signing the txs                                                                                                                                                                                                                                                                                                      |               | true     |
+| MIRROR_BASE_URL | The URL for the mirror node to use. e.g. https://testnet.mirrornode.hedera.com                                                                                                                                                                                                                                                                                                   |               | true     |
+| RELAY_BASE_URL | The URL of the RCP-Relay to perform the Tests against. e.g. https://testnet.hashio.io/api                                                                                                                                                                                                                                                                                        |               | true     | 
 | DEFAULT_DURATION | Duration of each test, K6 will perform as many requests as possible for each test in this given timeframe.  Some tests might override this duration to a minimum for at least 1 successful call for that test. i.e: if DEFAULT_DURATION=1s, but `eth_sendRawTransaction` needs at least 3s, k6 will use the bigger of the 2 (3s). to try to guarantee at least 1 successful call | 120s          | false | 
-| DEFAULT_VUS | Amount of concurrent (VUS) Virtual Users (doing requests)                                                                                                                                                                                                                                                                                                                       | 10            | false | 
-| DEFAULT_LIMIT | ?                                                                                                                                                                                                                                                                                                                                                                               | 100           | false | 
-| DEFAULT_PASS_RATE | The percentage of request that must pass for passing check                                                                                                                                                                                                                                                                                                                      | 0.95          | false | 
-| DEFAULT_MAX_DURATION | Threshold for passing test in ms (each request response should not take longer than this to pass)                                                                                                                                                                                                                                                                               | 500           | false | 
-| DEFAULT_GRACEFUL_STOP | Time of Grace given at the end between each scenario is run.                                                                                                                                                                                                                                                                                                                    | 5s            | false | 
-| FILTER_TEST | Test or Tests to be run, separated by comma without blanks ie: `FILTER_TEST=eth_call`, `FILTER_TEST=eth_call,eth_chainId,eth_sendRawTransaction`                                                                                                                                                                                                                                                         | *             | false |
-| DEBUG_MODE | If true, both the prep script and the k6 tests will produce useful logging to debug                                                                                                                                                                                                                                                                                             | false         | false |
-| SIGNED_TXS | Amount of signed Txs to generate by the prep script, to be used on eth_sendRawTransaction Tests                                                                                                                                                                                                                                                                                 | 10            | false |
+| DEFAULT_VUS | Amount of concurrent (VUS) Virtual Users (doing requests)                                                                                                                                                                                                                                                                                                                        | 10            | false | 
+| DEFAULT_LIMIT | ?                                                                                                                                                                                                                                                                                                                                                                                | 100           | false | 
+| DEFAULT_PASS_RATE | The percentage of request that must pass for passing check                                                                                                                                                                                                                                                                                                                       | 0.95          | false | 
+| DEFAULT_MAX_DURATION | Threshold for passing test in ms (each request response should not take longer than this to pass)                                                                                                                                                                                                                                                                                | 500           | false | 
+| DEFAULT_GRACEFUL_STOP | Time of Grace given at the end between each scenario is run.                                                                                                                                                                                                                                                                                                                     | 5s            | false | 
+| FILTER_TEST | Test or Tests to be run, separated by comma without blanks ie: `FILTER_TEST=eth_call`, `FILTER_TEST=eth_call,eth_chainId,eth_sendRawTransaction`                                                                                                                                                                                                                                 | *             | false |
+| DEBUG_MODE | If true, both the prep script and the k6 tests will produce useful logging to debug                                                                                                                                                                                                                                                                                              | false         | false |
+| SIGNED_TXS | Amount of signed Txs to generate by the prep script, to be used on eth_sendRawTransaction Tests                                                                                                                                                                                                                                                                                  | 10            | false |
+| TEST_TYPE | Type of test to run, either `performance` or `load`                                                                                                                                                                                                                                                                                                                             | performance   | false |
 
 
 
@@ -462,3 +463,28 @@ FILTER_TEST=eth_call,eth_sendRawTransaction
 ```
 
 When it completes, k6 will show a similar summary report. However, only for the selected tests.
+
+
+## Load Test
+
+To run a load test, just add or change ENV variable:
+```shell
+TEST_TYPE=load
+```
+
+Recommended Parameters when performing Load Tests:
+```shell
+DEFAULT_DURATION=300s
+DEFAULT_VUS=10
+DEFAULT_LIMIT=3000
+DEFAULT_PASS_RATE=0.90
+DEFAULT_MAX_DURATION=1000
+DEFAULT_GRACEFUL_STOP=5s
+FILTER_TEST=eth_chainId,eth_blockNumber,eth_gasPrice,eth_getBlockByNumber,eth_getCode,eth_call,eth_estimateGas,eth_getBalance,eth_getTransactionCount,eth_feeHistory,eth_getTransactionReceipt,eth_getBlockByHash
+DEBUG_MODE=false
+SIGNED_TXS=10
+TEST_TYPE=load
+``` 
+
+
+When it completes, k6 will show a similar summary report. However, only for the load tests.

--- a/k6/src/lib/common.js
+++ b/k6/src/lib/common.js
@@ -282,48 +282,43 @@ function TestScenarioBuilder() {
       run: function (testParameters, iteration = 0) {
         const response = that._request(testParameters, iteration);
         check(response, that._checks);
-
         // if Load test, then we need to sleep for random time between 1 and 5 seconds
         if (getTestType() === "load") {
             sleep(randomIntBetween(1, 5));
         }
-
-      }
-
-
-      ,
+      },
     };
-  }
+  };
 
   this.check = function (name, func) {
     this._checks[name] = func;
     return this;
-  }
+  };
 
   this.name = function (name) {
     this._name = name;
     return this;
-  }
+  };
 
   this.request = function (func) {
     this._request = func;
     return this;
-  }
+  };
 
   this.tags = function (tags) {
     this._tags = tags;
     return this;
-  }
+  };
 
   this.testDuration = function (testDuration) {
     this._testDuration = testDuration;
     return this;
-  }
+  };
 
   this.maxDuration = function (maxDuration){
     this._maxDuration = maxDuration;
     return this;
-  }
+  };
 
   return this;
 }

--- a/k6/src/prepare/prep.js
+++ b/k6/src/prepare/prep.js
@@ -54,6 +54,7 @@ async function getSignedTxs(mainWallet, greeterContract) {
         trx.nonce = nonce + i;
         const signedTx = await mainWallet.signTransaction(trx);
         signedTxCollection.push(signedTx);
+        console.log("Transaction " + i + " signed.");
     }
 
     return signedTxCollection;
@@ -62,6 +63,7 @@ async function getSignedTxs(mainWallet, greeterContract) {
 (async () => {
     const mainPrivateKeyString = process.env.PRIVATE_KEY;
     const mainWallet = new ethers.Wallet(mainPrivateKeyString, new LoggingProvider(process.env.RELAY_BASE_URL));
+    console.log("RPC Server:  " + process.env.RELAY_BASE_URL);
     console.log("Address: " + mainWallet.address);
 
     const contractFactory = new ethers.ContractFactory(Greeter.abi, Greeter.bytecode, mainWallet);

--- a/k6/src/scenarios/test/eth_call.js
+++ b/k6/src/scenarios/test/eth_call.js
@@ -35,6 +35,8 @@ const {options, run} = new TestScenarioBuilder()
     )
   )
   .check(methodName, (r) => isNonErrorResponse(r))
+  .testDuration("3s")
+  .maxDuration(2000)
   .build();
 
 export {options, run};


### PR DESCRIPTION
**Description**:
Improvements to k6 tests to be able to used them as Load Test

**Related issue(s)**:

Fixes #1127

**Notes for reviewer**:
While during the tests I was able to replicate the issue of `502` .



Mirror Node Latency:
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/123040664/234999696-da3fdfdd-69f8-4f0f-8080-5c15c2ed1080.png">

Request Distribution:
<img width="936" alt="image" src="https://user-images.githubusercontent.com/123040664/235000131-87374d45-e184-4498-ad68-6fabc7b1d55c.png">

Request Rate (RPS):
<img width="1890" alt="image" src="https://user-images.githubusercontent.com/123040664/235000213-991dd3fe-90da-4bef-afb5-53191fea6088.png">


Relay Methods Latency:
<img width="1717" alt="image" src="https://user-images.githubusercontent.com/123040664/234999826-d5449ed3-835c-476e-a1f8-c5a254200ed6.png">

# K6 Performance Test Results 

Timestamp: 2023-04-27T21:32:46.862Z 

Duration: 200s 

Test Type: load 

Virtual Users (VUs): 100 

| Scenario | VUS | Reqs | Pass % | RPS (1/s) | Pass RPS (1/s) | Avg. Req Duration (ms) | Median (ms) | Min (ms) | Max (ms) | P(90) (ms) | P(95) (ms) | Comment |
|----------|-----|------|--------|-----|----------|-------------------|-------|-----|-----|-------|-------|---------|
| eth_blockNumber | 100 | 817 | 61.64 | 4.00 | 2.47 | 4573.74 | 533.50 | 91.18 | 56817.96 | 13894.70 | 22725.88 | |
| eth_call | 100 | 780 | 58.54 | 3.81 | 2.23 | 5888.71 | 956.58 | 144.03 | 50591.10 | 20195.77 | 25528.24 | |
| eth_chainId | 100 | 903 | 65.63 | 4.41 | 2.89 | 2815.38 | 271.93 | 90.15 | 49949.48 | 7615.91 | 13264.06 | |
| eth_estimateGas | 100 | 811 | 61.65 | 3.96 | 2.44 | 3817.33 | 392.26 | 93.77 | 51322.57 | 11182.73 | 18761.71 | |
| eth_feeHistory | 100 | 778 | 60.93 | 3.81 | 2.32 | 4898.08 | 585.24 | 95.51 | 50511.11 | 15309.18 | 25038.32 | |
| eth_gasPrice | 100 | 855 | 64.48 | 4.18 | 2.70 | 3231.24 | 269.81 | 93.71 | 49431.81 | 9722.84 | 17122.53 | |
| eth_getBalance | 100 | 735 | 57.38 | 3.59 | 2.06 | 5066.47 | 584.07 | 95.46 | 54371.46 | 17570.78 | 28021.52 | |
| eth_getBlockByHash | 100 | 656 | 52.45 | 3.20 | 1.68 | 6662.04 | 922.73 | 193.02 | 52050.32 | 24445.93 | 29095.54 | |
| eth_getBlockByNumber | 100 | 770 | 59.66 | 3.76 | 2.24 | 5019.24 | 707.64 | 152.21 | 55419.14 | 19260.38 | 28013.14 | |
| eth_getCode | 100 | 748 | 60.11 | 3.65 | 2.19 | 4053.45 | 249.03 | 91.07 | 53301.43 | 13176.14 | 26475.02 | |
| eth_getTransactionCount | 100 | 724 | 54.28 | 3.53 | 1.92 | 5385.59 | 1485.32 | 251.69 | 50339.06 | 16581.35 | 25078.37 | |
| eth_getTransactionReceipt | 100 | 757 | 60.50 | 3.70 | 2.24 | 3393.69 | 260.04 | 92.19 | 57517.43 | 9867.86 | 16669.58 | |




**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
