### PR TITLE
refactor: use REQUEST_ID_STRING from constants instead of replicating

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -17,9 +17,9 @@
  * limitations under the License.
  *
  */
-import {decodeErrorMessage} from '../../formatters';
+import { decodeErrorMessage } from '../../formatters';
+import constants from "../../lib/constants";
 
-const REQUEST_ID_STRING = `Request ID: `;
 export class JsonRpcError {
   public code: number;
   public message: string;
@@ -29,7 +29,7 @@ export class JsonRpcError {
   constructor(args: { name: string, code: number, message: string, data?: string }, requestId?: string) {
     this.code = args.code;
     this.name = args.name;
-    this.message = requestId ? `[${REQUEST_ID_STRING}${requestId}] ` + args.message : args.message;
+    this.message = requestId ? `[${constants.REQUEST_ID_STRING}${requestId}] ` + args.message : args.message;
     this.data = args.data;
   }
 }

--- a/packages/relay/tests/lib/errors/JsonRpcError.spec.ts
+++ b/packages/relay/tests/lib/errors/JsonRpcError.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import { JsonRpcError } from '../../../src/lib/errors/JsonRpcError';
+
+describe('Errors', () => {
+    describe('JsonRpcError', () => {
+        it('Constructs correctly without request ID', () => {
+            const err = new JsonRpcError({
+                name: 'TestError',
+                code: -32999,
+                message: 'test error: foo',
+                data: 'some data'
+            });
+            expect(err.code).to.eq(-32999);
+            expect(err.name).to.eq('TestError');
+            expect(err.data).to.eq('some data');
+
+            // Check that request ID is *not* prefixed
+            expect(err.message).to.eq('test error: foo');
+        });
+
+        it('Constructs correctly with request ID', () => {
+            const err = new JsonRpcError({
+                name: 'TestError',
+                code: -32999,
+                message: 'test error: foo',
+                data: 'some data'
+            }, 'abcd-1234');
+            expect(err.code).to.eq(-32999);
+            expect(err.name).to.eq('TestError');
+            expect(err.data).to.eq('some data');
+
+            // Check that request ID is prefixed
+            expect(err.message).to.eq('[Request ID: abcd-1234] test error: foo');
+        });
+    });
+});

--- a/packages/relay/tests/lib/errors/JsonRpcError.spec.ts
+++ b/packages/relay/tests/lib/errors/JsonRpcError.spec.ts
@@ -1,3 +1,23 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import { expect } from 'chai';
 import { JsonRpcError } from '../../../src/lib/errors/JsonRpcError';
 

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -1,3 +1,23 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import { expect } from 'chai';
 import { hexToASCII, decodeErrorMessage, formatTransactionId } from '../../src/formatters';
 


### PR DESCRIPTION


**Description**:

This PR modifies ... in order to support ...
- refactor: use `REQUEST_ID_STRING` from `constants` instead of replicating
- test: added test for `JsonRpcError` constructor

**Related issue(s)**:

- N/A

**Notes for reviewer**:

- Should be better for code coverage, as `JsonRpcError` was previously only tested directly

**Checklist**

- [ ] Documented (Code comments, README, etc.) --> N/A
- [x] Tested (unit, integration, etc.)
