### PR TITLE
Add resolve type consideration for tokens (#1158)

### DIFF
--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -70,5 +70,7 @@ export default {
     NEXT_LINK_PREFIX: '/api/v1/',
     QUERY_COST_INCREMENTATION_STEP: 1.1,
 
-    TRANSACTION_ID_REGEX: /\d{1}\.\d{1}\.\d{1,10}\@\d{1,10}\.\d{1,9}/
+    TRANSACTION_ID_REGEX: /\d{1}\.\d{1}\.\d{1,10}\@\d{1,10}\.\d{1,9}/,
+
+    LONG_ZERO_PREFIX: '0x000000000000',
 };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -777,7 +777,7 @@ export class EthImpl implements Eth {
     }
 
     try {
-      const result = await this.mirrorNodeClient.resolveEntityType(address, requestId, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN]);
+      const result = await this.mirrorNodeClient.resolveEntityType(address, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN], requestId);
       if (result) {
         if (result?.type === constants.TYPE_TOKEN) {
           this.logger.trace(`${requestIdPrefix} Token redirect case, return redirectBytecode`);
@@ -944,7 +944,7 @@ export class EthImpl implements Eth {
 
     // check consensus node as back up
     try {
-      const result = await this.mirrorNodeClient.resolveEntityType(address, requestId, [constants.TYPE_ACCOUNT, constants.TYPE_CONTRACT]);
+      const result = await this.mirrorNodeClient.resolveEntityType(address, [constants.TYPE_ACCOUNT, constants.TYPE_CONTRACT], requestId);
       if (result?.type === constants.TYPE_ACCOUNT) {
         const accountInfo = await this.sdkClient.getAccountInfo(result?.entity.account, EthImpl.ethGetTransactionCount, requestId);
         return EthImpl.numberTo0x(Number(accountInfo.ethereumNonce));
@@ -1159,13 +1159,13 @@ export class EthImpl implements Eth {
 
     // If "From" is distinct from blank, we check is a valid account
     if(call.from) {
-      const fromEntityType = await this.mirrorNodeClient.resolveEntityType(call.from, requestId, [constants.TYPE_ACCOUNT]);
+      const fromEntityType = await this.mirrorNodeClient.resolveEntityType(call.from, [constants.TYPE_ACCOUNT], requestId);
       if (fromEntityType?.type !== constants.TYPE_ACCOUNT) {
         throw predefined.NON_EXISTING_ACCOUNT(call.from);
       }
     }
     // Check "To" is a valid Contract or HTS Address
-    const toEntityType = await this.mirrorNodeClient.resolveEntityType(call.to, requestId, [constants.TYPE_TOKEN, constants.TYPE_CONTRACT]);
+    const toEntityType = await this.mirrorNodeClient.resolveEntityType(call.to, [constants.TYPE_TOKEN, constants.TYPE_CONTRACT], requestId);
     if(!(toEntityType?.type === constants.TYPE_CONTRACT || toEntityType?.type === constants.TYPE_TOKEN)) {
       throw predefined.NON_EXISTING_CONTRACT(call.to);
     }

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -696,6 +696,31 @@ describe('MirrorNodeClient', async function () {
       const entityType = await mirrorNodeInstance.resolveEntityType(notFoundAddress);
       expect(entityType).to.be.null;
     });
+
+    it('calls mirror node tokens API when token is long zero type', async() => {
+      mock.onGet(`contracts/${mockData.tokenId}`).reply(404, mockData.notFound);
+      mock.onGet(`tokens/${mockData.tokenId}`).reply(200, mockData.token);
+
+      const entityType = await mirrorNodeInstance.resolveEntityType(mockData.tokenLongZero, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN]); 
+      expect(entityType).to.exist;
+      expect(entityType).to.have.property('type');
+      expect(entityType).to.have.property('entity');
+      expect(entityType.type).to.eq('token');
+      expect(entityType.entity.token_id).to.eq(mockData.tokenId);
+    });
+
+    it('does not call mirror node tokens API when token is not long zero type', async() => {
+      mock.onGet(`contracts/${mockData.contractEvmAddress}`).reply(200, mockData.contract);
+      mock.onGet(`tokens/${mockData.tokenId}`).reply(404, mockData.notFound);
+
+      const entityType = await mirrorNodeInstance.resolveEntityType(mockData.contractEvmAddress, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN]); 
+      expect(entityType).to.exist;
+      expect(entityType).to.have.property('type');
+      expect(entityType).to.have.property('entity');
+      expect(entityType.type).to.eq('contract');
+      expect(entityType.entity).to.have.property('contract_id');
+      expect(entityType.entity.contract_id).to.eq(mockData.contract.contract_id);
+    });
   });
 
   describe('getTransactionById', async() => {

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -75,7 +75,7 @@ function getMultipleAddressesEnabled() {
 }
 
 async function validateIsContractAddress(address, requestId) {
-    const isContract = await mirrorNodeClient.resolveEntityType(address, requestId, [constants.TYPE_CONTRACT]);
+    const isContract = await mirrorNodeClient.resolveEntityType(address, [constants.TYPE_CONTRACT], requestId);
     if (!isContract) {
         throw new JsonRpcError(predefined.INVALID_PARAMETER(`filters.address`, `${address} is not a valid contract type or does not exists`), requestId);
     }


### PR DESCRIPTION
Handle valid evm contract address considerations as part of entity resolution

- Add path to MirrorNodeClient retry log
- Conditionally add `this.getTokenById()` to `resolveEntityType()` only if address is of long zero type
- Move requestId to add of `resolveEntityType()` parameters
- Added test for to verify token is only called for long zero address

---------



Fixes #1156


- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
