### PR TITLE
feat: add server section to openrpc spec

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -5,6 +5,24 @@
         "description": "A specification of the implemented Ethereum JSON RPC APIs interface for Hedera clients and adheres to the Ethereum execution APIs schema.",
         "version": "0.23.0-SNAPSHOT"
     },
+    "servers": [
+        {
+          "name": "Hedera Mainnet RPC Relay",
+          "url": "https://mainnet.hashio.io/api"
+        },
+        {
+          "name": "Hedera Testnet RPC Relay",
+          "url": "https://testnet.hashio.io/api"
+        },
+        {
+          "name": "Hedera Previewnet RPC Relay",
+          "url": "https://previewnet.hashio.io/api"
+        },
+        {
+          "name": "localhost Hedera RPC Relay",
+          "url": "http://localhost:7564"
+        }
+    ],
     "methods": [
         {
             "name": "eth_accounts",

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -9,17 +9,17 @@
         {
           "name": "Mainnet",
           "url": "https://mainnet.hashio.io/api",
-          "description": "Hedera Mainnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Global rate limits apply."
+          "description": "Hedera Mainnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Rate limited based [on IP address](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/rate-limiting.md) and [on global HBAR spend](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/hbar-limiting.md)."
         },
         {
           "name": "Testnet",
           "url": "https://testnet.hashio.io/api",
-          "description": "Hedera Testnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Global rate limits apply."
+          "description": "Hedera Testnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Rate limited based [on IP address](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/rate-limiting.md) and [on global HBAR spend](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/hbar-limiting.md)."
         },
         {
           "name": "Previewnet",
           "url": "https://previewnet.hashio.io/api",
-          "description": "Hedera Previewnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Global rate limits apply."
+          "description": "Hedera Previewnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Rate limited based [on IP address](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/rate-limiting.md) and [on global HBAR spend](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/hbar-limiting.md)."
         },
         {
           "name": "localhost",

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -7,20 +7,24 @@
     },
     "servers": [
         {
-          "name": "Hedera Mainnet RPC Relay",
-          "url": "https://mainnet.hashio.io/api"
+          "name": "Mainnet",
+          "url": "https://mainnet.hashio.io/api",
+          "description": "Hedera Mainnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Global rate limits apply."
         },
         {
-          "name": "Hedera Testnet RPC Relay",
-          "url": "https://testnet.hashio.io/api"
+          "name": "Testnet",
+          "url": "https://testnet.hashio.io/api",
+          "description": "Hedera Testnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Global rate limits apply."
         },
         {
-          "name": "Hedera Previewnet RPC Relay",
-          "url": "https://previewnet.hashio.io/api"
+          "name": "Previewnet",
+          "url": "https://previewnet.hashio.io/api",
+          "description": "Hedera Previewnet endpoint, hosted by [Hashio](https://swirldslabs.com/hashio/), a JSON-RPC Relay Community Service. Global rate limits apply."
         },
         {
-          "name": "localhost Hedera RPC Relay",
-          "url": "http://localhost:7564"
+          "name": "localhost",
+          "url": "http://localhost:7564",
+          "description": "Run your own instance of [`hedera-json-rpc-relay`](https://github.com/hashgraph/hedera-json-rpc-relay) on `localhost`, and configure it connect to your choice of Hedera networks. No rate limits apply."
         }
     ],
     "methods": [


### PR DESCRIPTION
**Description**:

This PR modifies `docs/openrpc.json` in order to support users of the [OpenRPC spec file](https://spec.open-rpc.org/) contained in this repo + users using the OpenRPC playground.

* Adds a server section to the spec file. [Ref](https://spec.open-rpc.org/#server-object)
* Uses this to specify the public endpoints for Mainnet, Testnet, and Previewnet via Hashio, plus localhost (for those running the relay server locally)
* Intent is that user can copy one of these URLs into the `Enter a JSON-RPC server URL` field within the inspector section of the OpenRPC playground

**Related issue(s)**:

N/A

**Notes for reviewer**:

This is what the newly added section looks like:

![image](https://user-images.githubusercontent.com/1773785/236247795-c6de86eb-0c5c-4766-92bc-fa8de93e3cd7.png)

Or you can try it out yourself: [With change](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/bguiz/hedera-json-rpc-relay/457df96/docs/openrpc.json&uiSchema%5BappBar%5D%5Bui:title%5D=Hedera&uiSchema%5BappBar%5D%5Bui:logoUrl%5D=https%3A%2F%2Fhips.hedera.com%2Fassets%2Fhedera_logo.png&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:inputPlaceholder%5D=false&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false)

Without this patch, this is what happens currently: [Without change](https://playground.open-rpc.org/?schemaUrl=https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/openrpc.json&uiSchema%5BappBar%5D%5Bui:title%5D=Hedera&uiSchema%5BappBar%5D%5Bui:logoUrl%5D=https%3A%2F%2Fhips.hedera.com%2Fassets%2Fhedera_logo.png&uiSchema%5BappBar%5D%5Bui:input%5D=false&uiSchema%5BappBar%5D%5Bui:inputPlaceholder%5D=false&uiSchema%5BappBar%5D%5Bui:splitView%5D=false&uiSchema%5BappBar%5D%5Bui:darkMode%5D=false&uiSchema%5BappBar%5D%5Bui:examplesDropdown%5D=false)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.) --> Manually, see screenshot
