### PR TITLE
Add resolve type consideration for tokens

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -655,7 +655,7 @@ export class MirrorNodeClient {
      * @param entityIdentifier the address of the contract
      * @param requestId the request id
      * @param searchableTypes the types to search for
-     * @returns enitty object or null if not found
+     * @returns entity object or null if not found
      */
     public async resolveEntityType(
       entityIdentifier: string,

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -179,7 +179,7 @@ export class MirrorNodeClient {
                 const requestId = request ? request.split('\n')[3].substring(11,47) : '';
                 const requestIdPrefix = formatRequestIdMessage(requestId);
                 const delay = isDevMode ? mirrorNodeRetryDelayDevMode || 200 : mirrorNodeRetryDelay * retryCount;
-                this.logger.trace(`${requestIdPrefix} Retry delay ${delay} ms`);                
+                this.logger.trace(`${requestIdPrefix} Retry delay ${delay} ms on '${error?.request?.path}'`);                
                 return delay;
             },
             retryCondition: (error) => {
@@ -650,10 +650,17 @@ export class MirrorNodeClient {
         }
     }
 
+    /**
+     * Get the contract results for a given address
+     * @param entityIdentifier the address of the contract
+     * @param requestId the request id
+     * @param searchableTypes the types to search for
+     * @returns enitty object or null if not found
+     */
     public async resolveEntityType(
       entityIdentifier: string,
-      requestId?: string,
-      searchableTypes: any[] = [constants.TYPE_CONTRACT, constants.TYPE_ACCOUNT, constants.TYPE_TOKEN]
+      searchableTypes: any[] = [constants.TYPE_CONTRACT, constants.TYPE_ACCOUNT, constants.TYPE_TOKEN],
+      requestId?: string
     ) {
         const cachedLabel = `resolveEntityType.${entityIdentifier}`;
         const cachedResponse: { type: string, entity: any } | undefined = this.cache.get(cachedLabel);
@@ -682,8 +689,13 @@ export class MirrorNodeClient {
         try {
             const promises = [
                 searchableTypes.find(t => t === constants.TYPE_ACCOUNT) ? buildPromise(this.getAccount(entityIdentifier, requestId)) : Promise.reject(),
-                searchableTypes.find(t => t === constants.TYPE_TOKEN) ? buildPromise(this.getTokenById(`0.0.${parseInt(entityIdentifier, 16)}`, requestId)) : Promise.reject()
             ];
+
+            // only add long zero evm addresses for tokens as they do not refer to actual contract addresses but rather encoded entity nums            
+            if (entityIdentifier.startsWith(constants.LONG_ZERO_PREFIX)) {
+                promises.push(searchableTypes.find(t => t === constants.TYPE_TOKEN) ? buildPromise(this.getTokenById(`0.0.${parseInt(entityIdentifier, 16)}`, requestId)) : Promise.reject());
+            }
+
             // maps the promises with indices of the promises array
             // because there is no such method as Promise.anyWithIndex in js
             // the index is needed afterward for detecting the resolved promise type (contract, account, or token)

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -70,5 +70,7 @@ export default {
     NEXT_LINK_PREFIX: '/api/v1/',
     QUERY_COST_INCREMENTATION_STEP: 1.1,
 
-    TRANSACTION_ID_REGEX: /\d{1}\.\d{1}\.\d{1,10}\@\d{1,10}\.\d{1,9}/
+    TRANSACTION_ID_REGEX: /\d{1}\.\d{1}\.\d{1,10}\@\d{1,10}\.\d{1,9}/,
+
+    LONG_ZERO_PREFIX: '0x000000000000',
 };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -777,7 +777,7 @@ export class EthImpl implements Eth {
     }
 
     try {
-      const result = await this.mirrorNodeClient.resolveEntityType(address, requestId, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN]);
+      const result = await this.mirrorNodeClient.resolveEntityType(address, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN], requestId);
       if (result) {
         if (result?.type === constants.TYPE_TOKEN) {
           this.logger.trace(`${requestIdPrefix} Token redirect case, return redirectBytecode`);
@@ -944,7 +944,7 @@ export class EthImpl implements Eth {
 
     // check consensus node as back up
     try {
-      const result = await this.mirrorNodeClient.resolveEntityType(address, requestId, [constants.TYPE_ACCOUNT, constants.TYPE_CONTRACT]);
+      const result = await this.mirrorNodeClient.resolveEntityType(address, [constants.TYPE_ACCOUNT, constants.TYPE_CONTRACT], requestId);
       if (result?.type === constants.TYPE_ACCOUNT) {
         const accountInfo = await this.sdkClient.getAccountInfo(result?.entity.account, EthImpl.ethGetTransactionCount, requestId);
         return EthImpl.numberTo0x(Number(accountInfo.ethereumNonce));
@@ -1159,13 +1159,13 @@ export class EthImpl implements Eth {
 
     // If "From" is distinct from blank, we check is a valid account
     if(call.from) {
-      const fromEntityType = await this.mirrorNodeClient.resolveEntityType(call.from, requestId, [constants.TYPE_ACCOUNT]);
+      const fromEntityType = await this.mirrorNodeClient.resolveEntityType(call.from, [constants.TYPE_ACCOUNT], requestId);
       if (fromEntityType?.type !== constants.TYPE_ACCOUNT) {
         throw predefined.NON_EXISTING_ACCOUNT(call.from);
       }
     }
     // Check "To" is a valid Contract or HTS Address
-    const toEntityType = await this.mirrorNodeClient.resolveEntityType(call.to, requestId, [constants.TYPE_TOKEN, constants.TYPE_CONTRACT]);
+    const toEntityType = await this.mirrorNodeClient.resolveEntityType(call.to, [constants.TYPE_TOKEN, constants.TYPE_CONTRACT], requestId);
     if(!(toEntityType?.type === constants.TYPE_CONTRACT || toEntityType?.type === constants.TYPE_TOKEN)) {
       throw predefined.NON_EXISTING_CONTRACT(call.to);
     }

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -707,12 +707,11 @@ describe('MirrorNodeClient', async function () {
       expect(entityType).to.have.property('entity');
       expect(entityType.type).to.eq('token');
       expect(entityType.entity.token_id).to.eq(mockData.tokenId);
-
-      expect(mock.history.get.length).to.eq(2); // mirror Node API called for both account and tokens
     });
 
     it('does not call mirror node tokens API when token is not long zero type', async() => {
       mock.onGet(`contracts/${mockData.contractEvmAddress}`).reply(200, mockData.contract);
+      mock.onGet(`tokens/${mockData.tokenId}`).reply(404, mockData.notFound);
 
       const entityType = await mirrorNodeInstance.resolveEntityType(mockData.contractEvmAddress, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN]); 
       expect(entityType).to.exist;
@@ -721,8 +720,6 @@ describe('MirrorNodeClient', async function () {
       expect(entityType.type).to.eq('contract');
       expect(entityType.entity).to.have.property('contract_id');
       expect(entityType.entity.contract_id).to.eq(mockData.contract.contract_id);
-
-      expect(mock.history.get.length).to.eq(1); // mirror Node API called for both account and tokens
     });
   });
 

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -75,7 +75,7 @@ function getMultipleAddressesEnabled() {
 }
 
 async function validateIsContractAddress(address, requestId) {
-    const isContract = await mirrorNodeClient.resolveEntityType(address, requestId, [constants.TYPE_CONTRACT]);
+    const isContract = await mirrorNodeClient.resolveEntityType(address, [constants.TYPE_CONTRACT], requestId);
     if (!isContract) {
         throw new JsonRpcError(predefined.INVALID_PARAMETER(`filters.address`, `${address} is not a valid contract type or does not exists`), requestId);
     }


### PR DESCRIPTION
**Description**:
Handle valid evm contract address considerations as part of entity resolution

- Add path to MirrorNodeClient retry log
- Conditionally add `this.getTokenById()` to `resolveEntityType()` only if address is of long zero type
- Move requestId to add of `resolveEntityType()` parameters
- Added test for to verify token is only called for long zero address

**Related issue(s)**:

Fixes #1156 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
