### PR TITLE
Updated eth_estimateGas bad input tests

### DIFF
--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2653,7 +2653,7 @@ describe('Eth calls using MirrorNode', async function () {
     }, null);
 
     expect(result).to.exist;
-    expect(result.code).to.equal(-32008);
+    expect(result.code).to.equal(-32602);
     expect(result.name).to.equal('Invalid parameter');
     expect(result.message).to.equal('Invalid value field in transaction param. Value must be greater than 0');
   });
@@ -2666,7 +2666,7 @@ describe('Eth calls using MirrorNode', async function () {
     }, null);
 
     expect(result).to.exist;
-    expect(result.code).to.equal(-32008);
+    expect(result.code).to.equal(-32602);
     expect(result.name).to.equal('Invalid parameter');
     expect(result.message).to.equal('Invalid value field in transaction param. Value must be greater than 0');
   });
@@ -2674,19 +2674,19 @@ describe('Eth calls using MirrorNode', async function () {
   it('eth_estimateGas empty call returns transfer cost', async function () {
     restMock.onGet(`accounts/undefined`).reply(404);
     const gas = await ethImpl.estimateGas({}, null);
-    expect(gas).to.equal(EthImpl.gasTxHollowAccountCreation);
+    expect(gas).to.equal(EthImpl.gasTxBaseCost);
   });
 
   it('eth_estimateGas empty input transfer cost', async function () {
     restMock.onGet(`accounts/undefined`).reply(404);
     const gas = await ethImpl.estimateGas({ data: "" }, null);
-    expect(gas).to.equal(EthImpl.gasTxHollowAccountCreation);
+    expect(gas).to.equal(EthImpl.gasTxBaseCost);
   });
 
   it('eth_estimateGas zero input returns transfer cost', async function () {
     restMock.onGet(`accounts/undefined`).reply(404);
     const gas = await ethImpl.estimateGas({ data: "0x" }, null);
-    expect(gas).to.equal(EthImpl.gasTxHollowAccountCreation);
+    expect(gas).to.equal(EthImpl.gasTxBaseCost);
   });
 
   it('eth_gasPrice', async function () {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2667,7 +2667,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result).to.exist;
     expect(result.code).to.equal(-32602);
     expect(result.name).to.equal('Invalid parameter');
-    expect(result.message).to.equal('Invalid parameter 0: Invalid value field in transaction param. Value must be greater than 0');
+    expect(result.message).to.equal(`Invalid parameter 0: Invalid 'value' field in transaction param. Value must be greater than 0`);
   });
 
   it('eth_estimateGas transfer with invalid value', async function() {
@@ -2680,7 +2680,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result).to.exist;
     expect(result.code).to.equal(-32602);
     expect(result.name).to.equal('Invalid parameter');
-    expect(result.message).to.equal('Invalid parameter 0: Invalid value field in transaction param. Value must be greater than 0');
+    expect(result.message).to.equal(`Invalid parameter 0: Invalid 'value' field in transaction param. Value must be greater than 0`);
   });
 
   it('eth_estimateGas empty call returns transfer cost', async function () {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2645,6 +2645,18 @@ describe('Eth calls using MirrorNode', async function () {
     expect(gasAfterCache).to.equal(EthImpl.gasTxBaseCost);
   });
 
+  it('eth_estimateGas transfer to non existing account', async function() {
+    const receiverAddress = '0x5b98Ce3a4D1e1AC55F15Da174D5CeFcc5b8FB994';
+    restMock.onGet(`accounts/${receiverAddress}`).reply(404);
+
+    const hollowAccountGasCreation = await ethImpl.estimateGas({
+      to: receiverAddress,
+      value: 100_000_000_000
+    }, null);
+
+    expect(hollowAccountGasCreation).to.equal(EthImpl.gasTxHollowAccountCreation);
+  });
+
   it('eth_estimateGas transfer with 0 value', async function() {
     const receiverAddress = '0x5b98Ce3a4D1e1AC55F15Da174D5CeFcc5b8FB994';
     const result = await ethImpl.estimateGas({

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2655,7 +2655,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result).to.exist;
     expect(result.code).to.equal(-32602);
     expect(result.name).to.equal('Invalid parameter');
-    expect(result.message).to.equal('Invalid value field in transaction param. Value must be greater than 0');
+    expect(result.message).to.equal('Invalid parameter 0: Invalid value field in transaction param. Value must be greater than 0');
   });
 
   it('eth_estimateGas transfer with invalid value', async function() {
@@ -2668,25 +2668,25 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result).to.exist;
     expect(result.code).to.equal(-32602);
     expect(result.name).to.equal('Invalid parameter');
-    expect(result.message).to.equal('Invalid value field in transaction param. Value must be greater than 0');
+    expect(result.message).to.equal('Invalid parameter 0: Invalid value field in transaction param. Value must be greater than 0');
   });
 
   it('eth_estimateGas empty call returns transfer cost', async function () {
     restMock.onGet(`accounts/undefined`).reply(404);
     const gas = await ethImpl.estimateGas({}, null);
-    expect(gas).to.equal(EthImpl.gasTxBaseCost);
+    expect(gas).to.equal(EthImpl.defaultGas);
   });
 
   it('eth_estimateGas empty input transfer cost', async function () {
     restMock.onGet(`accounts/undefined`).reply(404);
     const gas = await ethImpl.estimateGas({ data: "" }, null);
-    expect(gas).to.equal(EthImpl.gasTxBaseCost);
+    expect(gas).to.equal(EthImpl.defaultGas);
   });
 
   it('eth_estimateGas zero input returns transfer cost', async function () {
     restMock.onGet(`accounts/undefined`).reply(404);
     const gas = await ethImpl.estimateGas({ data: "0x" }, null);
-    expect(gas).to.equal(EthImpl.gasTxBaseCost);
+    expect(gas).to.equal(EthImpl.defaultGas);
   });
 
   it('eth_gasPrice', async function () {


### PR DESCRIPTION
**Description**:
Fix eth_estimateGas calls that are missing items
- Updated error `32008` (code revert) for `32602` (invalid input)
- Update gas value from `EthImpl.gasTxHollowAccountCreation` to `EthImpl.gasTxBaseCost` where there's an invalid account
- Add a test for hollow accounts

**Related issue(s)**:

Fixes #1174 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
