### PR TITLE
Fix flaky subgraph test

### DIFF
--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Deploy and interact with contracts
         run: npx hardhat prepare
+      
+      - name: Generate types
+        run: npm run graph-codegen
 
       - name: Start local graph-node
         run: npm run graph-local -- --detach

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 18.15
 
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
**Description**:
This PR adds a new step in the subgraph CI workflow, which generates the necessary types before starting the graph node and deploy the subgraph.
Also there is a bug in node version 18.16 (latest) which is being used here. This results in hardhat not being able to download the compiler and exiting with exitcode 0. More info [here](https://github.com/NomicFoundation/hardhat/issues/3877)

**Related issue(s)**:

Fixes #1143 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
