### PR TITLE
Add Foundry Example with Precompiled Mock Contracts

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -7,6 +7,9 @@ env:
 
 jobs:
   check:
+    defaults:
+      run:
+        working-directory: ./tools/foundry-example/
     strategy:
       fail-fast: true
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "tools/foundry-example/lib/forge-std"]
+	path = tools/foundry-example/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "tools/foundry-example/lib/openzeppelin-contracts"]
+	path = tools/foundry-example/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "tools/foundry-example/lib/hedera-smart-contracts"]
+	path = tools/foundry-example/lib/hedera-smart-contracts
+	url = https://github.com/hashgraph/hedera-smart-contracts

--- a/tools/foundry-example/.github/workflows/test.yml
+++ b/tools/foundry-example/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on: workflow_dispatch
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+
+    name: Foundry project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Run Forge build
+        run: |
+          forge --version
+          forge build --sizes
+        id: build
+
+      - name: Run Forge tests
+        run: |
+          forge test -vvv
+        id: test

--- a/tools/foundry-example/.gitignore
+++ b/tools/foundry-example/.gitignore
@@ -1,0 +1,14 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/tools/foundry-example/README.md
+++ b/tools/foundry-example/README.md
@@ -1,0 +1,36 @@
+# Foundry example
+
+Simple scripts for basic operations like hbars transfer, balance fetching, and contract interactions (deployment and calls).
+
+## Prerequisite
+
+You must have the Foundry CLI(forge) installed.
+
+## Configuration
+
+## Setup & Install
+
+In the project directory:
+
+1. Run `forge install`
+2. Run `forge build`
+3. Run `forge test`
+
+To view lib dependency mappings:
+`forge remappings`
+
+To filter and run a specific test:
+`forge test --match-contract {ContractName} --match-test {testFunctionName}`
+
+For example:
+`forge test --match-contract CounterTest --match-test testIncrement`
+
+Or to run all tests in a file:
+`forge test --match-path test/{FileName}.t.sol`
+
+For varying degrees of verbosity in trace logs use the flags: `-v`, `-vv`, `-vvv` and `-vvvv`
+
+## Deploy to Network
+
+To deploy the `src/Counter.sol:Counter` contract to the Hedera testnet(alias is configured in `foundry.toml` as `h_testnet`)
+`forge create --rpc-url h_testnet --private-key 0x744963be31f2a9252bd58bfe59d3aba886395ad063a3abd1cf8b52b00185d4fd src/Counter.sol:Counter`

--- a/tools/foundry-example/README.md
+++ b/tools/foundry-example/README.md
@@ -4,9 +4,7 @@ Simple scripts for basic operations like hbars transfer, balance fetching, and c
 
 ## Prerequisite
 
-You must have the Foundry CLI(forge) installed.
-
-## Configuration
+You must have the Foundry CLI(forge) installed. See https://book.getfoundry.sh/getting-started/installation
 
 ## Setup & Install
 
@@ -33,4 +31,4 @@ For varying degrees of verbosity in trace logs use the flags: `-v`, `-vv`, `-vvv
 ## Deploy to Network
 
 To deploy the `src/Counter.sol:Counter` contract to the Hedera testnet(alias is configured in `foundry.toml` as `h_testnet`)
-`forge create --rpc-url h_testnet --private-key 0x744963be31f2a9252bd58bfe59d3aba886395ad063a3abd1cf8b52b00185d4fd src/Counter.sol:Counter`
+`forge create --rpc-url h_testnet --private-key {PrivateKey} src/Counter.sol:Counter`

--- a/tools/foundry-example/foundry.toml
+++ b/tools/foundry-example/foundry.toml
@@ -1,0 +1,11 @@
+[profile.default]
+src = 'src'
+out = 'out'
+libs = ['lib']
+
+[rpc_endpoints]
+h_previewnet = "https://previewnet.hashio.io/api"
+h_testnet = "https://testnet.hashio.io/api"
+h_mainnet = "https://mainnet.hashio.io/api"
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/tools/foundry-example/foundry.toml
+++ b/tools/foundry-example/foundry.toml
@@ -4,6 +4,7 @@ out = 'out'
 libs = ['lib']
 
 [rpc_endpoints]
+h_local = "http://localhost:7546"
 h_previewnet = "https://previewnet.hashio.io/api"
 h_testnet = "https://testnet.hashio.io/api"
 h_mainnet = "https://mainnet.hashio.io/api"

--- a/tools/foundry-example/script/Counter.s.sol
+++ b/tools/foundry-example/script/Counter.s.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Script.sol";
+
+contract CounterScript is Script {
+    function setUp() public {}
+
+    function run() public {
+        vm.broadcast();
+    }
+}

--- a/tools/foundry-example/src/Counter.sol
+++ b/tools/foundry-example/src/Counter.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract Counter {
+    uint256 public number;
+
+    function setNumber(uint256 newNumber) public {
+        number = newNumber;
+    }
+
+    function increment() public {
+        number++;
+    }
+}

--- a/tools/foundry-example/src/NoDelegateCall.sol
+++ b/tools/foundry-example/src/NoDelegateCall.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity >=0.8.0;
+
+import "../test/libraries/Constants.sol";
+
+/// @title Prevents delegatecall to a contract
+/// @notice Base contract that provides a modifier for preventing delegatecall to methods in a child contract
+abstract contract NoDelegateCall is Constants {
+    /// @dev The original address of this contract
+    address private immutable original;
+
+    /// @dev slightly modified as in context of constructor address(this) is the address of the deployed contract and not the etched contract address
+    ///      hence _original allows passing the address to which a contract is etched to; for normal uses pass ADDRESS_ZERO
+    constructor(address _original) {
+        // Immutables are computed in the init code of the contract, and then inlined into the deployed bytecode.
+        // In other words, this variable won't change when it's checked at runtime.
+        original = _original == ADDRESS_ZERO ? address(this) : _original;
+    }
+
+    /// @dev Private method is used instead of inlining into modifier because modifiers are copied into each method,
+    ///     and the use of immutable means the address bytes are copied in every place the modifier is used.
+    function checkNotDelegateCall() private view {
+        require(address(this) == original, "NO_DELEGATECALL");
+    }
+
+    /// @notice Prevents delegatecall into the modified method
+    modifier noDelegateCall() {
+        checkNotDelegateCall();
+        _;
+    }
+}

--- a/tools/foundry-example/src/SimpleVault.sol
+++ b/tools/foundry-example/src/SimpleVault.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+import "hedera-smart-contracts/safe-hts-precompile/SafeHTS.sol";
+
+import "hedera-smart-contracts/exchange-rate-precompile/SelfFunding.sol";
+
+contract SimpleVault is SelfFunding {
+
+    mapping(address => bool) public isAssociated;
+    mapping(address => mapping(address => uint64)) public vaultBalances;
+
+    function associate(address token) external {
+        if (!isAssociated[token]) {
+            SafeHTS.safeAssociateToken(token, address(this));
+            isAssociated[token] = true;
+        }
+    }
+
+    function depositAndWithdraw(address depositToken, uint64 depositAmount, address withdrawToken, uint64 withdrawAmount) public payable costsCents(3) {
+        deposit(depositToken, depositAmount);
+        withdraw(withdrawToken, withdrawAmount);
+    }
+
+    function deposit(address token, uint64 amount) public payable costsCents(2) {
+        SafeHTS.safeTransferToken(token, msg.sender, address(this), int64(amount));
+        vaultBalances[token][msg.sender] += amount;
+    }
+
+    function withdraw(address token, uint64 amount) public payable costsCents(1) {
+        SafeHTS.safeTransferToken(token, address(this), msg.sender, int64(amount));
+        vaultBalances[token][msg.sender] -= amount;
+    }
+}

--- a/tools/foundry-example/test/Counter.t.sol
+++ b/tools/foundry-example/test/Counter.t.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import "../src/Counter.sol";
+
+contract CounterTest is Test {
+    Counter public counter;
+
+    function setUp() public {
+        counter = new Counter();
+        counter.setNumber(0);
+    }
+
+    function testIncrement() public {
+        counter.increment();
+        assertEq(counter.number(), 1);
+    }
+
+    function testSetNumber(uint256 x) public {
+        counter.setNumber(x);
+        assertEq(counter.number(), x);
+    }
+}

--- a/tools/foundry-example/test/ExchangeRatePrecompileMock.t.sol
+++ b/tools/foundry-example/test/ExchangeRatePrecompileMock.t.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import './utils/ExchangeRateUtils.sol';
+
+contract ExchangeRatePrecompileMockTest is ExchangeRateUtils {
+
+    // setUp is executed before each and every test function
+    function setUp() public {
+        _setUpExchangeRatePrecompileMock();
+        _setUpAccounts();
+    }
+
+    function test_CanCorrectlyConvertTinycentsToTinybars() public {
+        uint256 tinycents = 1e8;
+        uint256 tinybars = _doConvertTinycentsToTinybars(tinycents);
+        assertEq(tinybars, 1e7, "expected 1 cent to equal 1e7 tinybar(0.1 HBAR) at $0.1/HBAR");
+    }
+
+    function test_CanCorrectlyConvertTinybarsToTinyCents() public {
+        uint256 tinybars = 1e8;
+        uint256 tinycents = _doConvertTinybarsToTinycents(tinybars);
+        assertEq(tinycents, 1e9, "expected 1 HBAR to equal 10 cents(1e9 tinycents) at $0.1/HBAR");
+    }
+
+}
+
+// forge test --match-contract ExchangeRatePrecompileMockTest -vv

--- a/tools/foundry-example/test/HederaFungibleToken.t.sol
+++ b/tools/foundry-example/test/HederaFungibleToken.t.sol
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'hedera-smart-contracts/hts-precompile/IHederaTokenService.sol';
+import 'hedera-smart-contracts/hts-precompile/KeyHelper.sol';
+import './utils/HederaTokenUtils.sol';
+import './utils/HederaFungibleTokenUtils.sol';
+
+// DONE - refactor for actions to be standalone internal functions with assertions inside
+// DONE - complete other precompile contracts implementation and test suite
+// DONE - investigate permissions that tx.origin is granted in precompile mock and adjust authorization accordingly if required
+// DONE - add deploy contracts scripts for hedera testnet and mainnet & document cmd in README.md
+// DONE - do validation on token at creation
+// DONE - do validations in _precheck functions such that never reverts with error strings in ERC{20/721}
+
+// TODO: search project for all TODOs and prioritize accordingly
+// TODO: write tests for all token keyTypes
+// TODO: investigate ordering of response codes on Hedera and adjust ordering in mocks accordingly
+// TODO: evaluate code coverage of all tests
+// TODO: match gas cost/consumption and msg.value for all 3 precompile/system contract's mock functions with gas cost and HBAR value/cost on Hedera
+
+contract HederaFungibleTokenTest is HederaTokenUtils, HederaFungibleTokenUtils, KeyHelper {
+
+    // setUp is executed before each and every test function
+    function setUp() public {
+        _setUpHtsPrecompileMock();
+        _setUpAccounts();
+    }
+
+    // positive cases
+    function test_CreateHederaFungibleTokenViaHtsPrecompile() public {
+        address sender = alice;
+        string memory name = 'Token A';
+        string memory symbol = 'TA';
+        address treasury = alice;
+        int64 initialTotalSupply = 1e16;
+        int32 decimals = 8;
+
+        _doCreateHederaFungibleTokenViaHtsPrecompile(sender, name, symbol, treasury, initialTotalSupply, decimals);
+    }
+
+    function test_CreateHederaFungibleTokenDirectly() public {
+        address sender = alice;
+        string memory name = 'Token A';
+        string memory symbol = 'TA';
+        address treasury = alice;
+        int64 initialTotalSupply = 1e16;
+        int32 decimals = 8;
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+
+        _doCreateHederaFungibleTokenDirectly(sender, name, symbol, treasury, initialTotalSupply, decimals, keys);
+    }
+
+    function test_ApproveViaHtsPrecompile() public {
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+        address tokenAddress = _createSimpleMockFungibleToken(alice, keys);
+
+        uint allowance = 1e8;
+        _doApproveViaHtsPrecompile(alice, tokenAddress, bob, allowance);
+    }
+
+    function test_ApproveDirectly() public {
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+        address tokenAddress = _createSimpleMockFungibleToken(alice, keys);
+
+        uint allowance = 1e8;
+        _doApproveDirectly(alice, tokenAddress, bob, allowance);
+    }
+
+    function test_TransferViaHtsPrecompile() public {
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+        address tokenAddress = _createSimpleMockFungibleToken(alice, keys);
+
+        bool success;
+        uint256 amount = 1e8;
+
+        TransferParams memory transferParams = TransferParams({
+            sender: alice,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: amount
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, false, 'expected transfer to fail since recipient is not associated with token');
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, 'expected bob to associate with token');
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, true, 'expected transfer to succeed');
+    }
+
+    function test_TransferDirectly() public {
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+        address tokenAddress = _createSimpleMockFungibleToken(alice, keys);
+
+        bool success;
+        uint256 amount = 1e8;
+
+        TransferParams memory transferParams = TransferParams({
+            sender: alice,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: amount
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, false, 'expected transfer to fail since recipient is not associated with token');
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, 'expected bob to associate with token');
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, true, 'expected transfer to succeed');
+    }
+
+    function test_TransferUsingAllowanceViaHtsPrecompile() public {
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+        address tokenAddress = _createSimpleMockFungibleToken(alice, keys);
+
+        bool success;
+        uint256 amount = 1e8;
+
+        TransferParams memory transferParams = TransferParams({
+            sender: bob,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: amount
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, false, 'expected transfer to fail since bob is not associated with token');
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, 'expected bob to associate with token');
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, false, 'expected transfer to fail since bob is not granted an allowance');
+
+        uint allowance = 1e8;
+        _doApproveViaHtsPrecompile(alice, tokenAddress, bob, allowance);
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, true, 'expected transfer to succeed');
+    }
+
+    function test_TransferUsingAllowanceDirectly() public {
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+        address tokenAddress = _createSimpleMockFungibleToken(alice, keys);
+
+        bool success;
+        uint256 amount = 1e8;
+
+        TransferParams memory transferParams = TransferParams({
+            sender: bob,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: amount
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, false, 'expected transfer to fail since bob is not associated with token');
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, 'expected bob to associate with token');
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, false, 'expected transfer to fail since bob is not granted an allowance');
+
+        uint allowance = 1e8;
+        _doApproveViaHtsPrecompile(alice, tokenAddress, bob, allowance);
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, true, 'expected transfer to succeed');
+    }
+
+    /// @dev there is no test_CanMintDirectly as the ERC20 standard does not typically allow direct mints
+    function test_CanMintViaHtsPrecompile() public {
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = KeyHelper.getSingleKey(KeyHelper.KeyType.SUPPLY, KeyHelper.KeyValueType.CONTRACT_ID, alice);
+        address tokenAddress = _createSimpleMockFungibleToken(alice, keys);
+
+        _doAssociateViaHtsPrecompile(bob, tokenAddress);
+
+        bool success;
+
+        int64 mintAmount = 1e8;
+
+        MintResponse memory mintResponse;
+        MintParams memory mintParams;
+
+        mintParams = MintParams({
+            sender: bob,
+            token: tokenAddress,
+            mintAmount: mintAmount
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        assertEq(mintResponse.success, false, "expected mint to fail since bob is not supply key");
+
+        mintParams = MintParams({
+            sender: alice,
+            token: tokenAddress,
+            mintAmount: mintAmount
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        assertEq(mintResponse.success, true, "expected mint to succeed");
+    }
+
+    /// @dev there is no test_CanBurnDirectly as the ERC20 standard does not typically allow direct burns
+    function test_CanBurnViaHtsPrecompile() public {
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+        address tokenAddress = _createSimpleMockFungibleToken(alice, keys);
+
+        bool success;
+
+        int64 burnAmount = 1e8;
+
+        BurnParams memory burnParams;
+
+        burnParams = BurnParams({
+            sender: bob,
+            token: tokenAddress,
+            amountOrSerialNumber: burnAmount
+        });
+
+        (success, ) = _doBurnViaHtsPrecompile(burnParams);
+        assertEq(success, false, "expected burn to fail since bob is not treasury");
+
+        burnParams = BurnParams({
+            sender: alice,
+            token: tokenAddress,
+            amountOrSerialNumber: burnAmount
+        });
+
+        (success, ) = _doBurnViaHtsPrecompile(burnParams);
+        assertEq(success, true, "expected mint to succeed");
+    }
+
+    // negative cases
+    function test_CannotApproveIfSpenderNotAssociated() public {
+        /// @dev already demonstrated in some of the postive test cases
+        // cannot approve spender if spender is not associated with HederaFungibleToken BOTH directly and viaHtsPrecompile
+    }
+
+    function test_CannotTransferIfRecipientNotAssociated() public {
+        /// @dev already demonstrated in some of the postive test cases
+        // cannot transfer to recipient if recipient is not associated with HederaFungibleToken BOTH directly and viaHtsPrecompile
+    }
+}
+
+// forge test --match-contract HederaFungibleTokenTest --match-test test_CanBurnViaHtsPrecompile -vv
+// forge test --match-contract HederaFungibleTokenTest -vv

--- a/tools/foundry-example/test/HederaFungibleToken.t.sol
+++ b/tools/foundry-example/test/HederaFungibleToken.t.sol
@@ -6,19 +6,6 @@ import 'hedera-smart-contracts/hts-precompile/KeyHelper.sol';
 import './utils/HederaTokenUtils.sol';
 import './utils/HederaFungibleTokenUtils.sol';
 
-// DONE - refactor for actions to be standalone internal functions with assertions inside
-// DONE - complete other precompile contracts implementation and test suite
-// DONE - investigate permissions that tx.origin is granted in precompile mock and adjust authorization accordingly if required
-// DONE - add deploy contracts scripts for hedera testnet and mainnet & document cmd in README.md
-// DONE - do validation on token at creation
-// DONE - do validations in _precheck functions such that never reverts with error strings in ERC{20/721}
-
-// TODO: search project for all TODOs and prioritize accordingly
-// TODO: write tests for all token keyTypes
-// TODO: investigate ordering of response codes on Hedera and adjust ordering in mocks accordingly
-// TODO: evaluate code coverage of all tests
-// TODO: match gas cost/consumption and msg.value for all 3 precompile/system contract's mock functions with gas cost and HBAR value/cost on Hedera
-
 contract HederaFungibleTokenTest is HederaTokenUtils, HederaFungibleTokenUtils, KeyHelper {
 
     // setUp is executed before each and every test function

--- a/tools/foundry-example/test/HederaNonFungibleToken.t.sol
+++ b/tools/foundry-example/test/HederaNonFungibleToken.t.sol
@@ -1,0 +1,531 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'hedera-smart-contracts/hts-precompile/IHederaTokenService.sol';
+import 'hedera-smart-contracts/hts-precompile/HederaResponseCodes.sol';
+import 'hedera-smart-contracts/hts-precompile/KeyHelper.sol';
+import './mocks/hts-precompile/HederaNonFungibleToken.sol';
+import './mocks/hts-precompile/HtsPrecompileMock.sol';
+
+import './utils/HederaNonFungibleTokenUtils.sol';
+import './libraries/Constants.sol';
+
+contract HederaNonFungibleTokenTest is HederaNonFungibleTokenUtils, KeyHelper {
+
+    // setUp is executed before each and every test function
+    function setUp() public {
+        _setUpHtsPrecompileMock();
+        _setUpAccounts();
+    }
+
+    // positive cases
+    function test_CreateHederaNonFungibleTokenViaHtsPrecompile() public {
+
+        address sender = alice;
+        string memory name = 'NFT A';
+        string memory symbol = 'NFT-A';
+        address treasury = bob;
+
+        bool success;
+
+        (success, ) = _doCreateHederaNonFungibleTokenViaHtsPrecompile(sender, name, symbol, treasury);
+        assertEq(success, false, "expected failure since treasury is not sender");
+
+        treasury = alice;
+
+        (success, ) = _doCreateHederaNonFungibleTokenViaHtsPrecompile(sender, name, symbol, treasury);
+        assertEq(success, true, "expected success since treasury is sender");
+
+    }
+
+    function test_CreateHederaNonFungibleTokenDirectly() public {
+
+        address sender = alice;
+        string memory name = 'NFT A';
+        string memory symbol = 'NFT-A';
+        address treasury = bob;
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+
+        bool success;
+
+        (success, ) = _doCreateHederaNonFungibleTokenDirectly(sender, name, symbol, treasury, keys);
+        assertEq(success, false, "expected failure since treasury is not sender");
+
+        treasury = alice;
+
+        (success, ) = _doCreateHederaNonFungibleTokenDirectly(sender, name, symbol, treasury, keys);
+        assertEq(success, true, "expected success since treasury is sender");
+
+    }
+
+    function test_ApproveViaHtsPrecompile() public {
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = KeyHelper.getSingleKey(KeyHelper.KeyType.SUPPLY, KeyHelper.KeyValueType.CONTRACT_ID, alice);
+        address tokenAddress = _createSimpleMockNonFungibleToken(alice, keys);
+
+        bool success;
+
+        MintResponse memory mintResponse;
+        MintParams memory mintParams;
+
+        mintParams = MintParams({
+            sender: bob,
+            token: tokenAddress,
+            mintAmount: 0
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        assertEq(mintResponse.success, false, "expected failure since bob is not supply key");
+
+        mintParams = MintParams({
+            sender: alice,
+            token: tokenAddress,
+            mintAmount: 0
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        assertEq(mintResponse.success, true, "expected success since alice is supply key");
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, "bob should have associated with token");
+
+        ApproveNftParams memory approveNftParams;
+
+        approveNftParams = ApproveNftParams({
+            sender: bob,
+            token: tokenAddress,
+            spender: carol,
+            serialId: mintResponse.serialId
+        });
+
+        success = _doApproveNftViaHtsPrecompile(approveNftParams);
+        assertEq(success, false, "should have failed as bob does not own NFT with serialId");
+
+        approveNftParams = ApproveNftParams({
+            sender: alice,
+            token: tokenAddress,
+            spender: carol,
+            serialId: mintResponse.serialId
+        });
+
+        success = _doApproveNftViaHtsPrecompile(approveNftParams);
+        assertEq(success, true, "should have succeeded as alice does own NFT with serialId");
+    }
+
+    function test_ApproveDirectly() public {
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = KeyHelper.getSingleKey(KeyHelper.KeyType.SUPPLY, KeyHelper.KeyValueType.CONTRACT_ID, alice);
+        address tokenAddress = _createSimpleMockNonFungibleToken(alice, keys);
+
+        bool success;
+
+        MintResponse memory mintResponse;
+        MintParams memory mintParams;
+
+        mintParams = MintParams({
+            sender: alice,
+            token: tokenAddress,
+            mintAmount: 0
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        assertEq(mintResponse.success, true, "expected success since alice is supply key");
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, "bob should have associated with token");
+
+        ApproveNftParams memory approveNftParams;
+
+        approveNftParams = ApproveNftParams({
+            sender: bob,
+            token: tokenAddress,
+            spender: carol,
+            serialId: mintResponse.serialId
+        });
+
+        success = _doApproveNftDirectly(approveNftParams);
+        assertEq(success, false, "should have failed as bob does not own NFT with serialId");
+
+        approveNftParams = ApproveNftParams({
+            sender: alice,
+            token: tokenAddress,
+            spender: carol,
+            serialId: mintResponse.serialId
+        });
+
+        success = _doApproveNftDirectly(approveNftParams);
+        assertEq(success, true, "should have succeeded as alice does own NFT with serialId");
+    }
+
+    function test_TransferViaHtsPrecompile() public {
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = KeyHelper.getSingleKey(KeyHelper.KeyType.SUPPLY, KeyHelper.KeyValueType.CONTRACT_ID, alice);
+        address tokenAddress = _createSimpleMockNonFungibleToken(alice, keys);
+
+        bool success;
+        uint256 serialIdU256;
+
+        MintResponse memory mintResponse;
+        MintParams memory mintParams;
+
+        mintParams = MintParams({
+            sender: alice,
+            token: tokenAddress,
+            mintAmount: 0
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        serialIdU256 = uint64(mintResponse.serialId);
+
+        assertEq(mintResponse.success, true, "expected success since alice is supply key");
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, "bob should have associated with token");
+
+        TransferParams memory transferParams;
+
+        transferParams = TransferParams({
+            sender: bob,
+            token: tokenAddress,
+            from: alice,
+            to: carol,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, false, 'expected fail since bob does not own nft or have approval');
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: tokenAddress,
+            from: alice,
+            to: carol,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, false, 'expected fail since carol is not associated with nft');
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, true, 'expected success');
+    }
+
+    function test_TransferDirectly() public {
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = KeyHelper.getSingleKey(KeyHelper.KeyType.SUPPLY, KeyHelper.KeyValueType.CONTRACT_ID, alice);
+        address tokenAddress = _createSimpleMockNonFungibleToken(alice, keys);
+
+        bool success;
+        uint256 serialIdU256;
+
+        MintResponse memory mintResponse;
+        MintParams memory mintParams;
+
+        mintParams = MintParams({
+            sender: alice,
+            token: tokenAddress,
+            mintAmount: 0
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        serialIdU256 = uint64(mintResponse.serialId);
+
+        assertEq(mintResponse.success, true, "expected success since alice is supply key");
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, "bob should have associated with token");
+
+        TransferParams memory transferParams;
+
+        transferParams = TransferParams({
+            sender: bob,
+            token: tokenAddress,
+            from: alice,
+            to: carol,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, false, 'expected fail since bob does not own nft or have approval');
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: tokenAddress,
+            from: alice,
+            to: carol,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, false, 'expected fail since carol is not associated with nft');
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, true, 'expected success');
+    }
+
+    function test_TransferUsingAllowanceViaHtsPrecompile() public {
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = KeyHelper.getSingleKey(KeyHelper.KeyType.SUPPLY, KeyHelper.KeyValueType.CONTRACT_ID, alice);
+        address tokenAddress = _createSimpleMockNonFungibleToken(alice, keys);
+
+        bool success;
+        uint256 serialIdU256;
+
+        MintResponse memory mintResponse;
+        MintParams memory mintParams;
+
+        TransferParams memory transferParams;
+
+        ApproveNftParams memory approveNftParams;
+
+        mintParams = MintParams({
+            sender: alice,
+            token: tokenAddress,
+            mintAmount: 0
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        serialIdU256 = uint64(mintResponse.serialId);
+
+        assertEq(mintResponse.success, true, "expected success since alice is supply key");
+
+        transferParams = TransferParams({
+            sender: carol,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, false, 'expected fail since carol is not approved');
+
+        approveNftParams = ApproveNftParams({
+            sender: alice,
+            token: tokenAddress,
+            spender: carol,
+            serialId: mintResponse.serialId
+        });
+
+        _doApproveNftDirectly(approveNftParams);
+
+        transferParams = TransferParams({
+            sender: carol,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, false, 'expected fail since bob is not associated with nft');
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, "bob should have associated with token");
+
+        transferParams = TransferParams({
+            sender: carol,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, true, 'expected success');
+    }
+
+    function test_TransferUsingAllowanceDirectly() public {
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = KeyHelper.getSingleKey(KeyHelper.KeyType.SUPPLY, KeyHelper.KeyValueType.CONTRACT_ID, alice);
+        address tokenAddress = _createSimpleMockNonFungibleToken(alice, keys);
+
+        bool success;
+        uint256 serialIdU256;
+
+        MintResponse memory mintResponse;
+        MintParams memory mintParams;
+
+        TransferParams memory transferParams;
+
+        ApproveNftParams memory approveNftParams;
+
+        mintParams = MintParams({
+            sender: alice,
+            token: tokenAddress,
+            mintAmount: 0
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        serialIdU256 = uint64(mintResponse.serialId);
+
+        assertEq(mintResponse.success, true, "expected success since alice is supply key");
+
+        transferParams = TransferParams({
+            sender: carol,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferViaHtsPrecompile(transferParams);
+        assertEq(success, false, 'expected fail since carol is not approved');
+
+        approveNftParams = ApproveNftParams({
+            sender: alice,
+            token: tokenAddress,
+            spender: carol,
+            serialId: mintResponse.serialId
+        });
+
+        _doApproveNftDirectly(approveNftParams);
+
+        transferParams = TransferParams({
+            sender: carol,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, false, 'expected fail since bob is not associated with nft');
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, "bob should have associated with token");
+
+        transferParams = TransferParams({
+            sender: carol,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, true, 'expected success');
+    }
+
+    /// @dev there is no test_CanBurnDirectly as the ERC20 standard does not typically allow direct burns
+    function test_CanBurnViaHtsPrecompile() public {
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](1);
+        keys[0] = KeyHelper.getSingleKey(KeyHelper.KeyType.SUPPLY, KeyHelper.KeyValueType.CONTRACT_ID, alice);
+        address tokenAddress = _createSimpleMockNonFungibleToken(alice, keys);
+
+        bool success;
+        uint256 serialIdU256;
+
+        MintResponse memory mintResponse;
+        MintParams memory mintParams;
+        BurnParams memory burnParams;
+
+        mintParams = MintParams({
+            sender: alice,
+            token: tokenAddress,
+            mintAmount: 0
+        });
+
+        mintResponse = _doMintViaHtsPrecompile(mintParams);
+        serialIdU256 = uint64(mintResponse.serialId);
+
+        assertEq(mintResponse.success, true, "expected success since alice is supply key");
+
+        success = _doAssociateViaHtsPrecompile(bob, tokenAddress);
+        assertEq(success, true, "bob should have associated with token");
+
+        TransferParams memory transferParams;
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: tokenAddress,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, true, 'expected success');
+
+        burnParams = BurnParams({
+            sender: alice,
+            token: tokenAddress,
+            amountOrSerialNumber: mintResponse.serialId
+        });
+
+        (success, ) = _doBurnViaHtsPrecompile(burnParams);
+        assertEq(success, false, "burn should fail, since treasury does not own nft");
+
+        transferParams = TransferParams({
+            sender: bob,
+            token: tokenAddress,
+            from: bob,
+            to: alice,
+            amountOrSerialNumber: serialIdU256
+        });
+
+        (success, ) = _doTransferDirectly(transferParams);
+        assertEq(success, true, 'expected success');
+
+        burnParams = BurnParams({
+            sender: alice,
+            token: tokenAddress,
+            amountOrSerialNumber: mintResponse.serialId
+        });
+
+        (success, ) = _doBurnViaHtsPrecompile(burnParams);
+        assertEq(success, true, "burn should succeed");
+    }
+
+    // negative cases
+    function test_CannotApproveIfSpenderNotAssociated() public {
+        /// @dev already demonstrated in some of the postive test cases
+        // cannot approve spender if spender is not associated with HederaNonFungibleToken BOTH directly and viaHtsPrecompile
+    }
+
+    function test_CannotTransferIfRecipientNotAssociated() public {
+        /// @dev already demonstrated in some of the postive test cases
+        // cannot transfer to recipient if recipient is not associated with HederaNonFungibleToken BOTH directly and viaHtsPrecompile
+    }
+}
+
+// forge test --match-contract HederaNonFungibleTokenTest --match-test test_TransferUsingAllowanceDirectly -vv
+// forge test --match-contract HederaNonFungibleTokenTest -vv

--- a/tools/foundry-example/test/SimpleVault.t.sol
+++ b/tools/foundry-example/test/SimpleVault.t.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
+
+import "../src/SimpleVault.sol";
+import { ExchangeRateUtils } from './utils/ExchangeRateUtils.sol';
+import { HederaTokenUtils } from './utils/HederaTokenUtils.sol';
+import { HederaFungibleTokenUtils } from './utils/HederaFungibleTokenUtils.sol';
+
+contract SimpleVaultTest is HederaFungibleTokenUtils, ExchangeRateUtils {
+
+    SimpleVault public simpleVault;
+    address public simpleVaultAddress;
+    address tokenA;
+    address tokenB;
+
+    // setUp is executed before each and every test function
+    function setUp() public {
+        _setUpHtsPrecompileMock();
+        _setUpExchangeRatePrecompileMock();
+        _setUpAccounts();
+
+        simpleVault = new SimpleVault();
+        simpleVaultAddress = address(simpleVault);
+
+        IHederaTokenService.TokenKey[] memory keys = new IHederaTokenService.TokenKey[](0);
+        tokenA = _createSimpleMockFungibleToken(alice, keys);
+        tokenB = _createSimpleMockFungibleToken(alice, keys);
+    }
+
+    function _depositToSimpleVault(address sender, address token, uint64 amount) internal {
+
+        vm.startPrank(sender, sender);
+
+        uint amountU256 = uint(amount);
+
+        ERC20 erc20Token = ERC20(token);
+
+        uint senderStartingTokenBalance = erc20Token.balanceOf(sender);
+        uint senderStartingVaultBalance = simpleVault.vaultBalances(token, sender);
+
+        simpleVault.deposit{value: 2e8}(token, amount);
+
+        uint senderFinalTokenBalance = erc20Token.balanceOf(sender);
+        uint senderFinalVaultBalance = simpleVault.vaultBalances(token, sender);
+
+        assertEq(senderStartingTokenBalance - amountU256, senderFinalTokenBalance, "expected spender token balance to decrease after deposit");
+        assertEq(senderStartingVaultBalance + amountU256, senderFinalVaultBalance, "expected spender vault balance to increase after deposit");
+
+        vm.stopPrank();
+
+    }
+
+    function _withdrawFromSimpleVault(address sender, address token, uint64 amount) internal {
+
+        vm.startPrank(sender, sender);
+
+        uint amountU256 = uint(amount);
+
+        ERC20 erc20Token = ERC20(token);
+
+        uint senderStartingTokenBalance = erc20Token.balanceOf(sender);
+        uint senderStartingVaultBalance = simpleVault.vaultBalances(token, sender);
+
+        simpleVault.withdraw{value: 1e8}(token, amount);
+
+        uint senderFinalTokenBalance = erc20Token.balanceOf(sender);
+        uint senderFinalVaultBalance = simpleVault.vaultBalances(token, sender);
+
+        assertEq(senderStartingTokenBalance + amountU256, senderFinalTokenBalance, "expected spender token balance to increase after withdraw");
+        assertEq(senderStartingVaultBalance - amountU256, senderFinalVaultBalance, "expected spender vault balance to decrease after withdraw");
+
+        vm.stopPrank();
+
+    }
+
+    struct DepositAndWithdrawParams {
+        address sender;
+        address depositToken;
+        uint64 depositAmount;
+        address withdrawToken;
+        uint64 withdrawAmount;
+    }
+
+    function _depositAndWithdraw(DepositAndWithdrawParams memory depositAndWithdrawParams) internal {
+
+        vm.startPrank(depositAndWithdrawParams.sender, depositAndWithdrawParams.sender);
+
+        uint depositAmountU256 = uint(depositAndWithdrawParams.depositAmount);
+        uint withdrawAmountU256 = uint(depositAndWithdrawParams.withdrawAmount);
+
+        ERC20 erc20DepositToken = ERC20(depositAndWithdrawParams.depositToken);
+        ERC20 erc20WithdrawToken = ERC20(depositAndWithdrawParams.withdrawToken);
+
+        uint senderStartingDepositTokenBalance = erc20DepositToken.balanceOf(depositAndWithdrawParams.sender);
+        uint senderStartingDepositVaultBalance = simpleVault.vaultBalances(depositAndWithdrawParams.depositToken, depositAndWithdrawParams.sender);
+
+        uint senderStartingWithdrawTokenBalance = erc20WithdrawToken.balanceOf(depositAndWithdrawParams.sender);
+        uint senderStartingWithdrawVaultBalance = simpleVault.vaultBalances(depositAndWithdrawParams.withdrawToken, depositAndWithdrawParams.sender);
+
+        simpleVault.depositAndWithdraw{value: 3e8}(depositAndWithdrawParams.depositToken, depositAndWithdrawParams.depositAmount, depositAndWithdrawParams.withdrawToken, depositAndWithdrawParams.withdrawAmount);
+
+        uint senderFinalDepositTokenBalance = erc20DepositToken.balanceOf(depositAndWithdrawParams.sender);
+        uint senderFinalDepositVaultBalance = simpleVault.vaultBalances(depositAndWithdrawParams.depositToken, depositAndWithdrawParams.sender);
+
+        uint senderFinalWithdrawTokenBalance = erc20WithdrawToken.balanceOf(depositAndWithdrawParams.sender);
+        uint senderFinalWithdrawVaultBalance = simpleVault.vaultBalances(depositAndWithdrawParams.withdrawToken, depositAndWithdrawParams.sender);
+
+        assertEq(senderStartingDepositTokenBalance - depositAmountU256, senderFinalDepositTokenBalance, "expected spender token balance to decrease after deposit");
+        assertEq(senderStartingDepositVaultBalance + depositAmountU256, senderFinalDepositVaultBalance, "expected spender vault balance to increase after deposit");
+
+        assertEq(senderStartingWithdrawTokenBalance + withdrawAmountU256, senderFinalWithdrawTokenBalance, "expected spender token balance to increase after withdraw");
+        assertEq(senderStartingWithdrawVaultBalance - withdrawAmountU256, senderFinalWithdrawVaultBalance, "expected spender vault balance to decrease after withdraw");
+
+        vm.stopPrank();
+
+    }
+
+    // positive cases:
+    function test_Deposit() public {
+
+        address token = tokenA;
+        _doAssociateViaHtsPrecompile(bob, token);
+
+        uint amount = 1e6;
+
+        TransferParams memory transferParams;
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: token,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: amount
+        });
+
+        _doTransferDirectly(transferParams);
+
+        _doAssociateViaHtsPrecompile(simpleVaultAddress, token);
+
+        _doApproveDirectly(bob, token, simpleVaultAddress, amount);
+
+        amount = 1e4;
+        _depositToSimpleVault(bob, token, uint64(amount));
+
+    }
+
+    function test_Withdraw() public {
+        address token = tokenA;
+
+        _doAssociateViaHtsPrecompile(bob, token);
+
+        uint amount = 1e6;
+        TransferParams memory transferParams;
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: token,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: amount
+        });
+
+        _doTransferDirectly(transferParams);
+
+        _doAssociateViaHtsPrecompile(simpleVaultAddress, token);
+
+        _doApproveDirectly(bob, token, simpleVaultAddress, amount);
+
+        _depositToSimpleVault(bob, token, uint64(amount)); // first deposit before withdraw
+
+        uint withdrawAmount = 1e4;
+
+        _withdrawFromSimpleVault(bob, token, uint64(withdrawAmount));
+    }
+
+    function test_DepositAndWithdraw() public {
+        address depositToken = tokenA;
+        address withdrawToken = tokenB;
+
+        _doAssociateViaHtsPrecompile(bob, depositToken);
+        _doAssociateViaHtsPrecompile(bob, withdrawToken);
+
+        uint amount = 1e6;
+
+        TransferParams memory transferParams;
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: depositToken,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: amount
+        });
+
+        _doTransferDirectly(transferParams);
+
+        transferParams = TransferParams({
+            sender: alice,
+            token: withdrawToken,
+            from: alice,
+            to: bob,
+            amountOrSerialNumber: amount
+        });
+
+        _doTransferDirectly(transferParams);
+
+        _doAssociateViaHtsPrecompile(simpleVaultAddress, depositToken);
+        _doAssociateViaHtsPrecompile(simpleVaultAddress, withdrawToken);
+
+        _doApproveDirectly(bob, depositToken, simpleVaultAddress, 1e18);
+        _doApproveDirectly(bob, withdrawToken, simpleVaultAddress, 1e18);
+
+        _depositToSimpleVault(bob, withdrawToken, uint64(amount)); // first deposit before withdraw
+
+        uint depositAmount = 1e4;
+        uint withdrawAmount = 1e4;
+        DepositAndWithdrawParams memory depositAndWithdrawParams = DepositAndWithdrawParams({
+            sender: bob,
+            depositToken: depositToken,
+            depositAmount: uint64(depositAmount),
+            withdrawToken: withdrawToken,
+            withdrawAmount: uint64(withdrawAmount)
+        });
+
+        _depositAndWithdraw(depositAndWithdrawParams);
+    }
+
+    // negative cases:
+    function test_CannotDepositIfNotAssociated() public {
+    }
+
+    function test_CannotWithdrawIfNotAssociated() public {
+    }
+}
+
+// forge test --match-contract SimpleVaultTest --match-test test_Withdraw -vv

--- a/tools/foundry-example/test/UtilPrecompileMock.t.sol
+++ b/tools/foundry-example/test/UtilPrecompileMock.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import './utils/UtilUtils.sol';
+
+contract UtilPrecompileMockTest is UtilUtils {
+
+    mapping(bytes32 => bool) private seeds; // use mapping over list as it's much faster to index
+
+    // setUp is executed before each and every test function
+    function setUp() public {
+        _setUpUtilPrecompileMock();
+        _setUpAccounts();
+    }
+
+    function test_CallPseudoRandomSeed() public {
+
+        uint256 iterations = 10000;
+
+        address sender = alice;
+        bytes32 seed;
+
+        for (uint256 i = 0; i < iterations; i++) {
+            seed = _doCallPseudorandomSeed(sender);
+
+            if (seeds[seed]) {
+                revert("seed already exists");
+            }
+
+            seeds[seed] = true;
+
+            sender = _getAccount(uint256(seed) % NUM_OF_ACCOUNTS);
+        }
+    }
+
+}
+
+// forge test --match-contract UtilPrecompileMockTest -vv

--- a/tools/foundry-example/test/libraries/Constants.sol
+++ b/tools/foundry-example/test/libraries/Constants.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+abstract contract Constants {
+  address internal constant HTS_PRECOMPILE = address(0x167);
+  address internal constant EXCHANGE_RATE_PRECOMPILE = address(0x168);
+  address internal constant UTIL_PRECOMPILE = address(0x168);
+
+  address internal constant ADDRESS_ZERO = address(0);
+}

--- a/tools/foundry-example/test/mocks/exchange-rate-precompile/ExchangeRatePrecompileMock.sol
+++ b/tools/foundry-example/test/mocks/exchange-rate-precompile/ExchangeRatePrecompileMock.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'hedera-smart-contracts/exchange-rate-precompile/IExchangeRate.sol';
+
+contract ExchangeRatePrecompileMock is IExchangeRate {
+
+    // 1e8 tinybars = 1 HBAR
+    // 1e8 tinycents = 1 cent = 0.01 USD
+
+    // HBAR/USD rate in tinybars/tinycents
+    uint256 private rate; // 1e8 / 10; // Initial rate of 1e8 tinybars/10 tinycents, equivalent to $0.10/1 HBAR
+    /// @dev it appears that contracts that are etched do NOT have any starting state i.e. all state is initialised to the default
+    ///      hence "rate" is not initialised to 1e7 here, but updateRate is called after the ExchangeRatePrecompileMock is etched(using vm.etch) onto the EXCHANGE_RATE_PRECOMPILE address
+
+    function tinycentsToTinybars(uint256 tinycents) external override returns (uint256) {
+        require(rate > 0, "Rate must be greater than 0");
+        return (tinycents * rate) / 1e8;
+    }
+
+    function tinybarsToTinycents(uint256 tinybars) external override returns (uint256) {
+        require(rate > 0, "Rate must be greater than 0");
+        return (tinybars * 1e8) / rate;
+        // (1e8 * 1e8) / (1e8 / 12) = (12*1e8) tinycents
+    }
+
+    function updateRate(uint256 newRate) external {
+        require(newRate > 0, "New rate must be greater than 0");
+        rate = newRate;
+    }
+
+    function getCurrentRate() external view returns (uint256) {
+        return rate;
+    }
+}

--- a/tools/foundry-example/test/mocks/hts-precompile/HederaFungibleToken.sol
+++ b/tools/foundry-example/test/mocks/hts-precompile/HederaFungibleToken.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'openzeppelin-contracts/contracts/token/ERC20/ERC20.sol';
+
+import 'hedera-smart-contracts/hts-precompile/HederaResponseCodes.sol';
+import 'hedera-smart-contracts/hts-precompile/IHederaTokenService.sol';
+import './HtsPrecompileMock.sol';
+import '../../libraries/Constants.sol';
+
+contract HederaFungibleToken is ERC20, Constants {
+    error HtsPrecompileError(int64 responseCode);
+    HtsPrecompileMock internal constant HtsPrecompile = HtsPrecompileMock(HTS_PRECOMPILE);
+
+    bool public constant IS_FUNGIBLE = true; /// @dev if HederaNonFungibleToken then false
+    uint8 internal immutable _decimals;
+
+    constructor(
+        IHederaTokenService.FungibleTokenInfo memory _fungibleTokenInfo
+    ) ERC20(_fungibleTokenInfo.tokenInfo.token.name, _fungibleTokenInfo.tokenInfo.token.symbol) {
+        HtsPrecompile.registerHederaFungibleToken(msg.sender, _fungibleTokenInfo);
+        _decimals = uint8(uint32(_fungibleTokenInfo.decimals));
+        address treasury = _fungibleTokenInfo.tokenInfo.token.treasury;
+        _mint(treasury, uint(uint64(_fungibleTokenInfo.tokenInfo.totalSupply)));
+    }
+
+    /// @dev the HtsPrecompileMock should do precheck validation before calling any function with this modifier
+    ///      the HtsPrecompileMock has priveleged access to do certain operations
+    modifier onlyHtsPrecompile() {
+        require(msg.sender == HTS_PRECOMPILE, 'NOT_HTS_PRECOMPILE');
+        _;
+    }
+
+    // public/external state-changing functions:
+    // onlyHtsPrecompile functions:
+    /// @dev mints "amount" to treasury
+    function mintRequestFromHtsPrecompile(int64 amount) external onlyHtsPrecompile {
+        (, IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo) = HtsPrecompile.getFungibleTokenInfo(
+            address(this)
+        );
+        address treasury = fungibleTokenInfo.tokenInfo.token.treasury;
+        _mint(treasury, uint64(amount));
+    }
+
+    /// @dev burns "amount" from treasury
+    function burnRequestFromHtsPrecompile(int64 amount) external onlyHtsPrecompile {
+        (, IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo) = HtsPrecompile.getFungibleTokenInfo(
+            address(this)
+        );
+        address treasury = fungibleTokenInfo.tokenInfo.token.treasury;
+        _burn(treasury, uint64(amount));
+    }
+
+    /// @dev transfers "amount" from "from" to "to"
+    function transferRequestFromHtsPrecompile(bool isRequestFromOwner, address spender, address from, address to, uint256 amount) external onlyHtsPrecompile returns (int64 responseCode) {
+        if (!isRequestFromOwner) {
+            _spendAllowance(from, spender, amount);
+        }
+        _transfer(from, to, amount);
+
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    /// @dev gives "spender" an allowance of "amount" for "account"
+    function approveRequestFromHtsPrecompile(
+        address account,
+        address spender,
+        uint256 amount
+    ) external onlyHtsPrecompile {
+        _approve(account, spender, amount);
+    }
+
+    // standard ERC20 functions overriden for HtsPrecompileMock prechecks:
+    function approve(address spender, uint256 amount) public override returns (bool) {
+        int64 responseCode = HtsPrecompile.preApprove(msg.sender, spender, amount);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert HtsPrecompileError(responseCode);
+        }
+        return super.approve(spender, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        int64 responseCode = HtsPrecompile.preTransfer(msg.sender, from, to, amount);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert HtsPrecompileError(responseCode);
+        }
+        return super.transferFrom(from, to, amount);
+    }
+
+    function transfer(address to, uint256 amount) public virtual override returns (bool) {
+        int64 responseCode = HtsPrecompile.preTransfer(ADDRESS_ZERO, msg.sender, to, amount);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert HtsPrecompileError(responseCode);
+        }
+        return super.transfer(to, amount);
+    }
+
+    // standard ERC20 overriden functions
+    function decimals() public view override returns (uint8) {
+        return _decimals;
+    }
+}

--- a/tools/foundry-example/test/mocks/hts-precompile/HederaNonFungibleToken.sol
+++ b/tools/foundry-example/test/mocks/hts-precompile/HederaNonFungibleToken.sol
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'openzeppelin-contracts/contracts/token/ERC721/ERC721.sol';
+
+import 'hedera-smart-contracts/hts-precompile/HederaResponseCodes.sol';
+import 'hedera-smart-contracts/hts-precompile/IHederaTokenService.sol';
+import './HtsPrecompileMock.sol';
+import '../../libraries/Constants.sol';
+
+contract HederaNonFungibleToken is ERC721, Constants {
+    error HtsPrecompileError(int64 responseCode);
+
+    HtsPrecompileMock internal constant HtsPrecompile = HtsPrecompileMock(HTS_PRECOMPILE);
+
+    bool public constant IS_FUNGIBLE = false; /// @dev if HederaFungibleToken then true
+
+    struct NFTCounter {
+        int64 minted;
+        int64 burned;
+    }
+
+    NFTCounter internal nftCount;
+
+    /// @dev NonFungibleTokenInfo is for each NFT(with a unique serial number) that is minted; however TokenInfo covers the common token info across all instances
+    constructor(
+        IHederaTokenService.TokenInfo memory _nftTokenInfo
+    ) ERC721(_nftTokenInfo.token.name, _nftTokenInfo.token.symbol) {
+        address sender = msg.sender;
+        HtsPrecompile.registerHederaNonFungibleToken(sender, _nftTokenInfo);
+    }
+
+    /// @dev the HtsPrecompileMock should do precheck validation before calling any function with this modifier
+    ///      the HtsPrecompileMock has priveleged access to do certain operations
+    modifier onlyHtsPrecompile() {
+        require(msg.sender == HTS_PRECOMPILE, 'NOT_HTS_PRECOMPILE');
+        _;
+    }
+
+    // public/external state-changing functions:
+    // onlyHtsPrecompile functions:
+    function mintRequestFromHtsPrecompile(
+        bytes[] memory metadata
+    ) external onlyHtsPrecompile returns (int64 newTotalSupply, int64 serialNumber) {
+        (, IHederaTokenService.TokenInfo memory nftTokenInfo) = HtsPrecompile.getTokenInfo(
+            address(this)
+        );
+        address treasury = nftTokenInfo.token.treasury;
+
+        serialNumber = ++nftCount.minted; // the first nft that is minted has serialNumber: 1
+        _mint(treasury, uint64(serialNumber));
+
+        newTotalSupply = int64(int256(totalSupply()));
+    }
+
+    function burnRequestFromHtsPrecompile(
+        int64[] calldata tokenIds
+    ) external onlyHtsPrecompile returns (int64 newTotalSupply) {
+        int64 burnCount = int64(uint64(tokenIds.length));
+        nftCount.burned = nftCount.burned + burnCount;
+
+        for (uint256 i = 0; i < uint64(burnCount); i++) {
+            uint256 tokenId = uint64(tokenIds[i]);
+            _burn(tokenId);
+        }
+
+        newTotalSupply = int64(int256(totalSupply()));
+    }
+
+    /// @dev transfers "amount" from "from" to "to"
+    function transferRequestFromHtsPrecompile(
+        bool isRequestFromOwner,
+        address spender,
+        address from,
+        address to,
+        uint256 tokenId
+    ) external onlyHtsPrecompile returns (int64 responseCode) {
+        bool isSpenderApproved = _isApprovedOrOwner(spender, tokenId);
+        if (!isSpenderApproved) {
+            return HederaResponseCodes.INSUFFICIENT_TOKEN_BALANCE;
+        }
+
+        _transfer(from, to, tokenId);
+        responseCode = HederaResponseCodes.SUCCESS;
+        // if (getApproved(tokenId) == spender) {
+        //     _transfer(from, to, tokenId);
+        //     responseCode = HederaResponseCodes.SUCCESS;
+        // } else {
+        //     responseCode = HederaResponseCodes.INSUFFICIENT_TOKEN_BALANCE;
+        // }
+    }
+
+    /// @dev unlike fungible/ERC20 tokens this only allows for a single spender to be approved at any one time
+    function approveRequestFromHtsPrecompile(address spender, int64 tokenId) external onlyHtsPrecompile {
+        _approve(spender, uint64(tokenId));
+    }
+
+    function setApprovalForAllFromHtsPrecompile(
+        address owner,
+        address operator,
+        bool approved
+    ) external onlyHtsPrecompile {
+        _setApprovalForAll(owner, operator, approved);
+    }
+
+    // standard ERC721 functions overriden for HtsPrecompileMock prechecks:
+    function approve(address to, uint256 tokenId) public override {
+        address sender = msg.sender;
+        address spender = to;
+        int64 responseCode = HtsPrecompile.preApprove(sender, spender, tokenId);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert HtsPrecompileError(responseCode);
+        }
+
+        // TODO: do checks on approval prior to calling approval to avoid reverting with the OpenZeppelin error strings
+        // this checks can be done in the HtsPrecompile.pre{Action} functions and ultimately in the _precheck{Action} internal functions
+        return super.approve(to, tokenId);
+    }
+
+    function setApprovalForAll(address operator, bool approved) public override {
+        address sender = msg.sender;
+        int64 responseCode = HtsPrecompile.preSetApprovalForAll(sender, operator, approved);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert HtsPrecompileError(responseCode);
+        }
+        return super.setApprovalForAll(operator, approved);
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) public override {
+        address sender = msg.sender;
+        int64 responseCode = HtsPrecompile.preTransfer(sender, from, to, tokenId);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert HtsPrecompileError(responseCode);
+        }
+        return super.transferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) public override {
+        address sender = msg.sender;
+        int64 responseCode = HtsPrecompile.preTransfer(sender, from, to, tokenId);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert HtsPrecompileError(responseCode);
+        }
+        return super.safeTransferFrom(from, to, tokenId);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data) public override {
+        address sender = msg.sender;
+        int64 responseCode = HtsPrecompile.preTransfer(sender, from, to, tokenId);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert HtsPrecompileError(responseCode);
+        }
+        return super.safeTransferFrom(from, to, tokenId, data);
+    }
+
+    // Additional(not in IHederaTokenService or in IERC721) public/external view functions:
+    function totalSupply() public view returns (uint256) {
+        return uint64(nftCount.minted - nftCount.burned);
+    }
+
+    function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {
+        return _isApprovedOrOwner(spender, tokenId);
+    }
+
+    function mintCount() external view returns (int64 minted) {
+        minted = nftCount.minted;
+    }
+
+    function burnCount() external view returns (int64 burned) {
+        burned = nftCount.burned;
+    }
+
+}

--- a/tools/foundry-example/test/mocks/hts-precompile/HtsPrecompileMock.sol
+++ b/tools/foundry-example/test/mocks/hts-precompile/HtsPrecompileMock.sol
@@ -1,0 +1,1392 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'forge-std/console.sol';
+
+import 'hedera-smart-contracts/hts-precompile/HederaResponseCodes.sol';
+import 'hedera-smart-contracts/hts-precompile/IHederaTokenService.sol';
+import 'hedera-smart-contracts/hts-precompile/KeyHelper.sol';
+import './HederaFungibleToken.sol';
+import './HederaNonFungibleToken.sol';
+import '../../../src/NoDelegateCall.sol';
+import '../../libraries/Constants.sol';
+
+contract HtsPrecompileMock is NoDelegateCall, IHederaTokenService, KeyHelper {
+
+    error HtsPrecompileError(int64 responseCode);
+
+    /// @dev only for Fungible tokens
+    // Fungible token -> FungibleTokenInfo
+    mapping(address => FungibleTokenInfo) internal _fungibleTokenInfos;
+    // Fungible token -> _isFungible
+    mapping(address => bool) internal _isFungible;
+
+    /// @dev only for NonFungibleToken
+    // NFT token -> TokenInfo; TokenInfo is used instead of NonFungibleTokenInfo as the former is common to all NFT instances whereas the latter is for a specific NFT instance(uniquely identified by its serialNumber)
+    mapping(address => TokenInfo) internal _nftTokenInfos;
+    // NFT token -> serialNumber -> PartialNonFungibleTokenInfo
+    mapping(address => mapping(int64 => PartialNonFungibleTokenInfo)) internal _partialNonFungibleTokenInfos;
+    // NFT token -> _isNonFungible
+    mapping(address => bool) internal _isNonFungible;
+
+    /// @dev common to both NFT and Fungible HTS tokens
+    // HTS token -> account -> isAssociated
+    mapping(address => mapping(address => bool)) internal _association;
+    // HTS token -> account -> isKyced
+    mapping(address => mapping(address => bool)) internal _kyc; // is KYCed is the positive case(i.e. explicitly requires KYC approval); see defaultKycStatus
+    // HTS token -> account -> isFrozen
+    mapping(address => mapping(address => bool)) internal _unfrozen; // is unfrozen is positive case(i.e. explicitly requires being unfrozen); see freezeDefault
+    // HTS token -> keyType -> value e.g. tokenId -> 16 -> 0x123 means that the SUPPLY key for tokenId is account 0x123
+    mapping(address => mapping(uint => address)) internal _tokenKeys; /// @dev faster access then getting keys via {FungibleTokenInfo|NonFungibleTokenInfo}#TokenInfo.HederaToken.tokenKeys[]; however only supports KeyValueType.CONTRACT_ID
+
+    // this struct avoids duplicating common NFT data, in particular IHederaTokenService.NonFungibleTokenInfo.tokenInfo
+    struct PartialNonFungibleTokenInfo {
+        address ownerId;
+        int64 creationTime;
+        bytes metadata;
+        address spenderId;
+    }
+
+    constructor() NoDelegateCall(HTS_PRECOMPILE) {}
+
+    // peripheral internal helpers:
+    // Concatenate metadata bytes arrays
+    function _concatenate(bytes[] memory metadata) internal pure returns (bytes memory) {
+        // Calculate the total length of concatenated bytes
+        uint totalLength = 0;
+        for (uint i = 0; i < metadata.length; i++) {
+            totalLength += metadata[i].length;
+        }
+
+        // Create a new bytes variable with the total length
+        bytes memory result = new bytes(totalLength);
+
+        // Concatenate bytes from metadata array into result
+        uint currentIndex = 0;
+        for (uint i = 0; i < metadata.length; i++) {
+            for (uint j = 0; j < metadata[i].length; j++) {
+                result[currentIndex] = metadata[i][j];
+                currentIndex++;
+            }
+        }
+
+        return result;
+    }
+
+    modifier onlyHederaToken() {
+        require(_isToken(msg.sender), 'NOT_HEDERA_TOKEN');
+        _;
+    }
+
+    // Check if the address is a token
+    function _isToken(address token) internal view returns (bool) {
+        return _isFungible[token] || _isNonFungible[token];
+    }
+
+    /// @dev Hedera appears to have phased out authorization from the EOA with https://github.com/hashgraph/hedera-services/releases/tag/v0.36.0
+    function _isAccountOriginOrSender(address account) internal view returns (bool) {
+        return _isAccountOrigin(account) || _isAccountSender(account);
+    }
+
+    function _isAccountOrigin(address account) internal view returns (bool) {
+        return account == tx.origin;
+    }
+
+    function _isAccountSender(address account) internal view returns (bool) {
+        return account == msg.sender;
+    }
+
+    // Get the treasury account for a token
+    function _getTreasuryAccount(address token) internal view returns (address treasury) {
+        if (_isFungible[token]) {
+            treasury = _fungibleTokenInfos[token].tokenInfo.token.treasury;
+        } else {
+            treasury = _nftTokenInfos[token].token.treasury;
+        }
+    }
+
+    // Check if the treasury signature is valid
+    function _hasTreasurySig(address token) internal view returns (bool validKey, bool noKey) {
+        address key = _getTreasuryAccount(token);
+        noKey = key == ADDRESS_ZERO;
+        validKey = _isAccountSender(key);
+    }
+
+    // Check if the admin key signature is valid
+    function _hasAdminKeySig(address token) internal view returns (bool validKey, bool noKey) {
+        address key = getKey(token, KeyHelper.KeyType.ADMIN);
+        noKey = key == ADDRESS_ZERO;
+        validKey = _isAccountSender(key);
+    }
+
+    // Check if the kyc key signature is valid
+    function _hasKycKeySig(address token) internal view returns (bool validKey, bool noKey) {
+        address key = getKey(token, KeyHelper.KeyType.KYC);
+        noKey = key == ADDRESS_ZERO;
+        validKey = _isAccountSender(key);
+    }
+
+    // Check if the freeze key signature is valid
+    function _hasFreezeKeySig(address token) internal view returns (bool validKey, bool noKey) {
+        address key = getKey(token, KeyHelper.KeyType.FREEZE);
+        noKey = key == ADDRESS_ZERO;
+        validKey = _isAccountSender(key);
+    }
+
+    // Check if the wipe key signature is valid
+    function _hasWipeKeySig(address token) internal view returns (bool validKey, bool noKey) {
+        address key = getKey(token, KeyHelper.KeyType.WIPE);
+        noKey = key == ADDRESS_ZERO;
+        validKey = _isAccountSender(key);
+    }
+
+    // Check if the supply key signature is valid
+    function _hasSupplyKeySig(address token) internal view returns (bool validKey, bool noKey) {
+        address key = getKey(token, KeyHelper.KeyType.SUPPLY);
+        noKey = key == ADDRESS_ZERO;
+        validKey = _isAccountSender(key);
+    }
+
+    // Check if the fee schedule key signature is valid
+    function _hasFeeScheduleKeySig(address token) internal view returns (bool validKey, bool noKey) {
+        address key = getKey(token, KeyHelper.KeyType.FEE);
+        noKey = key == ADDRESS_ZERO;
+        validKey = _isAccountSender(key);
+    }
+
+    // Check if the pause key signature is valid
+    function _hasPauseKeySig(address token) internal view returns (bool validKey, bool noKey) {
+        address key = getKey(token, KeyHelper.KeyType.PAUSE);
+        noKey = key == ADDRESS_ZERO;
+        validKey = _isAccountSender(key);
+    }
+
+    function _setFungibleTokenInfo(FungibleTokenInfo memory fungibleTokenInfo) internal returns (address treasury) {
+        address tokenAddress = msg.sender;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.name = fungibleTokenInfo.tokenInfo.token.name;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.symbol = fungibleTokenInfo.tokenInfo.token.symbol;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.treasury = fungibleTokenInfo.tokenInfo.token.treasury;
+
+        treasury = fungibleTokenInfo.tokenInfo.token.treasury;
+
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.memo = fungibleTokenInfo.tokenInfo.token.memo;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.tokenSupplyType = fungibleTokenInfo
+            .tokenInfo
+            .token
+            .tokenSupplyType;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.maxSupply = fungibleTokenInfo.tokenInfo.token.maxSupply;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.freezeDefault = fungibleTokenInfo
+            .tokenInfo
+            .token
+            .freezeDefault;
+
+        // Copy the tokenKeys array
+        uint256 length = fungibleTokenInfo.tokenInfo.token.tokenKeys.length;
+        for (uint256 i = 0; i < length; i++) {
+            TokenKey memory tokenKey = fungibleTokenInfo.tokenInfo.token.tokenKeys[i];
+            _fungibleTokenInfos[tokenAddress].tokenInfo.token.tokenKeys.push(tokenKey);
+
+            /// @dev contractId can in fact be any address including an EOA address
+            ///      The KeyHelper lists 5 types for KeyValueType; however only CONTRACT_ID is considered
+            _tokenKeys[tokenAddress][tokenKey.keyType] = tokenKey.key.contractId;
+        }
+
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.expiry.second = fungibleTokenInfo
+            .tokenInfo
+            .token
+            .expiry
+            .second;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.expiry.autoRenewAccount = fungibleTokenInfo
+            .tokenInfo
+            .token
+            .expiry
+            .autoRenewAccount;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.token.expiry.autoRenewPeriod = fungibleTokenInfo
+            .tokenInfo
+            .token
+            .expiry
+            .autoRenewPeriod;
+
+        _fungibleTokenInfos[tokenAddress].tokenInfo.totalSupply = fungibleTokenInfo.tokenInfo.totalSupply;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.deleted = fungibleTokenInfo.tokenInfo.deleted;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.defaultKycStatus = fungibleTokenInfo.tokenInfo.defaultKycStatus;
+        _fungibleTokenInfos[tokenAddress].tokenInfo.pauseStatus = fungibleTokenInfo.tokenInfo.pauseStatus;
+
+        // Handle copying of other arrays (fixedFees, fractionalFees, and royaltyFees) if needed
+
+        _fungibleTokenInfos[tokenAddress].tokenInfo.ledgerId = fungibleTokenInfo.tokenInfo.ledgerId;
+        _fungibleTokenInfos[tokenAddress].decimals = fungibleTokenInfo.decimals;
+    }
+
+    function _setNftTokenInfo(TokenInfo memory nftTokenInfo) internal returns (address treasury) {
+        address tokenAddress = msg.sender;
+        _nftTokenInfos[tokenAddress].token.name = nftTokenInfo.token.name;
+        _nftTokenInfos[tokenAddress].token.symbol = nftTokenInfo.token.symbol;
+        _nftTokenInfos[tokenAddress].token.treasury = nftTokenInfo.token.treasury;
+
+        treasury = nftTokenInfo.token.treasury;
+
+        _nftTokenInfos[tokenAddress].token.memo = nftTokenInfo.token.memo;
+        _nftTokenInfos[tokenAddress].token.tokenSupplyType = nftTokenInfo.token.tokenSupplyType;
+        _nftTokenInfos[tokenAddress].token.maxSupply = nftTokenInfo.token.maxSupply;
+        _nftTokenInfos[tokenAddress].token.freezeDefault = nftTokenInfo.token.freezeDefault;
+
+        // Copy the tokenKeys array
+        uint256 length = nftTokenInfo.token.tokenKeys.length;
+        for (uint256 i = 0; i < length; i++) {
+            TokenKey memory tokenKey = nftTokenInfo.token.tokenKeys[i];
+            _nftTokenInfos[tokenAddress].token.tokenKeys.push(tokenKey);
+
+            /// @dev contractId can in fact be any address including an EOA address
+            ///      The KeyHelper lists 5 types for KeyValueType; however only CONTRACT_ID is considered
+            _tokenKeys[tokenAddress][tokenKey.keyType] = tokenKey.key.contractId;
+        }
+
+        _nftTokenInfos[tokenAddress].token.expiry.second = nftTokenInfo.token.expiry.second;
+        _nftTokenInfos[tokenAddress].token.expiry.autoRenewAccount = nftTokenInfo.token.expiry.autoRenewAccount;
+        _nftTokenInfos[tokenAddress].token.expiry.autoRenewPeriod = nftTokenInfo.token.expiry.autoRenewPeriod;
+
+        _nftTokenInfos[tokenAddress].totalSupply = nftTokenInfo.totalSupply;
+        _nftTokenInfos[tokenAddress].deleted = nftTokenInfo.deleted;
+        _nftTokenInfos[tokenAddress].defaultKycStatus = nftTokenInfo.defaultKycStatus;
+        _nftTokenInfos[tokenAddress].pauseStatus = nftTokenInfo.pauseStatus;
+
+        // Handle copying of other arrays (fixedFees, fractionalFees, and royaltyFees) if needed
+
+        _nftTokenInfos[tokenAddress].ledgerId = nftTokenInfo.ledgerId;
+    }
+
+    function _preCreateToken(
+        address sender,
+        HederaToken memory token,
+        int64 initialTotalSupply,
+        int32 decimals
+    ) internal view returns (int64 responseCode) {
+        bool validTreasurySig = sender == token.treasury;
+        // TODO: add additional validation on token; validation most likely required on only tokenKeys(if an address(contract/EOA) has a zero-balance then consider the tokenKey invalid since active accounts on Hedera must have a positive HBAR balance)
+        if (!validTreasurySig) {
+            return HederaResponseCodes.AUTHORIZATION_FAILED;
+        }
+
+        if (decimals < 0 || decimals > 18) {
+            return HederaResponseCodes.INVALID_TOKEN_DECIMALS;
+        }
+
+        if (initialTotalSupply < 0) {
+            return HederaResponseCodes.INVALID_TOKEN_INITIAL_SUPPLY;
+        }
+
+        uint256 tokenNameLength = _getStringLength(token.name);
+        uint256 tokenSymbolLength = _getStringLength(token.symbol);
+
+        if (tokenNameLength == 0) {
+            return HederaResponseCodes.MISSING_TOKEN_NAME;
+        }
+
+        // TODO: investigate correctness of max length conditionals
+        // solidity strings use UTF-8 encoding, Hedera restricts the name and symbol to 100 bytes
+        // in ASCII that is 100 characters
+        // however in UTF-8 it is 100/4 = 25 UT-8 characters
+        if (tokenNameLength > 100) {
+            return HederaResponseCodes.TOKEN_NAME_TOO_LONG;
+        }
+
+        if (tokenSymbolLength == 0) {
+            return HederaResponseCodes.MISSING_TOKEN_SYMBOL;
+        }
+
+        if (tokenSymbolLength > 100) {
+            return HederaResponseCodes.TOKEN_SYMBOL_TOO_LONG;
+        }
+
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    /// @dev the following internal _precheck functions are called in either of the following 2 scenarios:
+    ///      1. before the HtsPrecompileMock calls any of the HederaFungibleToken or HederaNonFungibleToken functions that specify the onlyHtsPrecompile modifier
+    ///      2. in any of HtsPrecompileMock functions that specifies the onlyHederaToken modifier which is only callable by a HederaFungibleToken or HederaNonFungibleToken contract
+
+    /// @dev for both Fungible and NonFungible
+    function _precheckApprove(
+        address token,
+        address sender, // sender should be owner in order to approve
+        address spender,
+        uint256 amountOrSerialNumber /// for Fungible is the amount and for NonFungible is the serialNumber
+    ) internal view returns (int64 responseCode) {
+
+        CommonPrecheckData memory commonPrecheckData = _getCommonPrecheckData(token, sender, sender, ADDRESS_ZERO);
+
+        /// @dev Hedera does not require an account to be associated with a token in be approved an allowance
+        // if (!_association[token][owner] || !_association[token][spender]) {
+        //     return HederaResponseCodes.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+        // }
+
+        if (!commonPrecheckData.doesAccount1PassUnfrozen || !commonPrecheckData.doesAccount2PassUnfrozen) {
+            return HederaResponseCodes.ACCOUNT_FROZEN_FOR_TOKEN;
+        }
+        if (!commonPrecheckData.doesAccount1PassKyc || !commonPrecheckData.doesAccount2PassKyc) {
+            return HederaResponseCodes.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
+        }
+
+        if (!commonPrecheckData.isFungible && !commonPrecheckData.isNonFungible) {
+            return HederaResponseCodes.INVALID_TOKEN_ID;
+        }
+
+        if (commonPrecheckData.isNonFungible) {
+            int64 serialNumber = int64(uint64(amountOrSerialNumber));
+            PartialNonFungibleTokenInfo memory partialNonFungibleTokenInfo = _partialNonFungibleTokenInfos[token][serialNumber];
+            if (partialNonFungibleTokenInfo.ownerId != sender) {
+                return HederaResponseCodes.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+            }
+        }
+
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function _precheckSetApprovalForAll(
+        address token,
+        address owner,
+        address operator,
+        bool approved
+    ) internal view returns (int64 responseCode) {
+        CommonPrecheckData memory commonPrecheckData = _getCommonPrecheckData(token, operator, owner, ADDRESS_ZERO);
+
+        if (!_association[token][owner] || !_association[token][operator]) {
+            return HederaResponseCodes.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+        }
+        if (!commonPrecheckData.doesAccount1PassUnfrozen || !commonPrecheckData.doesAccount2PassUnfrozen) {
+            return HederaResponseCodes.ACCOUNT_FROZEN_FOR_TOKEN;
+        }
+        if (!commonPrecheckData.doesAccount1PassKyc || !commonPrecheckData.doesAccount2PassKyc) {
+            return HederaResponseCodes.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
+        }
+
+        if (!commonPrecheckData.isNonFungible) {
+            /// @dev since setApprovalForAll is only applicable to token of type NON_FUNGIBLE
+            return HederaResponseCodes.INVALID_TOKEN_ID;
+        }
+
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function _precheckMint(
+        address token,
+        int64 amount,
+        bytes[] memory metadata
+    ) internal view returns (int64 responseCode) {
+        bool isFungible = _isFungible[token];
+        bool isNonFungible = _isNonFungible[token];
+
+        if (!isFungible && !isNonFungible) {
+            return HederaResponseCodes.INVALID_TOKEN_ID;
+        }
+
+        (bool validKey, bool noKey) = _hasSupplyKeySig(token);
+
+        if (noKey) {
+            return HederaResponseCodes.TOKEN_HAS_NO_SUPPLY_KEY;
+        }
+        if (!validKey) {
+            return HederaResponseCodes.INVALID_SUPPLY_KEY;
+        }
+
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function _precheckBurn(
+        address token,
+        int64 amount,
+        int64[] memory serialNumbers // since only 1 NFT can be burnt at a time; expect length to be 1
+    ) internal view returns (int64 responseCode) {
+        bool isFungible = _isFungible[token];
+        bool isNonFungible = _isNonFungible[token];
+
+        if (!isFungible && !isNonFungible) {
+            return HederaResponseCodes.INVALID_TOKEN_ID;
+        }
+
+        (bool validKey, bool noKey) = _hasTreasurySig(token);
+        address treasuryKey = _getTreasuryAccount(token);
+
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(token);
+        HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(token);
+
+        bool doesTreasuryOwnSufficientToken = isFungible
+            ? (hederaFungibleToken.balanceOf(treasuryKey) >= uint64(amount))
+            : (treasuryKey == hederaNonFungibleToken.ownerOf(uint64(serialNumbers[0])));
+
+        if (noKey || !validKey) {
+            // @dev noKey should always be false as a token must have a treasury account; however use INVALID_TREASURY_ACCOUNT_FOR_TOKEN if treasury has been deleted
+            return HederaResponseCodes.AUTHORIZATION_FAILED;
+        }
+        if (!doesTreasuryOwnSufficientToken) {
+            if (isFungible) {
+                return HederaResponseCodes.INSUFFICIENT_TOKEN_BALANCE;
+            }
+            if (isNonFungible) {
+                return HederaResponseCodes.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+            }
+        }
+
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    // account1 is typically the spender
+    // account2 is typically the owner
+    // account3 is typically the recipient
+    struct CommonPrecheckData {
+        bool isFungible;
+        bool isNonFungible;
+        bool doesAccount1PassKyc;
+        bool doesAccount2PassKyc;
+        bool doesAccount3PassKyc;
+        bool doesAccount1PassUnfrozen;
+        bool doesAccount2PassUnfrozen;
+        bool doesAccount3PassUnfrozen;
+    }
+
+    /// @dev doesPassKyc if KYC is not enabled or if enabled then account is KYCed explicitly or by default
+    function _doesAccountPassKyc(int64 responseCode, bool isKyced) internal pure returns (bool doesPassKyc) {
+        doesPassKyc = responseCode == HederaResponseCodes.SUCCESS ? isKyced : true;
+    }
+
+    /// @dev doesPassUnfrozen if freeze is not enabled or if enabled then account is unfrozen explicitly or by default
+    function _doesAccountPassUnfrozen(int64 responseCode, bool isFrozen) internal pure returns (bool doesPassUnfrozen) {
+        doesPassUnfrozen = responseCode == HederaResponseCodes.SUCCESS ? !isFrozen : true;
+    }
+
+    function _getCommonPrecheckData(
+        address token,
+        address account1,
+        address account2,
+        address account3
+    ) internal view returns (CommonPrecheckData memory commonPrecheckData) {
+        commonPrecheckData.isFungible = _isFungible[token];
+        commonPrecheckData.isNonFungible = _isNonFungible[token];
+
+        (int64 responseCodeForKyc, bool _isKyced) = isKyc(token, account1);
+        commonPrecheckData.doesAccount1PassKyc = _doesAccountPassKyc(responseCodeForKyc, _isKyced);
+
+        (responseCodeForKyc, _isKyced) = isKyc(token, account2);
+        commonPrecheckData.doesAccount2PassKyc = _doesAccountPassKyc(responseCodeForKyc, _isKyced);
+
+        (responseCodeForKyc, _isKyced) = isKyc(token, account3);
+        commonPrecheckData.doesAccount3PassKyc = _doesAccountPassKyc(responseCodeForKyc, _isKyced);
+
+        (int64 responseCodeForFrozen, bool _isFrozen) = isFrozen(token, account1);
+        commonPrecheckData.doesAccount1PassUnfrozen = _doesAccountPassUnfrozen(responseCodeForFrozen, _isFrozen);
+
+        (responseCodeForFrozen, _isFrozen) = isFrozen(token, account2);
+        commonPrecheckData.doesAccount2PassUnfrozen = _doesAccountPassUnfrozen(responseCodeForFrozen, _isFrozen);
+
+        (responseCodeForFrozen, _isFrozen) = isFrozen(token, account3);
+        commonPrecheckData.doesAccount3PassUnfrozen = _doesAccountPassUnfrozen(responseCodeForFrozen, _isFrozen);
+    }
+
+    function _precheckTransfer(
+        address token,
+        address spender,
+        address from,
+        address to,
+        uint256 amountOrSerialNumber
+    ) internal view returns (int64 responseCode, bool isRequestFromOwner) {
+        CommonPrecheckData memory commonPrecheckData = _getCommonPrecheckData(token, spender, from, to);
+
+        if (!_association[token][from] || !_association[token][to]) {
+            return (HederaResponseCodes.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT, false);
+        }
+        if (!commonPrecheckData.doesAccount2PassUnfrozen || !commonPrecheckData.doesAccount3PassUnfrozen) {
+            return (HederaResponseCodes.ACCOUNT_FROZEN_FOR_TOKEN, false);
+        }
+        if (!commonPrecheckData.doesAccount2PassKyc || !commonPrecheckData.doesAccount3PassKyc) {
+            return (HederaResponseCodes.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN, false);
+        }
+
+        // If transfer request is not from owner then check allowance of msg.sender
+        bool shouldAssumeRequestFromOwner = spender == ADDRESS_ZERO;
+        isRequestFromOwner = _isAccountSender(from) || shouldAssumeRequestFromOwner;
+
+        // do balance checks here even if request is from owner
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(token);
+        HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(token);
+
+        bool doesFromOwnSufficientToken = commonPrecheckData.isFungible
+            ? (hederaFungibleToken.balanceOf(from) >= amountOrSerialNumber)
+            : (from == hederaNonFungibleToken.ownerOf(amountOrSerialNumber));
+
+        if (!doesFromOwnSufficientToken) {
+            if (commonPrecheckData.isFungible) {
+                return (HederaResponseCodes.INSUFFICIENT_TOKEN_BALANCE, isRequestFromOwner);
+            }
+            if (commonPrecheckData.isNonFungible) {
+                return (HederaResponseCodes.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO, isRequestFromOwner);
+            }
+        }
+
+        if (isRequestFromOwner) {
+            return (HederaResponseCodes.SUCCESS, true);
+        }
+
+        address spender = spender; // TODO: investigate if Hedera also considers tx.origin as a possible spender
+        if (commonPrecheckData.isFungible) {
+            (, uint256 spenderAllowance) = allowance(token, from, spender);
+            // TODO: do validation for other allowance response codes such as SPENDER_DOES_NOT_HAVE_ALLOWANCE and MAX_ALLOWANCES_EXCEEDED
+            if (spenderAllowance < amountOrSerialNumber) {
+                return (HederaResponseCodes.AMOUNT_EXCEEDS_ALLOWANCE, false);
+            }
+        } else {
+            bool canSpendToken = HederaNonFungibleToken(token).isApprovedOrOwner(spender, amountOrSerialNumber);
+            if (!canSpendToken) {
+                return (HederaResponseCodes.INSUFFICIENT_ACCOUNT_BALANCE, false);
+            }
+        }
+
+        return (HederaResponseCodes.SUCCESS, false);
+    }
+
+    function preApprove(
+        address sender, // msg.sender in the context of the Hedera{Non|}FungibleToken; it should be owner for SUCCESS
+        address spender,
+        uint256 amountOrSerialNumber /// for Fungible is the amount and for NonFungible is the serialNumber
+    ) external onlyHederaToken returns (int64 responseCode) {
+        address token = msg.sender;
+        responseCode = _precheckApprove(token, sender, spender, amountOrSerialNumber);
+    }
+
+    function preSetApprovalForAll(
+        address sender, // msg.sender in the context of the Hedera{Non|}FungibleToken; it should be owner for SUCCESS
+        address operator,
+        bool approved
+    ) external onlyHederaToken returns (int64 responseCode) {
+        address token = msg.sender;
+        responseCode = _precheckSetApprovalForAll(token, sender, operator, approved);
+    }
+
+    /// @dev not currently called by Hedera{}Token
+    function preMint(
+        address token,
+        int64 amount,
+        bytes[] memory metadata
+    ) external onlyHederaToken returns (int64 responseCode) {
+        address token = msg.sender;
+        responseCode = _precheckMint(token, amount, metadata);
+    }
+
+    /// @dev not currently called by Hedera{}Token
+    function preBurn(int64 amount, int64[] memory serialNumbers) external onlyHederaToken returns (int64 responseCode) {
+        address token = msg.sender;
+        responseCode = _precheckBurn(token, amount, serialNumbers);
+    }
+
+    function preTransfer(
+        address spender, /// @dev if spender == ADDRESS_ZERO then assume ERC20#transfer(i.e. msg.sender is attempting to spend their balance) otherwise ERC20#transferFrom(i.e. msg.sender is attempting to spend balance of "from" using allowance)
+        address from,
+        address to,
+        uint256 amountOrSerialNumber
+    ) external onlyHederaToken returns (int64 responseCode) {
+        address token = msg.sender;
+        (responseCode, ) = _precheckTransfer(token, spender, from, to, amountOrSerialNumber);
+    }
+
+    /// @dev register HederaFungibleToken; msg.sender is the HederaFungibleToken
+    ///      can be called by any contract; however assumes msg.sender is a HederaFungibleToken
+    function registerHederaFungibleToken(address caller, FungibleTokenInfo memory fungibleTokenInfo) external {
+
+        /// @dev if caller is this contract(i.e. the HtsPrecompileMock) then no need to call _preCreateToken since it was already called when the createFungibleToken or other relevant method was called
+        bool doPrecheck = caller != address(this);
+
+        int64 responseCode = doPrecheck ? _preCreateToken(caller, fungibleTokenInfo.tokenInfo.token, fungibleTokenInfo.tokenInfo.totalSupply, fungibleTokenInfo.decimals) : HederaResponseCodes.SUCCESS;
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert("PRECHECK_FAILED"); // TODO: revert with custom error that includes response code
+        }
+
+        address tokenAddress = msg.sender;
+        _isFungible[tokenAddress] = true;
+        address treasury = _setFungibleTokenInfo(fungibleTokenInfo);
+        associateToken(treasury, tokenAddress);
+    }
+
+    /// @dev register HederaNonFungibleToken; msg.sender is the HederaNonFungibleToken
+    ///      can be called by any contract; however assumes msg.sender is a HederaNonFungibleToken
+    function registerHederaNonFungibleToken(address caller, TokenInfo memory nftTokenInfo) external {
+
+        /// @dev if caller is this contract(i.e. the HtsPrecompileMock) then no need to call _preCreateToken since it was already called when the createNonFungibleToken or other relevant method was called
+        bool doPrecheck = caller != address(this);
+
+        int64 responseCode = doPrecheck ? _preCreateToken(caller, nftTokenInfo.token, 0, 0) : HederaResponseCodes.SUCCESS;
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            revert("PRECHECK_FAILED"); // TODO: revert with custom error that includes response code
+        }
+
+        address tokenAddress = msg.sender;
+        _isNonFungible[tokenAddress] = true;
+        address treasury = _setNftTokenInfo(nftTokenInfo);
+
+        associateToken(treasury, tokenAddress);
+    }
+
+    // IHederaTokenService public/external view functions:
+    function getApproved(
+        address token,
+        uint256 serialNumber
+    ) external view returns (int64 responseCode, address approved) {
+        // TODO: do prechecks; that token is valid and serialNumber exists
+        responseCode = HederaResponseCodes.SUCCESS;
+        approved = HederaNonFungibleToken(token).getApproved(serialNumber);
+    }
+
+    function getFungibleTokenInfo(
+        address token
+    ) external view returns (int64 responseCode, FungibleTokenInfo memory fungibleTokenInfo) {
+        fungibleTokenInfo = _fungibleTokenInfos[token];
+    }
+
+    function getNonFungibleTokenInfo(
+        address token,
+        int64 serialNumber
+    ) external view returns (int64 responseCode, NonFungibleTokenInfo memory nonFungibleTokenInfo) {
+        TokenInfo memory nftTokenInfo = _nftTokenInfos[token];
+        PartialNonFungibleTokenInfo memory partialNonFungibleTokenInfo = _partialNonFungibleTokenInfos[token][
+            serialNumber
+        ];
+
+        nonFungibleTokenInfo.tokenInfo = nftTokenInfo;
+
+        nonFungibleTokenInfo.serialNumber = serialNumber;
+
+        nonFungibleTokenInfo.ownerId = partialNonFungibleTokenInfo.ownerId;
+        nonFungibleTokenInfo.creationTime = partialNonFungibleTokenInfo.creationTime;
+        nonFungibleTokenInfo.metadata = partialNonFungibleTokenInfo.metadata;
+        nonFungibleTokenInfo.spenderId = partialNonFungibleTokenInfo.spenderId;
+
+        responseCode = HederaResponseCodes.SUCCESS;
+    }
+
+    function getTokenCustomFees(
+        address token
+    )
+        external
+        view
+        returns (
+            int64 responseCode,
+            FixedFee[] memory fixedFees,
+            FractionalFee[] memory fractionalFees,
+            RoyaltyFee[] memory royaltyFees
+        )
+    {
+        responseCode = HederaResponseCodes.SUCCESS;
+        fixedFees = _fungibleTokenInfos[token].tokenInfo.fixedFees;
+        fractionalFees = _fungibleTokenInfos[token].tokenInfo.fractionalFees;
+        royaltyFees = _fungibleTokenInfos[token].tokenInfo.royaltyFees;
+    }
+
+    function getTokenDefaultFreezeStatus(
+        address token
+    ) external view returns (int64 responseCode, bool defaultFreezeStatus) {
+        responseCode = HederaResponseCodes.SUCCESS;
+        defaultFreezeStatus = _fungibleTokenInfos[token].tokenInfo.token.freezeDefault;
+    }
+
+    function getTokenDefaultKycStatus(address token) external view returns (int64 responseCode, bool defaultKycStatus) {
+        responseCode = HederaResponseCodes.SUCCESS;
+        defaultKycStatus = _fungibleTokenInfos[token].tokenInfo.defaultKycStatus;
+    }
+
+    function getTokenExpiryInfo(address token) external view returns (int64 responseCode, Expiry memory expiry) {
+        if (!_isToken(token)) {
+            return (HederaResponseCodes.INVALID_TOKEN_ID, expiry);
+        }
+
+        if (_isFungible[token]) {
+            expiry = _fungibleTokenInfos[token].tokenInfo.token.expiry;
+        } else {
+            expiry = _nftTokenInfos[token].token.expiry;
+        }
+
+        return (HederaResponseCodes.SUCCESS, expiry);
+    }
+
+    function getTokenInfo(address token) external view returns (int64 responseCode, TokenInfo memory tokenInfo) {
+        if (!_isToken(token)) {
+            return (HederaResponseCodes.INVALID_TOKEN_ID, tokenInfo);
+        }
+
+        if (_isFungible[token]) {
+            tokenInfo = _fungibleTokenInfos[token].tokenInfo;
+        } else {
+            tokenInfo = _nftTokenInfos[token];
+        }
+
+        return (HederaResponseCodes.SUCCESS, tokenInfo);
+    }
+
+    function getTokenKey(address token, uint keyType) external view returns (int64 responseCode, KeyValue memory key) {
+        if (!_isToken(token)) {
+            return (HederaResponseCodes.INVALID_TOKEN_ID, key);
+        }
+
+        /// @dev the key can be retrieved using either of the following method
+        // method 1: gas inefficient
+        // key = _getTokenKey(_fungibleTokenInfos[token].tokenInfo.token.tokenKeys, keyType);
+
+        // method 2: more gas efficient and works for BOTH token types; however currently only considers contractId
+        address keyValue = _tokenKeys[token][keyType];
+        key.contractId = keyValue;
+
+        return (HederaResponseCodes.SUCCESS, key);
+    }
+
+    function _getTokenKey(IHederaTokenService.TokenKey[] memory tokenKeys, uint keyType) internal view returns (KeyValue memory key) {
+        uint256 length = tokenKeys.length;
+
+        for (uint256 i = 0; i < length; i++) {
+            IHederaTokenService.TokenKey memory tokenKey = tokenKeys[i];
+            if (tokenKey.keyType == keyType) {
+                key = tokenKey.key;
+                break;
+            }
+        }
+    }
+
+    function getTokenType(address token) external view returns (int64 responseCode, int32 tokenType) {
+        bool isFungibleToken = _isFungible[token];
+        bool isNonFungibleToken = _isNonFungible[token];
+        if (!isFungibleToken && !isNonFungibleToken) {
+            return (HederaResponseCodes.INVALID_TOKEN_ID, tokenType);
+        }
+
+        tokenType = isFungibleToken ? int32(0) : int32(1);
+        return (HederaResponseCodes.SUCCESS, tokenType);
+    }
+
+    function grantTokenKyc(address token, address account) external returns (int64 responseCode) {
+        if (!_isFungible[token] && !_isNonFungible[token]) {
+            return (HederaResponseCodes.INVALID_TOKEN_ID);
+        }
+
+        if (_kyc[token][account]) {
+            return (HederaResponseCodes.SUCCESS);
+        }
+
+        (bool validKey, bool noKey) = _hasKycKeySig(token);
+
+        if (noKey) {
+            return (HederaResponseCodes.TOKEN_HAS_NO_KYC_KEY);
+        }
+
+        if (!validKey) {
+            return (HederaResponseCodes.INVALID_KYC_KEY);
+        }
+
+        _kyc[token][account] = true;
+        return (HederaResponseCodes.SUCCESS);
+    }
+
+    /// @dev Applicable ONLY to NFT Tokens; accessible via IERC721
+    function isApprovedForAll(
+        address token,
+        address owner,
+        address operator
+    ) external view returns (int64 responseCode, bool approved) {}
+
+    function isFrozen(address token, address account) public view returns (int64 responseCode, bool frozen) {
+        bool isFungible = _isFungible[token];
+        bool isNonFungible = _isNonFungible[token];
+
+        if (!isFungible && !isNonFungible) {
+            return (HederaResponseCodes.INVALID_TOKEN_ID, false);
+        }
+
+        if (getKey(token, KeyHelper.KeyType.FREEZE) == ADDRESS_ZERO) {
+            return (HederaResponseCodes.TOKEN_HAS_NO_FREEZE_KEY, false);
+        }
+
+        bool freezeDefault;
+        if (isFungible) {
+            FungibleTokenInfo memory fungibleTokenInfo = _fungibleTokenInfos[token];
+            freezeDefault = fungibleTokenInfo.tokenInfo.token.freezeDefault;
+        } else {
+            TokenInfo memory nftTokenInfo = _nftTokenInfos[token];
+            freezeDefault = nftTokenInfo.token.freezeDefault;
+        }
+
+        /// @dev if freezeDefault is true then an account must explicitly be unfrozen otherwise assume unfrozen
+        frozen = freezeDefault ? !(_unfrozen[token][account]) : false;
+        return (HederaResponseCodes.SUCCESS, frozen);
+    }
+
+    function isKyc(address token, address account) public view returns (int64 responseCode, bool kycGranted) {
+        bool isFungible = _isFungible[token];
+        bool isNonFungible = _isNonFungible[token];
+
+        if (!isFungible && !isNonFungible) {
+            return (HederaResponseCodes.INVALID_TOKEN_ID, false);
+        }
+
+        if (getKey(token, KeyHelper.KeyType.KYC) == ADDRESS_ZERO) {
+            return (HederaResponseCodes.TOKEN_HAS_NO_KYC_KEY, false);
+        }
+
+        bool defaultKycStatus;
+        if (isFungible) {
+            FungibleTokenInfo memory fungibleTokenInfo = _fungibleTokenInfos[token];
+            defaultKycStatus = fungibleTokenInfo.tokenInfo.defaultKycStatus;
+        } else {
+            TokenInfo memory nftTokenInfo = _nftTokenInfos[token];
+            defaultKycStatus = nftTokenInfo.defaultKycStatus;
+        }
+
+        /// @dev if defaultKycStatus is true then an account must explicitly be KYCed otherwise assume KYCed
+        kycGranted = defaultKycStatus ? _kyc[token][account] : true;
+        return (HederaResponseCodes.SUCCESS, kycGranted);
+    }
+
+    function isToken(address token) public view returns (int64 responseCode, bool isToken) {
+        isToken = _isToken(token);
+        responseCode = isToken ? HederaResponseCodes.SUCCESS : HederaResponseCodes.INVALID_TOKEN_ID;
+    }
+
+    function allowance(
+        address token,
+        address owner,
+        address spender
+    ) public view returns (int64 responseCode, uint256 allowance) {
+        if (!_isFungible[token]) {
+            return (HederaResponseCodes.INVALID_TOKEN_ID, 0);
+        }
+
+        allowance = HederaFungibleToken(token).allowance(owner, spender);
+        return (HederaResponseCodes.SUCCESS, allowance);
+    }
+
+    // Additional(not in IHederaTokenService) public/external view functions:
+    /// @dev KeyHelper.KeyType is an enum; whereas KeyHelper.keyTypes is a mapping that maps the enum index to a uint256
+    /// keyTypes[KeyType.ADMIN] = 1;
+    /// keyTypes[KeyType.KYC] = 2;
+    /// keyTypes[KeyType.FREEZE] = 4;
+    /// keyTypes[KeyType.WIPE] = 8;
+    /// keyTypes[KeyType.SUPPLY] = 16;
+    /// keyTypes[KeyType.FEE] = 32;
+    /// keyTypes[KeyType.PAUSE] = 64;
+    /// i.e. the relation is 2^(uint(KeyHelper.KeyType)) = keyType
+    function getKey(address token, KeyHelper.KeyType keyType) public view returns (address keyOwner) {
+        /// @dev the following relation is used due to the below described issue with KeyHelper.getKeyType
+        uint _keyType = 2 ** uint(keyType);
+        /// @dev the following does not work since the KeyHelper has all of its storage/state cleared/defaulted once vm.etch is used
+        ///      to fix this KeyHelper should expose a function that does what it's constructor does i.e. initialise the keyTypes mapping
+        // uint _keyType = getKeyType(keyType);
+        keyOwner = _tokenKeys[token][_keyType];
+    }
+
+    // IHederaTokenService public/external state-changing functions:
+    function createFungibleToken(
+        HederaToken memory token,
+        int64 initialTotalSupply,
+        int32 decimals
+    ) external payable noDelegateCall returns (int64 responseCode, address tokenAddress) {
+        responseCode = _preCreateToken(msg.sender, token, initialTotalSupply, decimals);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return (responseCode, ADDRESS_ZERO);
+        }
+
+        FungibleTokenInfo memory fungibleTokenInfo;
+        TokenInfo memory tokenInfo;
+
+        tokenInfo.token = token;
+        tokenInfo.totalSupply = initialTotalSupply;
+
+        fungibleTokenInfo.decimals = decimals;
+        fungibleTokenInfo.tokenInfo = tokenInfo;
+
+        /// @dev no need to register newly created HederaFungibleToken in this context as the constructor will call HtsPrecompileMock#registerHederaFungibleToken
+        HederaFungibleToken hederaFungibleToken = new HederaFungibleToken(fungibleTokenInfo);
+        return (HederaResponseCodes.SUCCESS, address(hederaFungibleToken));
+    }
+
+    function createNonFungibleToken(
+        HederaToken memory token
+    ) external payable noDelegateCall returns (int64 responseCode, address tokenAddress) {
+        responseCode = _preCreateToken(msg.sender, token, 0, 0);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return (responseCode, ADDRESS_ZERO);
+        }
+
+        TokenInfo memory tokenInfo;
+        tokenInfo.token = token;
+
+        /// @dev no need to register newly created HederaNonFungibleToken in this context as the constructor will call HtsPrecompileMock#registerHederaNonFungibleToken
+        HederaNonFungibleToken hederaNonFungibleToken = new HederaNonFungibleToken(tokenInfo);
+        return (HederaResponseCodes.SUCCESS, address(hederaNonFungibleToken));
+    }
+
+    // TODO: implement logic that considers fixedFees, fractionalFees where applicable such as on transfers
+    function createFungibleTokenWithCustomFees(
+        HederaToken memory token,
+        int64 initialTotalSupply,
+        int32 decimals,
+        FixedFee[] memory fixedFees,
+        FractionalFee[] memory fractionalFees
+    ) external payable noDelegateCall returns (int64 responseCode, address tokenAddress) {
+        responseCode = _preCreateToken(msg.sender, token, initialTotalSupply, decimals);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return (responseCode, ADDRESS_ZERO);
+        }
+
+        FungibleTokenInfo memory fungibleTokenInfo;
+        TokenInfo memory tokenInfo;
+
+        tokenInfo.token = token;
+        tokenInfo.totalSupply = initialTotalSupply;
+        tokenInfo.fixedFees = fixedFees;
+        tokenInfo.fractionalFees = fractionalFees;
+
+        fungibleTokenInfo.decimals = decimals;
+        fungibleTokenInfo.tokenInfo = tokenInfo;
+
+        /// @dev no need to register newly created HederaFungibleToken in this context as the constructor will call HtsPrecompileMock#registerHederaFungibleToken
+        HederaFungibleToken hederaFungibleToken = new HederaFungibleToken(fungibleTokenInfo);
+        return (HederaResponseCodes.SUCCESS, address(hederaFungibleToken));
+    }
+
+    // TODO: implement logic that considers fixedFees, royaltyFees where applicable such as on transfers
+    function createNonFungibleTokenWithCustomFees(
+        HederaToken memory token,
+        FixedFee[] memory fixedFees,
+        RoyaltyFee[] memory royaltyFees
+    ) external payable noDelegateCall returns (int64 responseCode, address tokenAddress) {
+        responseCode = _preCreateToken(msg.sender, token, 0, 0);
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return (responseCode, ADDRESS_ZERO);
+        }
+
+        TokenInfo memory tokenInfo;
+        tokenInfo.token = token;
+        tokenInfo.fixedFees = fixedFees;
+        tokenInfo.royaltyFees = royaltyFees;
+
+        /// @dev no need to register newly created HederaNonFungibleToken in this context as the constructor will call HtsPrecompileMock#registerHederaNonFungibleToken
+        HederaNonFungibleToken hederaNonFungibleToken = new HederaNonFungibleToken(tokenInfo);
+        return (HederaResponseCodes.SUCCESS, address(hederaNonFungibleToken));
+    }
+
+    // TODO
+    function cryptoTransfer(
+        TransferList memory transferList,
+        TokenTransferList[] memory tokenTransfers
+    ) external noDelegateCall returns (int64 responseCode) {}
+
+    // TODO
+    function deleteToken(address token) external noDelegateCall returns (int64 responseCode) {}
+
+    function approve(
+        address token,
+        address spender,
+        uint256 amount
+    ) external noDelegateCall returns (int64 responseCode) {
+        address owner = msg.sender;
+        responseCode = _precheckApprove(token, owner, spender, amount); // _precheckApprove works for BOTH token types
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return responseCode;
+        }
+
+        HederaFungibleToken(token).approveRequestFromHtsPrecompile(owner, spender, amount);
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function approveNFT(
+        address token,
+        address approved,
+        uint256 serialNumber
+    ) external noDelegateCall returns (int64 responseCode) {
+        address owner = msg.sender;
+        address spender = approved;
+        int64 _serialNumber = int64(int(serialNumber));
+        responseCode = _precheckApprove(token, owner, spender, serialNumber); // _precheckApprove works for BOTH token types
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return responseCode;
+        }
+
+        HederaNonFungibleToken(token).approveRequestFromHtsPrecompile(spender, _serialNumber);
+        _partialNonFungibleTokenInfos[token][_serialNumber].spenderId = spender;
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function associateToken(address account, address token) public noDelegateCall returns (int64 responseCode) {
+        if (!_isFungible[token] && !_isNonFungible[token]) {
+            return HederaResponseCodes.INVALID_TOKEN_ID;
+        }
+
+        if (_association[token][account]) {
+            return HederaResponseCodes.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
+        }
+
+        _association[token][account] = true;
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function associateTokens(
+        address account,
+        address[] memory tokens
+    ) external noDelegateCall returns (int64 responseCode) {
+        for (uint256 i = 0; i < tokens.length; i++) {
+            responseCode = associateToken(account, tokens[i]);
+            if (responseCode != HederaResponseCodes.SUCCESS) {
+                return responseCode;
+            }
+        }
+
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function dissociateTokens(
+        address account,
+        address[] memory tokens
+    ) external noDelegateCall returns (int64 responseCode) {
+        for (uint256 i = 0; i < tokens.length; i++) {
+            int64 responseCode = dissociateToken(account, tokens[i]);
+            if (responseCode != HederaResponseCodes.SUCCESS) {
+                return responseCode;
+            }
+        }
+
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function dissociateToken(address account, address token) public noDelegateCall returns (int64 responseCode) {
+        if (!_isFungible[token] && !_isNonFungible[token]) {
+            return HederaResponseCodes.INVALID_TOKEN_ID;
+        }
+
+        if (!_association[token][account]) {
+            return HederaResponseCodes.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+        }
+
+        _association[token][account] = false;
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    // TODO
+    function freezeToken(address token, address account) external noDelegateCall returns (int64 responseCode) {}
+
+    function mintToken(
+        address token,
+        int64 amount,
+        bytes[] memory metadata
+    ) external noDelegateCall returns (int64 responseCode, int64 newTotalSupply, int64[] memory serialNumbers) {
+        responseCode = _precheckMint(token, amount, metadata);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return (responseCode, 0, new int64[](0));
+        }
+
+        if (_isFungible[token]) {
+            HederaFungibleToken hederaFungibleToken = HederaFungibleToken(token);
+            hederaFungibleToken.mintRequestFromHtsPrecompile(amount);
+            newTotalSupply = int64(int(hederaFungibleToken.totalSupply()));
+            return (responseCode, newTotalSupply, new int64[](0));
+        }
+
+        serialNumbers = new int64[](1); // since you can only mint 1 NFT at a time
+
+        int64 serialNumber;
+        (newTotalSupply, serialNumber) = HederaNonFungibleToken(token).mintRequestFromHtsPrecompile(metadata);
+
+        serialNumbers[0] = serialNumber;
+
+        _partialNonFungibleTokenInfos[token][serialNumber] = PartialNonFungibleTokenInfo({
+            ownerId: _getTreasuryAccount(token),
+            creationTime: int64(int(block.timestamp)),
+            metadata: _concatenate(metadata),
+            spenderId: ADDRESS_ZERO
+        });
+
+        return (responseCode, newTotalSupply, serialNumbers);
+    }
+
+    function burnToken(
+        address token,
+        int64 amount,
+        int64[] memory serialNumbers
+    ) external noDelegateCall returns (int64 responseCode, int64 newTotalSupply) {
+        responseCode = _precheckBurn(token, amount, serialNumbers);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return (responseCode, 0);
+        }
+
+        if (_isFungible[token]) {
+            HederaFungibleToken hederaFungibleToken = HederaFungibleToken(token);
+            hederaFungibleToken.burnRequestFromHtsPrecompile(amount);
+            newTotalSupply = int64(int(hederaFungibleToken.totalSupply()));
+            return (responseCode, newTotalSupply);
+        }
+
+        newTotalSupply = HederaNonFungibleToken(token).burnRequestFromHtsPrecompile(serialNumbers);
+        int64 serialNumber;
+        uint burnCount = serialNumbers.length;
+        for (uint256 i = 0; i < burnCount; i++) {
+            serialNumber = serialNumbers[i];
+            delete _partialNonFungibleTokenInfos[token][serialNumber].ownerId;
+            delete _partialNonFungibleTokenInfos[token][serialNumber].spenderId;
+        }
+
+        return (responseCode, newTotalSupply);
+    }
+
+    // TODO
+    function pauseToken(address token) external noDelegateCall returns (int64 responseCode) {}
+
+    // TODO
+    function revokeTokenKyc(address token, address account) external noDelegateCall returns (int64 responseCode) {}
+
+    function setApprovalForAll(
+        address token,
+        address operator,
+        bool approved
+    ) external noDelegateCall returns (int64 responseCode) {
+        address owner = msg.sender;
+        responseCode = _precheckSetApprovalForAll(token, owner, operator, approved);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return responseCode;
+        }
+
+        HederaNonFungibleToken(token).setApprovalForAllFromHtsPrecompile(owner, operator, approved);
+        return HederaResponseCodes.SUCCESS;
+    }
+
+    function transferFrom(
+        address token,
+        address from,
+        address to,
+        uint256 amount
+    ) external noDelegateCall returns (int64 responseCode) {
+        /// @dev spender is set to non-zero address such that shouldAssumeRequestFromOwner always evaluates to false if HtsPrecompileMock#transferFrom is called
+        address spender = msg.sender;
+        bool isRequestFromOwner;
+
+        (responseCode, isRequestFromOwner) = _precheckTransfer(token, spender, from, to, amount);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return responseCode;
+        }
+
+        responseCode = HederaFungibleToken(token).transferRequestFromHtsPrecompile(
+            isRequestFromOwner,
+            spender,
+            from,
+            to,
+            amount
+        );
+
+        return responseCode;
+    }
+
+    function transferFromNFT(
+        address token,
+        address from,
+        address to,
+        uint256 serialNumber
+    ) external noDelegateCall returns (int64 responseCode) {
+        address spender = msg.sender;
+        bool isRequestFromOwner;
+
+        (responseCode, isRequestFromOwner) = _precheckTransfer(token, spender, from, to, serialNumber);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return responseCode;
+        }
+
+        HederaNonFungibleToken(token).transferRequestFromHtsPrecompile(
+            isRequestFromOwner,
+            spender,
+            from,
+            to,
+            serialNumber
+        );
+
+        int64 _serialNumber = int64(uint64(serialNumber));
+        _partialNonFungibleTokenInfos[token][_serialNumber].ownerId = to;
+        delete _partialNonFungibleTokenInfos[token][_serialNumber].spenderId;
+
+        return responseCode;
+    }
+
+    /// TODO implementation is currently identical to transferFromNFT; investigate the differences between the 2 functions
+    function transferNFT(
+        address token,
+        address sender,
+        address recipient,
+        int64 serialNumber
+    ) public noDelegateCall returns (int64 responseCode) {
+        address spender = msg.sender;
+        uint256 _serialNumber = uint64(serialNumber);
+        bool isRequestFromOwner;
+
+        (responseCode, isRequestFromOwner) = _precheckTransfer(token, spender, sender, recipient, _serialNumber);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return responseCode;
+        }
+
+        responseCode = HederaNonFungibleToken(token).transferRequestFromHtsPrecompile(
+            isRequestFromOwner,
+            spender,
+            sender,
+            recipient,
+            _serialNumber
+        );
+
+        _partialNonFungibleTokenInfos[token][serialNumber].ownerId = recipient;
+        delete _partialNonFungibleTokenInfos[token][serialNumber].spenderId;
+
+        return responseCode;
+    }
+
+    function transferNFTs(
+        address token,
+        address[] memory sender,
+        address[] memory receiver,
+        int64[] memory serialNumber
+    ) external noDelegateCall returns (int64 responseCode) {
+        uint length = sender.length;
+        uint receiverCount = receiver.length;
+        uint serialNumberCount = serialNumber.length;
+
+        require(length == receiverCount && length == serialNumberCount, 'UNEQUAL_ARRAYS');
+
+        address _sender;
+        address _receiver;
+        int64 _serialNumber;
+
+        for (uint256 i = 0; i < length; i++) {
+            _sender = sender[i];
+            _receiver = receiver[i];
+            _serialNumber = serialNumber[i];
+
+            responseCode = transferNFT(token, _sender, _receiver, _serialNumber);
+
+            // TODO: instead of reverting return responseCode; this will require prechecks on each individual transfer before enacting the transfer of all NFTs
+            // alternatively consider reverting but catch error and extract responseCode from the error and return the responseCode
+            if (responseCode != HederaResponseCodes.SUCCESS) {
+                revert HtsPrecompileError(responseCode);
+            }
+        }
+    }
+
+    /// TODO implementation is currently identical to transferFrom; investigate the differences between the 2 functions
+    function transferToken(
+        address token,
+        address sender,
+        address recipient,
+        int64 amount
+    ) public noDelegateCall returns (int64 responseCode) {
+        address spender = msg.sender;
+        bool isRequestFromOwner;
+        uint _amount = uint(int(amount));
+
+        (responseCode, isRequestFromOwner) = _precheckTransfer(token, spender, sender, recipient, _amount);
+
+        if (responseCode != HederaResponseCodes.SUCCESS) {
+            return responseCode;
+        }
+
+        responseCode = HederaFungibleToken(token).transferRequestFromHtsPrecompile(
+            isRequestFromOwner,
+            spender,
+            sender,
+            recipient,
+            _amount
+        );
+
+        return responseCode;
+    }
+
+    function transferTokens(
+        address token,
+        address[] memory accountId,
+        int64[] memory amount
+    ) external noDelegateCall returns (int64 responseCode) {
+        uint length = accountId.length;
+        uint amountCount = amount.length;
+
+        require(length == amountCount, 'UNEQUAL_ARRAYS');
+
+        address spender = msg.sender;
+        address receiver;
+        int64 _amount;
+
+        for (uint256 i = 0; i < length; i++) {
+            receiver = accountId[i];
+            _amount = amount[i];
+
+            responseCode = transferToken(token, spender, receiver, _amount);
+
+            // TODO: instead of reverting return responseCode; this will require prechecks on each individual transfer before enacting the transfer of all NFTs
+            // alternatively consider reverting but catch error and extract responseCode from the error and return the responseCode
+            if (responseCode != HederaResponseCodes.SUCCESS) {
+                revert HtsPrecompileError(responseCode);
+            }
+        }
+    }
+
+    // TODO
+    function unfreezeToken(address token, address account) external noDelegateCall returns (int64 responseCode) {}
+
+    // TODO
+    function unpauseToken(address token) external noDelegateCall returns (int64 responseCode) {}
+
+    // TODO
+    function updateTokenExpiryInfo(
+        address token,
+        Expiry memory expiryInfo
+    ) external noDelegateCall returns (int64 responseCode) {}
+
+    // TODO
+    function updateTokenInfo(
+        address token,
+        HederaToken memory tokenInfo
+    ) external noDelegateCall returns (int64 responseCode) {}
+
+    // TODO
+    function updateTokenKeys(
+        address token,
+        TokenKey[] memory keys
+    ) external noDelegateCall returns (int64 responseCode) {}
+
+    // TODO
+    function wipeTokenAccount(
+        address token,
+        address account,
+        int64 amount
+    ) external noDelegateCall returns (int64 responseCode) {}
+
+    // TODO
+    function wipeTokenAccountNFT(
+        address token,
+        address account,
+        int64[] memory serialNumbers
+    ) external noDelegateCall returns (int64 responseCode) {
+        // TODO: NonFungibleToken
+    }
+
+    // TODO
+    function redirectForToken(address token, bytes memory encodedFunctionSelector) external noDelegateCall {}
+
+    // Additional(not in IHederaTokenService) public/external state-changing functions:
+    function isAssociated(address account, address token) external view returns (bool associated) {
+        associated = _association[token][account];
+    }
+
+    function getTreasuryAccount(address token) external view returns (address treasury) {
+        return _getTreasuryAccount(token);
+    }
+
+    function _getStringLength(string memory _string) internal pure returns (uint length) {
+        length = bytes(_string).length;
+    }
+}

--- a/tools/foundry-example/test/mocks/util-precompile/UtilPrecompileMock.sol
+++ b/tools/foundry-example/test/mocks/util-precompile/UtilPrecompileMock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'hedera-smart-contracts/util-precompile/IPrngSystemContract.sol';
+
+contract UtilPrecompileMock is IPrngSystemContract {
+
+  address internal constant UTIL_PRECOMPILE = address(0x169);
+
+  bytes32 internal lastSeed; // to increase pseudorandomness by feeding in the previous seed into latest seed
+
+  function getPseudorandomSeed() external returns (bytes32) {
+    lastSeed = keccak256(abi.encodePacked(lastSeed, block.timestamp, block.number, block.difficulty, msg.sender));
+    return lastSeed;
+  }
+}

--- a/tools/foundry-example/test/utils/CommonUtils.sol
+++ b/tools/foundry-example/test/utils/CommonUtils.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'forge-std/Test.sol';
+
+/// generic test utils
+abstract contract CommonUtils is Test {
+
+    address internal alice = vm.addr(1);
+    address internal bob = vm.addr(2);
+    address internal carol = vm.addr(3);
+    address internal dave = vm.addr(4);
+
+    uint256 public constant NUM_OF_ACCOUNTS = 4;
+
+    modifier setPranker(address pranker) {
+        vm.startPrank(pranker);
+        _;
+        vm.stopPrank();
+    }
+
+    function _setUpAccounts() internal {
+        vm.deal(alice, 100 ether);
+        vm.deal(bob, 100 ether);
+        vm.deal(carol, 100 ether);
+        vm.deal(dave, 100 ether);
+    }
+
+    function _getAccount(uint index) internal returns (address) {
+        if (index == 0) {
+            return alice;
+        }
+        if (index == 1) {
+            return bob;
+        }
+        if (index == 2) {
+            return carol;
+        }
+
+        return dave; // return dave by default
+    }
+
+}

--- a/tools/foundry-example/test/utils/ExchangeRateUtils.sol
+++ b/tools/foundry-example/test/utils/ExchangeRateUtils.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'forge-std/Test.sol';
+
+import '../mocks/exchange-rate-precompile/ExchangeRatePrecompileMock.sol';
+import './CommonUtils.sol';
+import '../libraries/Constants.sol';
+
+/// for testing actions of the exchange rate precompiled/system contract
+abstract contract ExchangeRateUtils is Test, CommonUtils, Constants {
+
+    ExchangeRatePrecompileMock exchangeRatePrecompile = ExchangeRatePrecompileMock(EXCHANGE_RATE_PRECOMPILE);
+
+    function _setUpExchangeRatePrecompileMock() internal {
+        ExchangeRatePrecompileMock exchangeRatePrecompileMock = new ExchangeRatePrecompileMock();
+        bytes memory code = address(exchangeRatePrecompileMock).code;
+        vm.etch(EXCHANGE_RATE_PRECOMPILE, code);
+        _doUpdateRate(1e7);
+    }
+
+    function _doConvertTinycentsToTinybars(uint256 tinycents) internal returns (uint256 tinybars) {
+
+        tinybars = exchangeRatePrecompile.tinycentsToTinybars(tinycents);
+
+    }
+
+    function _doConvertTinybarsToTinycents(uint256 tinybars) internal returns (uint256 tinycents) {
+
+        tinycents = exchangeRatePrecompile.tinybarsToTinycents(tinybars);
+
+    }
+
+    function _doUpdateRate(uint256 newRate) internal {
+
+        exchangeRatePrecompile.updateRate(newRate);
+
+    }
+
+}

--- a/tools/foundry-example/test/utils/HederaFungibleTokenUtils.sol
+++ b/tools/foundry-example/test/utils/HederaFungibleTokenUtils.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'hedera-smart-contracts/hts-precompile/IHederaTokenService.sol';
+import 'hedera-smart-contracts/hts-precompile/HederaResponseCodes.sol';
+
+import '../mocks/hts-precompile/HederaFungibleToken.sol';
+
+import "./CommonUtils.sol";
+import "./HederaTokenUtils.sol";
+
+contract HederaFungibleTokenUtils is CommonUtils, HederaTokenUtils {
+
+    function _getSimpleHederaFungibleTokenInfo(
+        string memory name,
+        string memory symbol,
+        address treasury,
+        int64 initialTotalSupply,
+        int32 decimals
+    ) internal returns (IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo) {
+        IHederaTokenService.TokenInfo memory tokenInfo;
+
+        IHederaTokenService.HederaToken memory token = _getSimpleHederaToken(name, symbol, treasury);
+
+        tokenInfo.token = token;
+        tokenInfo.totalSupply = initialTotalSupply;
+
+        fungibleTokenInfo.decimals = decimals;
+        fungibleTokenInfo.tokenInfo = tokenInfo;
+    }
+
+    function _doCreateHederaFungibleTokenViaHtsPrecompile(
+        address sender,
+        string memory name,
+        string memory symbol,
+        address treasury,
+        int64 initialTotalSupply,
+        int32 decimals
+    ) internal setPranker(sender) returns (address tokenAddress) {
+        bool isToken;
+        assertTrue(isToken == false);
+        IHederaTokenService.HederaToken memory token = _getSimpleHederaToken(name, symbol, treasury);
+
+        int64 responseCode;
+        (responseCode, tokenAddress) = htsPrecompile.createFungibleToken(token, initialTotalSupply, decimals);
+
+        int32 tokenType;
+        (, isToken) = htsPrecompile.isToken(tokenAddress);
+        (responseCode, tokenType) = htsPrecompile.getTokenType(tokenAddress);
+
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(tokenAddress);
+
+        assertEq(responseCode, HederaResponseCodes.SUCCESS, 'Failed to createFungibleToken');
+
+        assertEq(responseCode, HederaResponseCodes.SUCCESS, 'Did not set is{}Token correctly');
+        assertEq(tokenType, 0, 'Did not set isFungible correctly');
+
+        assertEq(uint64(initialTotalSupply), hederaFungibleToken.totalSupply(), 'Did not set initial supply correctly');
+        assertEq(token.name, hederaFungibleToken.name(), 'Did not set name correctly');
+        assertEq(token.symbol, hederaFungibleToken.symbol(), 'Did not set symbol correctly');
+        assertEq(
+            hederaFungibleToken.totalSupply(),
+            hederaFungibleToken.balanceOf(token.treasury),
+            'Did not mint initial supply to treasury'
+        );
+    }
+
+    function _doCreateHederaFungibleTokenDirectly(
+        address sender,
+        string memory name,
+        string memory symbol,
+        address treasury,
+        int64 initialTotalSupply,
+        int32 decimals,
+        IHederaTokenService.TokenKey[] memory keys
+    ) internal setPranker(sender) returns (address tokenAddress) {
+        IHederaTokenService.FungibleTokenInfo memory fungibleTokenInfo = _getSimpleHederaFungibleTokenInfo(
+            name,
+            symbol,
+            sender,
+            initialTotalSupply,
+            decimals
+        );
+
+        fungibleTokenInfo.tokenInfo.token.tokenKeys = keys;
+
+        IHederaTokenService.HederaToken memory token = fungibleTokenInfo.tokenInfo.token;
+
+        /// @dev no need to register newly created HederaFungibleToken in this context as the constructor will call HtsPrecompileMock#registerHederaFungibleToken
+        HederaFungibleToken hederaFungibleToken = new HederaFungibleToken(fungibleTokenInfo);
+        tokenAddress = address(hederaFungibleToken);
+
+        (int64 responseCode, int32 tokenType) = htsPrecompile.getTokenType(tokenAddress);
+
+        assertEq(responseCode, HederaResponseCodes.SUCCESS, 'Did not set is{}Token correctly');
+        assertEq(tokenType, 0, 'Did not set isFungible correctly');
+
+        assertEq(uint64(initialTotalSupply), hederaFungibleToken.totalSupply(), 'Did not set initial supply correctly');
+        assertEq(token.name, hederaFungibleToken.name(), 'Did not set name correctly');
+        assertEq(token.symbol, hederaFungibleToken.symbol(), 'Did not set symbol correctly');
+        assertEq(
+            hederaFungibleToken.totalSupply(),
+            hederaFungibleToken.balanceOf(token.treasury),
+            'Did not mint initial supply to treasury'
+        );
+    }
+
+    function _createSimpleMockFungibleToken(
+        address sender,
+        IHederaTokenService.TokenKey[] memory keys
+    ) internal returns (address tokenAddress) {
+        string memory name = 'Token A';
+        string memory symbol = 'TA';
+        address treasury = sender;
+        int64 initialTotalSupply = 1e16;
+        int32 decimals = 8;
+
+        tokenAddress = _doCreateHederaFungibleTokenDirectly(
+            sender,
+            name,
+            symbol,
+            treasury,
+            initialTotalSupply,
+            decimals,
+            keys
+        );
+    }
+
+    function _doApproveViaHtsPrecompile(
+        address sender,
+        address token,
+        address spender,
+        uint allowance
+    ) internal setPranker(sender) returns (bool success) {
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(token);
+        uint spenderStartingAllowance = hederaFungibleToken.allowance(sender, spender);
+        int64 responseCode = htsPrecompile.approve(token, spender, allowance);
+        assertEq(
+            responseCode,
+            HederaResponseCodes.SUCCESS,
+            "expected spender to be given token allowance to sender's account"
+        );
+
+        uint spenderFinalAllowance = hederaFungibleToken.allowance(sender, spender);
+
+        assertEq(spenderFinalAllowance, allowance, "spender's expected allowance not set correctly");
+    }
+
+    function _doApproveDirectly(
+        address sender,
+        address token,
+        address spender,
+        uint allowance
+    ) internal setPranker(sender) returns (bool success) {
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(token);
+        uint spenderStartingAllowance = hederaFungibleToken.allowance(sender, spender);
+        success = hederaFungibleToken.approve(spender, allowance);
+        assertEq(success, true, 'expected successful approval');
+        uint spenderFinalAllowance = hederaFungibleToken.allowance(sender, spender);
+        assertEq(spenderFinalAllowance, allowance, "spender's expected allowance not set correctly");
+    }
+}

--- a/tools/foundry-example/test/utils/HederaNonFungibleTokenUtils.sol
+++ b/tools/foundry-example/test/utils/HederaNonFungibleTokenUtils.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'hedera-smart-contracts/hts-precompile/IHederaTokenService.sol';
+import 'hedera-smart-contracts/hts-precompile/HederaResponseCodes.sol';
+
+import '../mocks/hts-precompile/HederaFungibleToken.sol';
+
+import "./CommonUtils.sol";
+import "./HederaTokenUtils.sol";
+
+contract HederaNonFungibleTokenUtils is CommonUtils, HederaTokenUtils {
+
+    function _getSimpleHederaNftTokenInfo(
+        string memory name,
+        string memory symbol,
+        address treasury
+    ) internal returns (IHederaTokenService.TokenInfo memory tokenInfo) {
+        IHederaTokenService.HederaToken memory token = _getSimpleHederaToken(name, symbol, treasury);
+        tokenInfo.token = token;
+    }
+
+    function _doCreateHederaNonFungibleTokenViaHtsPrecompile(
+        address sender,
+        string memory name,
+        string memory symbol,
+        address treasury
+    ) internal setPranker(sender) returns (bool success, address tokenAddress) {
+
+        int64 expectedResponseCode = HederaResponseCodes.SUCCESS;
+        int64 responseCode;
+
+        if (sender != treasury) {
+            expectedResponseCode = HederaResponseCodes.AUTHORIZATION_FAILED;
+        }
+
+        IHederaTokenService.HederaToken memory token = _getSimpleHederaToken(name, symbol, treasury);
+        (responseCode, tokenAddress) = htsPrecompile.createNonFungibleToken(token);
+
+        assertEq(expectedResponseCode, responseCode, "response code does not equal expected response code");
+
+        success = responseCode == HederaResponseCodes.SUCCESS;
+
+        if (success) {
+            int32 tokenType;
+            bool isToken;
+            (, isToken) = htsPrecompile.isToken(tokenAddress);
+            (responseCode, tokenType) = htsPrecompile.getTokenType(tokenAddress);
+
+            HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(tokenAddress);
+
+            assertEq(responseCode, HederaResponseCodes.SUCCESS, 'Failed to createNonFungibleToken');
+
+            assertEq(responseCode, HederaResponseCodes.SUCCESS, 'Did not set is{}Token correctly');
+            assertEq(tokenType, 1, 'Did not set isNonFungible correctly');
+
+            assertEq(token.name, hederaNonFungibleToken.name(), 'Did not set name correctly');
+            assertEq(token.symbol, hederaNonFungibleToken.symbol(), 'Did not set symbol correctly');
+            assertEq(
+                hederaNonFungibleToken.totalSupply(),
+                hederaNonFungibleToken.balanceOf(token.treasury),
+                'Did not mint initial supply to treasury'
+            );
+        }
+
+    }
+
+    function _doCreateHederaNonFungibleTokenDirectly(
+        address sender,
+        string memory name,
+        string memory symbol,
+        address treasury,
+        IHederaTokenService.TokenKey[] memory keys
+    ) internal setPranker(sender) returns (bool success, address tokenAddress) {
+
+        int64 expectedResponseCode = HederaResponseCodes.SUCCESS;
+        int64 responseCode;
+
+        IHederaTokenService.TokenInfo memory nftTokenInfo = _getSimpleHederaNftTokenInfo(
+            name,
+            symbol,
+            treasury
+        );
+
+        nftTokenInfo.token.tokenKeys = keys;
+
+        IHederaTokenService.HederaToken memory token = nftTokenInfo.token;
+
+        if (sender != treasury) {
+            expectedResponseCode = HederaResponseCodes.AUTHORIZATION_FAILED;
+        }
+
+        if (expectedResponseCode != HederaResponseCodes.SUCCESS) {
+            vm.expectRevert(bytes("PRECHECK_FAILED"));
+        }
+
+        /// @dev no need to register newly created HederaNonFungibleToken in this context as the constructor will call HtsPrecompileMock#registerHederaNonFungibleToken
+        HederaNonFungibleToken hederaNonFungibleToken = new HederaNonFungibleToken(nftTokenInfo);
+
+        if (expectedResponseCode == HederaResponseCodes.SUCCESS) {
+            success = true;
+        }
+
+        if (success) {
+
+            tokenAddress = address(hederaNonFungibleToken);
+
+            (int64 responseCode, int32 tokenType) = htsPrecompile.getTokenType(tokenAddress);
+
+            assertEq(responseCode, HederaResponseCodes.SUCCESS, 'Did not set is{}Token correctly');
+            assertEq(tokenType, 1, 'Did not set isNonFungible correctly');
+
+            assertEq(token.name, hederaNonFungibleToken.name(), 'Did not set name correctly');
+            assertEq(token.symbol, hederaNonFungibleToken.symbol(), 'Did not set symbol correctly');
+            assertEq(
+                hederaNonFungibleToken.totalSupply(),
+                hederaNonFungibleToken.balanceOf(token.treasury),
+                'Did not mint initial supply to treasury'
+            );
+
+        }
+
+    }
+
+    function _createSimpleMockNonFungibleToken(
+        address sender,
+        IHederaTokenService.TokenKey[] memory keys
+    ) internal returns (address tokenAddress) {
+
+        string memory name = 'NFT A';
+        string memory symbol = 'NFT-A';
+        address treasury = sender;
+
+        (, tokenAddress) = _doCreateHederaNonFungibleTokenDirectly(sender, name, symbol, treasury, keys);
+    }
+
+    struct ApproveNftParams {
+        address sender;
+        address token;
+        address spender;
+        int64 serialId;
+    }
+
+    struct ApproveNftInfo {
+        address owner;
+        address spender;
+        uint256 serialIdU256;
+    }
+
+    function _doApproveNftViaHtsPrecompile(ApproveNftParams memory approveNftParams) internal setPranker(approveNftParams.sender) returns (bool success) {
+
+        int64 expectedResponseCode = HederaResponseCodes.SUCCESS;
+        int64 responseCode;
+
+        ApproveNftInfo memory approveNftInfo;
+
+        HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(approveNftParams.token);
+
+        approveNftInfo.serialIdU256 = uint64(approveNftParams.serialId);
+        approveNftInfo.owner = hederaNonFungibleToken.ownerOf(approveNftInfo.serialIdU256);
+
+        if (approveNftParams.sender != approveNftInfo.owner) {
+            expectedResponseCode = HederaResponseCodes.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+        }
+
+        responseCode = htsPrecompile.approveNFT(approveNftParams.token, approveNftParams.spender, approveNftInfo.serialIdU256);
+
+        assertEq(responseCode, expectedResponseCode, "expected response code does not equal actual response code");
+
+        success = responseCode == HederaResponseCodes.SUCCESS;
+
+        approveNftInfo.spender = hederaNonFungibleToken.getApproved(approveNftInfo.serialIdU256);
+
+        if (success) {
+            assertEq(approveNftInfo.spender, approveNftParams.spender, "spender was not correctly updated");
+        }
+
+    }
+
+    function _doApproveNftDirectly(ApproveNftParams memory approveNftParams) internal setPranker(approveNftParams.sender) returns (bool success) {
+
+        int64 expectedResponseCode = HederaResponseCodes.SUCCESS;
+        int64 responseCode;
+
+        ApproveNftInfo memory approveNftInfo;
+
+        HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(approveNftParams.token);
+
+        approveNftInfo.serialIdU256 = uint64(approveNftParams.serialId);
+        approveNftInfo.owner = hederaNonFungibleToken.ownerOf(approveNftInfo.serialIdU256);
+
+        if (approveNftParams.sender != approveNftInfo.owner) {
+            expectedResponseCode = HederaResponseCodes.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+        }
+
+        if (expectedResponseCode != HederaResponseCodes.SUCCESS) {
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    HederaFungibleToken.HtsPrecompileError.selector,
+                    expectedResponseCode
+                )
+            );
+        }
+
+        hederaNonFungibleToken.approve(approveNftParams.spender, approveNftInfo.serialIdU256);
+
+        if (expectedResponseCode == HederaResponseCodes.SUCCESS) {
+            success = true;
+        }
+
+        approveNftInfo.spender = hederaNonFungibleToken.getApproved(approveNftInfo.serialIdU256);
+
+        if (success) {
+            assertEq(approveNftInfo.spender, approveNftParams.spender, "spender was not correctly updated");
+        }
+
+    }
+
+}

--- a/tools/foundry-example/test/utils/HederaTokenUtils.sol
+++ b/tools/foundry-example/test/utils/HederaTokenUtils.sol
@@ -1,0 +1,661 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'forge-std/Test.sol';
+
+import '../mocks/hts-precompile/HtsPrecompileMock.sol';
+import './CommonUtils.sol';
+
+/// for testing actions common to both HTS token types i.e FUNGIBLE and NON_FUNGIBLE
+/// also has common constants for both HTS token types
+abstract contract HederaTokenUtils is Test, CommonUtils, Constants {
+
+    HtsPrecompileMock htsPrecompile = HtsPrecompileMock(HTS_PRECOMPILE);
+
+    function _setUpHtsPrecompileMock() internal {
+        HtsPrecompileMock htsPrecompileMock = new HtsPrecompileMock();
+        bytes memory code = address(htsPrecompileMock).code;
+        vm.etch(HTS_PRECOMPILE, code);
+    }
+
+    function _getSimpleHederaToken(
+        string memory name,
+        string memory symbol,
+        address treasury
+    ) internal returns (IHederaTokenService.HederaToken memory token) {
+        token.name = name;
+        token.symbol = symbol;
+        token.treasury = treasury;
+    }
+
+    function _doAssociateViaHtsPrecompile(
+        address sender,
+        address token
+    ) internal setPranker(sender) returns (bool success) {
+        bool isInitiallyAssociated = htsPrecompile.isAssociated(sender, token);
+        int64 responseCode = htsPrecompile.associateToken(sender, token);
+        success = responseCode == HederaResponseCodes.SUCCESS;
+
+        int64 expectedResponseCode;
+
+        if (isInitiallyAssociated) {
+            expectedResponseCode = HederaResponseCodes.TOKEN_ALREADY_ASSOCIATED_TO_ACCOUNT;
+        }
+
+        if (!isInitiallyAssociated) {
+            expectedResponseCode = HederaResponseCodes.SUCCESS;
+        }
+
+        bool isFinallyAssociated = htsPrecompile.isAssociated(sender, token);
+
+        assertEq(responseCode, expectedResponseCode, 'expected response code does not match actual response code');
+    }
+
+    struct MintKeys {
+        address supplyKey;
+        address treasury;
+    }
+
+    struct MintInfo {
+        uint256 totalSupply;
+        uint256 treasuryBalance;
+        bool isFungible;
+        bool isNonFungible;
+        uint256 mintAmountU256;
+        int64 mintCount;
+    }
+
+    struct MintParams {
+        address sender;
+        address token;
+        int64 mintAmount;
+    }
+
+    struct MintResponse {
+        bool success;
+        int64 responseCode;
+        int64 serialId;
+    }
+
+    function _doMintViaHtsPrecompile(MintParams memory mintParams) internal setPranker(mintParams.sender) returns (MintResponse memory mintResponse) {
+
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(mintParams.token);
+        HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(mintParams.token);
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        int64 newTotalSupply;
+        int64[] memory serialNumbers;
+        int32 tokenType;
+
+        int64 expectedResponseCode = HederaResponseCodes.SUCCESS; // assume SUCCESS initially and later overwrite error code accordingly
+
+        MintKeys memory mintKeys = MintKeys({
+            supplyKey: htsPrecompile.getKey(mintParams.token, KeyHelper.KeyType.SUPPLY),
+            treasury: htsPrecompile.getTreasuryAccount(mintParams.token)
+        });
+
+        (mintResponse.responseCode, tokenType) = htsPrecompile.getTokenType(mintParams.token);
+
+        mintResponse.success = mintResponse.responseCode == HederaResponseCodes.SUCCESS;
+
+        if (tokenType == 1) {
+            /// @dev since you can only mint one NFT at a time; also mintAmount is ONLY applicable to type FUNGIBLE
+            mintParams.mintAmount = 1;
+        }
+
+        MintInfo memory preMintInfo = MintInfo({
+            totalSupply: mintResponse.success ? (tokenType == 0 ? hederaFungibleToken.totalSupply() : hederaNonFungibleToken.totalSupply()) : 0,
+            treasuryBalance: mintResponse.success ? (tokenType == 0 ? hederaFungibleToken.balanceOf(mintKeys.treasury) : hederaNonFungibleToken.totalSupply()) : 0,
+            isFungible: tokenType == 0 ? true : false,
+            isNonFungible: tokenType == 1 ? true : false,
+            mintAmountU256: uint64(mintParams.mintAmount),
+            mintCount: tokenType == 1 ? hederaNonFungibleToken.mintCount() : int64(0)
+        });
+
+        if (mintKeys.supplyKey != mintParams.sender) {
+            expectedResponseCode = HederaResponseCodes.INVALID_SUPPLY_KEY;
+        }
+
+        if (mintKeys.supplyKey == ADDRESS_ZERO) {
+            expectedResponseCode = HederaResponseCodes.TOKEN_HAS_NO_SUPPLY_KEY;
+        }
+
+        (mintResponse.responseCode, newTotalSupply, serialNumbers) = htsPrecompile.mintToken(mintParams.token, mintParams.mintAmount, NULL_BYTES);
+
+        assertEq(expectedResponseCode, mintResponse.responseCode, 'expected response code does not equal actual response code');
+
+        mintResponse.success = mintResponse.responseCode == HederaResponseCodes.SUCCESS;
+
+        MintInfo memory postMintInfo = MintInfo({
+            totalSupply: tokenType == 0 ? hederaFungibleToken.totalSupply() : hederaNonFungibleToken.totalSupply(),
+            treasuryBalance: tokenType == 0 ? hederaFungibleToken.balanceOf(mintKeys.treasury) : hederaNonFungibleToken.totalSupply(),
+            isFungible: tokenType == 0 ? true : false,
+            isNonFungible: tokenType == 1 ? true : false,
+            mintAmountU256: uint64(mintParams.mintAmount),
+            mintCount: tokenType == 1 ? hederaNonFungibleToken.mintCount() : int64(0)
+        });
+
+        if (mintResponse.success) {
+
+            assertEq(
+                postMintInfo.totalSupply,
+                uint64(newTotalSupply),
+                'expected newTotalSupply to equal post mint totalSupply'
+            );
+
+            if (preMintInfo.isFungible) {
+
+                assertEq(
+                    preMintInfo.totalSupply + preMintInfo.mintAmountU256,
+                    postMintInfo.totalSupply,
+                    'expected total supply to increase by mint amount'
+                );
+                assertEq(
+                    preMintInfo.treasuryBalance + preMintInfo.mintAmountU256,
+                    postMintInfo.treasuryBalance,
+                    'expected treasury balance to increase by mint amount'
+                );
+            }
+
+            if (preMintInfo.isNonFungible) {
+                assertEq(
+                    preMintInfo.totalSupply + 1,
+                    postMintInfo.totalSupply,
+                    'expected total supply to increase by mint amount'
+                );
+                assertEq(
+                    preMintInfo.treasuryBalance + 1,
+                    postMintInfo.treasuryBalance,
+                    'expected treasury balance to increase by mint amount'
+                );
+
+                assertEq(preMintInfo.mintCount + 1, postMintInfo.mintCount, "expected mintCount to increase by 1");
+                assertEq(serialNumbers[0], postMintInfo.mintCount, "expected minted serialNumber to equal mintCount");
+
+                mintResponse.serialId = serialNumbers[0];
+            }
+        }
+
+        if (!mintResponse.success) {
+            assertEq(
+                preMintInfo.totalSupply,
+                postMintInfo.totalSupply,
+                'expected total supply to not change if failed'
+            );
+            assertEq(
+                preMintInfo.treasuryBalance,
+                postMintInfo.treasuryBalance,
+                'expected treasury balance to not change if failed'
+            );
+        }
+    }
+
+    struct TransferParams {
+        address sender;
+        address token;
+        address from;
+        address to;
+        uint256 amountOrSerialNumber; // amount for FUNGIBLE serialNumber for NON_FUNGIBLE
+    }
+
+    struct TransferInfo {
+        // applicable to FUNGIBLE
+        uint256 spenderAllowance;
+        uint256 fromBalance;
+        uint256 toBalance;
+        // applicable to NON_FUNGIBLE
+        address owner;
+        address approvedId;
+        bool isSenderOperator;
+    }
+
+    struct TransferChecks {
+        bool isRecipientAssociated;
+        bool isRequestFromOwner;
+        int64 expectedResponseCode;
+        bool isToken;
+        int32 tokenType;
+        bool isFungible;
+        bool isNonFungible;
+    }
+
+    function _doTransferViaHtsPrecompile(
+        TransferParams memory transferParams
+    ) internal setPranker(transferParams.sender) returns (bool success, int64 responseCode) {
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(transferParams.token);
+        HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(transferParams.token);
+
+        TransferChecks memory transferChecks;
+        TransferInfo memory preTransferInfo;
+
+        transferChecks.expectedResponseCode = HederaResponseCodes.SUCCESS; // assume SUCCESS and overwrite with !SUCCESS where applicable
+
+        (transferChecks.expectedResponseCode, transferChecks.tokenType) = htsPrecompile.getTokenType(transferParams.token);
+
+        if (transferChecks.expectedResponseCode == HederaResponseCodes.SUCCESS) {
+            transferChecks.isFungible = transferChecks.tokenType == 0 ? true : false;
+            transferChecks.isNonFungible = transferChecks.tokenType == 1 ? true : false;
+        }
+
+        transferChecks.isRecipientAssociated = htsPrecompile.isAssociated(transferParams.to, transferParams.token);
+        transferChecks.isRequestFromOwner = transferParams.sender == transferParams.from;
+
+        if (transferChecks.isFungible) {
+            preTransferInfo.spenderAllowance = hederaFungibleToken.allowance(transferParams.from, transferParams.sender);
+            preTransferInfo.fromBalance = hederaFungibleToken.balanceOf(transferParams.from);
+            preTransferInfo.toBalance = hederaFungibleToken.balanceOf(transferParams.to);
+        }
+
+        if (transferChecks.isNonFungible) {
+            preTransferInfo.owner = hederaNonFungibleToken.ownerOf(transferParams.amountOrSerialNumber);
+            preTransferInfo.approvedId = hederaNonFungibleToken.getApproved(transferParams.amountOrSerialNumber);
+            preTransferInfo.isSenderOperator = hederaNonFungibleToken.isApprovedForAll(transferParams.from, transferParams.sender);
+        }
+
+        if (transferChecks.isRequestFromOwner) {
+            if (transferChecks.isFungible) {
+                if (preTransferInfo.fromBalance < transferParams.amountOrSerialNumber) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.INSUFFICIENT_TOKEN_BALANCE;
+                }
+            }
+
+            if (transferChecks.isNonFungible) {
+                if (preTransferInfo.owner != transferParams.sender) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+                }
+            }
+        }
+
+        if (!transferChecks.isRequestFromOwner) {
+            if (transferChecks.isFungible) {
+                if (preTransferInfo.spenderAllowance < transferParams.amountOrSerialNumber) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.AMOUNT_EXCEEDS_ALLOWANCE;
+                }
+            }
+
+            if (transferChecks.isNonFungible) {
+
+                if (preTransferInfo.owner != transferParams.from) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.INVALID_ALLOWANCE_OWNER_ID;
+                }
+
+                if (preTransferInfo.approvedId != transferParams.sender && !preTransferInfo.isSenderOperator) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.SPENDER_DOES_NOT_HAVE_ALLOWANCE;
+                }
+            }
+        }
+
+        if (!transferChecks.isRecipientAssociated) {
+            transferChecks.expectedResponseCode = HederaResponseCodes.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+        }
+
+        responseCode = htsPrecompile.transferFrom(
+            transferParams.token,
+            transferParams.from,
+            transferParams.to,
+            transferParams.amountOrSerialNumber
+        );
+
+        assertEq(
+            transferChecks.expectedResponseCode,
+            responseCode,
+            'expected response code does not equal actual response code'
+        );
+
+        success = responseCode == HederaResponseCodes.SUCCESS;
+
+        TransferInfo memory postTransferInfo;
+
+        if (transferChecks.isFungible) {
+            postTransferInfo.spenderAllowance = hederaFungibleToken.allowance(transferParams.from, transferParams.sender);
+            postTransferInfo.fromBalance = hederaFungibleToken.balanceOf(transferParams.from);
+            postTransferInfo.toBalance = hederaFungibleToken.balanceOf(transferParams.to);
+        }
+
+        if (transferChecks.isNonFungible) {
+            postTransferInfo.owner = hederaNonFungibleToken.ownerOf(transferParams.amountOrSerialNumber);
+            postTransferInfo.approvedId = hederaNonFungibleToken.getApproved(transferParams.amountOrSerialNumber);
+            postTransferInfo.isSenderOperator = hederaNonFungibleToken.isApprovedForAll(transferParams.from, transferParams.sender);
+        }
+
+        if (success) {
+
+            if (transferChecks.isFungible) {
+                assertEq(
+                    preTransferInfo.toBalance + transferParams.amountOrSerialNumber,
+                    postTransferInfo.toBalance,
+                    'to balance did not update correctly'
+                );
+                assertEq(
+                    preTransferInfo.fromBalance - transferParams.amountOrSerialNumber,
+                    postTransferInfo.fromBalance,
+                    'from balance did not update correctly'
+                );
+
+                if (!transferChecks.isRequestFromOwner) {
+                    assertEq(
+                        preTransferInfo.spenderAllowance - transferParams.amountOrSerialNumber,
+                        postTransferInfo.spenderAllowance,
+                        'spender allowance did not update correctly'
+                    );
+                }
+            }
+
+            if (transferChecks.isNonFungible) {
+                assertEq(postTransferInfo.owner, transferParams.to, "expected to to be new owner");
+                assertEq(postTransferInfo.approvedId, ADDRESS_ZERO, "expected approvedId to be reset");
+                assertEq(postTransferInfo.isSenderOperator, preTransferInfo.isSenderOperator, "operator should not have changed");
+            }
+        }
+
+        if (!success) {
+
+            if (transferChecks.isFungible) {
+                assertEq(preTransferInfo.toBalance, postTransferInfo.toBalance, 'to balance changed unexpectedly');
+                assertEq(preTransferInfo.fromBalance, postTransferInfo.fromBalance, 'from balance changed unexpectedly');
+
+                if (!transferChecks.isRequestFromOwner) {
+                    assertEq(
+                        preTransferInfo.spenderAllowance,
+                        postTransferInfo.spenderAllowance,
+                        'spender allowance changed unexpectedly'
+                    );
+                }
+            }
+
+            if (transferChecks.isNonFungible) {
+                assertEq(preTransferInfo.owner, postTransferInfo.owner, 'owner should not have changed on failure');
+                assertEq(preTransferInfo.approvedId, postTransferInfo.approvedId, 'approvedId should not have changed on failure');
+                assertEq(preTransferInfo.isSenderOperator, postTransferInfo.isSenderOperator, 'isSenderOperator should not have changed on failure');
+            }
+        }
+    }
+
+    function _doTransferDirectly(
+        TransferParams memory transferParams
+    ) internal setPranker(transferParams.sender) returns (bool success, int64 responseCode) {
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(transferParams.token);
+        HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(transferParams.token);
+
+        TransferChecks memory transferChecks;
+        TransferInfo memory preTransferInfo;
+
+        transferChecks.expectedResponseCode = HederaResponseCodes.SUCCESS; // assume SUCCESS and overwrite with !SUCCESS where applicable
+
+        (transferChecks.expectedResponseCode, transferChecks.tokenType) = htsPrecompile.getTokenType(transferParams.token);
+
+        if (transferChecks.expectedResponseCode == HederaResponseCodes.SUCCESS) {
+            transferChecks.isFungible = transferChecks.tokenType == 0 ? true : false;
+            transferChecks.isNonFungible = transferChecks.tokenType == 1 ? true : false;
+        }
+
+        transferChecks.isRecipientAssociated = htsPrecompile.isAssociated(transferParams.to, transferParams.token);
+        transferChecks.isRequestFromOwner = transferParams.sender == transferParams.from;
+
+        if (transferChecks.isFungible) {
+            preTransferInfo.spenderAllowance = hederaFungibleToken.allowance(transferParams.from, transferParams.sender);
+            preTransferInfo.fromBalance = hederaFungibleToken.balanceOf(transferParams.from);
+            preTransferInfo.toBalance = hederaFungibleToken.balanceOf(transferParams.to);
+        }
+
+        if (transferChecks.isNonFungible) {
+            preTransferInfo.owner = hederaNonFungibleToken.ownerOf(transferParams.amountOrSerialNumber);
+            preTransferInfo.approvedId = hederaNonFungibleToken.getApproved(transferParams.amountOrSerialNumber);
+            preTransferInfo.isSenderOperator = hederaNonFungibleToken.isApprovedForAll(transferParams.from, transferParams.sender);
+        }
+
+        if (transferChecks.isRequestFromOwner) {
+            if (transferChecks.isFungible) {
+                if (preTransferInfo.fromBalance < transferParams.amountOrSerialNumber) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.INSUFFICIENT_TOKEN_BALANCE;
+                }
+            }
+
+            if (transferChecks.isNonFungible) {
+                if (preTransferInfo.owner != transferParams.sender) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+                }
+            }
+        }
+
+        if (!transferChecks.isRequestFromOwner) {
+            if (transferChecks.isFungible) {
+                if (preTransferInfo.spenderAllowance < transferParams.amountOrSerialNumber) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.AMOUNT_EXCEEDS_ALLOWANCE;
+                }
+            }
+
+            if (transferChecks.isNonFungible) {
+
+                if (preTransferInfo.owner != transferParams.from) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.INVALID_ALLOWANCE_OWNER_ID;
+                }
+
+                if (preTransferInfo.approvedId != transferParams.sender && !preTransferInfo.isSenderOperator) {
+                    transferChecks.expectedResponseCode = HederaResponseCodes.SPENDER_DOES_NOT_HAVE_ALLOWANCE;
+                }
+            }
+        }
+
+        if (!transferChecks.isRecipientAssociated) {
+            transferChecks.expectedResponseCode = HederaResponseCodes.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+        }
+
+        if (transferChecks.expectedResponseCode != HederaResponseCodes.SUCCESS) {
+            vm.expectRevert(
+                abi.encodeWithSelector(
+                    HederaFungibleToken.HtsPrecompileError.selector,
+                    transferChecks.expectedResponseCode
+                )
+            );
+        }
+
+        if (transferChecks.isRequestFromOwner) {
+            if (transferChecks.isFungible) {
+                hederaFungibleToken.transfer(transferParams.to, transferParams.amountOrSerialNumber);
+            }
+            if (transferChecks.isNonFungible) {
+                hederaNonFungibleToken.transferFrom(transferParams.from, transferParams.to, transferParams.amountOrSerialNumber);
+            }
+        }
+
+        if (!transferChecks.isRequestFromOwner) {
+            if (transferChecks.isFungible) {
+                hederaFungibleToken.transferFrom(transferParams.from, transferParams.to, transferParams.amountOrSerialNumber);
+            }
+            if (transferChecks.isNonFungible) {
+                hederaNonFungibleToken.transferFrom(transferParams.from, transferParams.to, transferParams.amountOrSerialNumber);
+            }
+        }
+
+        if (transferChecks.expectedResponseCode == HederaResponseCodes.SUCCESS) {
+            success = true;
+        }
+
+        TransferInfo memory postTransferInfo;
+
+        if (transferChecks.isFungible) {
+            postTransferInfo.spenderAllowance = hederaFungibleToken.allowance(transferParams.from, transferParams.sender);
+            postTransferInfo.fromBalance = hederaFungibleToken.balanceOf(transferParams.from);
+            postTransferInfo.toBalance = hederaFungibleToken.balanceOf(transferParams.to);
+        }
+
+        if (transferChecks.isNonFungible) {
+            postTransferInfo.owner = hederaNonFungibleToken.ownerOf(transferParams.amountOrSerialNumber);
+            postTransferInfo.approvedId = hederaNonFungibleToken.getApproved(transferParams.amountOrSerialNumber);
+            postTransferInfo.isSenderOperator = hederaNonFungibleToken.isApprovedForAll(transferParams.from, transferParams.sender);
+        }
+
+        if (success) {
+            if (transferChecks.isFungible) {
+                assertEq(
+                    preTransferInfo.toBalance + transferParams.amountOrSerialNumber,
+                    postTransferInfo.toBalance,
+                    'to balance did not update correctly'
+                );
+                assertEq(
+                    preTransferInfo.fromBalance - transferParams.amountOrSerialNumber,
+                    postTransferInfo.fromBalance,
+                    'from balance did not update correctly'
+                );
+
+                if (!transferChecks.isRequestFromOwner) {
+                    assertEq(
+                        preTransferInfo.spenderAllowance - transferParams.amountOrSerialNumber,
+                        postTransferInfo.spenderAllowance,
+                        'spender allowance did not update correctly'
+                    );
+                }
+            }
+
+            if (transferChecks.isNonFungible) {
+                assertEq(postTransferInfo.owner, transferParams.to, "expected to to be new owner");
+                assertEq(postTransferInfo.approvedId, ADDRESS_ZERO, "expected approvedId to be reset");
+                assertEq(postTransferInfo.isSenderOperator, preTransferInfo.isSenderOperator, "operator should not have changed");
+            }
+        }
+
+        if (!success) {
+            if (transferChecks.isFungible) {
+                assertEq(preTransferInfo.toBalance, postTransferInfo.toBalance, 'to balance changed unexpectedly');
+                assertEq(preTransferInfo.fromBalance, postTransferInfo.fromBalance, 'from balance changed unexpectedly');
+
+                if (!transferChecks.isRequestFromOwner) {
+                    assertEq(
+                        preTransferInfo.spenderAllowance,
+                        postTransferInfo.spenderAllowance,
+                        'spender allowance changed unexpectedly'
+                    );
+                }
+            }
+
+            if (transferChecks.isNonFungible) {
+                assertEq(preTransferInfo.owner, postTransferInfo.owner, 'owner should not have changed on failure');
+                assertEq(preTransferInfo.approvedId, postTransferInfo.approvedId, 'approvedId should not have changed on failure');
+                assertEq(preTransferInfo.isSenderOperator, postTransferInfo.isSenderOperator, 'isSenderOperator should not have changed on failure');
+            }
+        }
+    }
+
+    struct BurnParams {
+        address sender;
+        address token;
+        int64 amountOrSerialNumber;
+    }
+
+    struct BurnChecks {
+        bool isToken;
+        int32 tokenType;
+        bool isFungible;
+        bool isNonFungible;
+        uint256 amountOrSerialNumberU256;
+        int64 expectedResponseCode;
+    }
+
+    struct BurnInfo {
+        address owner;
+        uint256 totalSupply;
+        uint256 treasuryBalance;
+    }
+
+    function _doBurnViaHtsPrecompile(BurnParams memory burnParams) internal setPranker(burnParams.sender) returns (bool success, int64 responseCode) {
+
+        HederaFungibleToken hederaFungibleToken = HederaFungibleToken(burnParams.token);
+        HederaNonFungibleToken hederaNonFungibleToken = HederaNonFungibleToken(burnParams.token);
+
+        BurnChecks memory burnChecks;
+
+        bytes[] memory NULL_BYTES = new bytes[](1);
+
+        int64 newTotalSupply;
+        int64[] memory serialNumbers = new int64[](1); // this test function currently only supports 1 NFT being burnt at a time
+
+        burnChecks.amountOrSerialNumberU256 = uint64(burnParams.amountOrSerialNumber);
+        burnChecks.expectedResponseCode = HederaResponseCodes.SUCCESS; // assume SUCCESS initially and later overwrite error code accordingly
+
+        burnChecks.expectedResponseCode = HederaResponseCodes.SUCCESS; // assume SUCCESS and overwrite with !SUCCESS where applicable
+
+        (burnChecks.expectedResponseCode, burnChecks.tokenType) = htsPrecompile.getTokenType(burnParams.token);
+
+        if (burnChecks.expectedResponseCode == HederaResponseCodes.SUCCESS) {
+            burnChecks.isFungible = burnChecks.tokenType == 0 ? true : false;
+            burnChecks.isNonFungible = burnChecks.tokenType == 1 ? true : false;
+        }
+
+        address treasury = htsPrecompile.getTreasuryAccount(burnParams.token);
+
+        BurnInfo memory preBurnInfo;
+
+        preBurnInfo.totalSupply = hederaFungibleToken.totalSupply();
+        preBurnInfo.treasuryBalance = hederaFungibleToken.balanceOf(treasury);
+
+        if (burnChecks.isNonFungible) {
+            // amount is only applicable to type FUNGIBLE
+            serialNumbers[0] = burnParams.amountOrSerialNumber; // only burn 1 NFT at a time
+            preBurnInfo.owner = hederaNonFungibleToken.ownerOf(burnChecks.amountOrSerialNumberU256);
+            burnParams.amountOrSerialNumber = 0;
+
+            if (burnParams.sender != preBurnInfo.owner) {
+                burnChecks.expectedResponseCode = HederaResponseCodes.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+            }
+        }
+
+        if (treasury != burnParams.sender) {
+            burnChecks.expectedResponseCode = HederaResponseCodes.AUTHORIZATION_FAILED;
+        }
+
+        (responseCode, newTotalSupply) = htsPrecompile.burnToken(burnParams.token, burnParams.amountOrSerialNumber, serialNumbers);
+
+        assertEq(burnChecks.expectedResponseCode, responseCode, 'expected response code does not equal actual response code');
+
+        success = responseCode == HederaResponseCodes.SUCCESS;
+
+        BurnInfo memory postBurnInfo;
+
+        postBurnInfo.totalSupply = hederaFungibleToken.totalSupply();
+        postBurnInfo.treasuryBalance = hederaFungibleToken.balanceOf(treasury);
+
+        if (success) {
+            if (burnChecks.isFungible) {
+                assertEq(
+                    preBurnInfo.totalSupply - burnChecks.amountOrSerialNumberU256,
+                    postBurnInfo.totalSupply,
+                    'expected total supply to decrease by burn amount'
+                );
+                assertEq(
+                    preBurnInfo.treasuryBalance - burnChecks.amountOrSerialNumberU256,
+                    postBurnInfo.treasuryBalance,
+                    'expected treasury balance to decrease by burn amount'
+                );
+            }
+
+            if (burnChecks.isNonFungible) {
+                assertEq(
+                    preBurnInfo.totalSupply - 1,
+                    postBurnInfo.totalSupply,
+                    'expected total supply to decrease by burn amount'
+                );
+                assertEq(
+                    preBurnInfo.treasuryBalance - 1,
+                    postBurnInfo.treasuryBalance,
+                    'expected treasury balance to decrease by burn amount'
+                );
+            }
+        }
+
+        if (!success) {
+            assertEq(
+                preBurnInfo.totalSupply,
+                postBurnInfo.totalSupply,
+                'expected total supply to not change if failed'
+            );
+            assertEq(
+                preBurnInfo.treasuryBalance,
+                postBurnInfo.treasuryBalance,
+                'expected treasury balance to not change if failed'
+            );
+        }
+    }
+
+}

--- a/tools/foundry-example/test/utils/UtilUtils.sol
+++ b/tools/foundry-example/test/utils/UtilUtils.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import 'forge-std/Test.sol';
+
+import '../mocks/util-precompile/UtilPrecompileMock.sol';
+import './CommonUtils.sol';
+import '../libraries/Constants.sol';
+
+/// for testing actions of the util precompiled/system contract
+abstract contract UtilUtils is Test, CommonUtils, Constants {
+
+    UtilPrecompileMock utilPrecompile = UtilPrecompileMock(UTIL_PRECOMPILE);
+
+    function _setUpUtilPrecompileMock() internal {
+        UtilPrecompileMock utilPrecompileMock = new UtilPrecompileMock();
+        bytes memory code = address(utilPrecompileMock).code;
+        vm.etch(UTIL_PRECOMPILE, code);
+    }
+
+    function _doCallPseudorandomSeed(address sender) internal setPranker(sender) returns (bytes32 seed) {
+        seed = utilPrecompile.getPseudorandomSeed();
+    }
+}

--- a/tools/hardhat-example/.gitignore
+++ b/tools/hardhat-example/.gitignore
@@ -4,6 +4,7 @@ coverage
 coverage.json
 typechain
 typechain-types
+types
 
 #Hardhat files
 cache


### PR DESCRIPTION
**Description**:

This PR introduces a `foundry-example` project in the `./tools` directory alongside other example projects implemented using popular Ethereum development frameworks.

The purpose of this addition is to improve the local development experience for smart contract developers working with Hedera's precompiled contracts (HTS, Exchange Rate, and Prng) by providing mock contracts that can be used for faster testing in Foundry.

**Related issue(s)**:

Fixes #1172 

**Notes for reviewer**:

The `Util` and `ExchangeRate` precompile mocks are essentially complete, while the `HTS` precompile mock covers the most commonly used functionalities. The implementation could benefit from refactoring, and the reviewer's feedback is welcome to improve the overall structure and organization of the code.

It might be beneficial to move the precompile mock contracts and their tests into a separate repository rather than including them in the `foundry-example` project. The `foundry-example` project can then import the precompile mocks and use them in an example contract such as the `SimpleVault` contract.

List of TODOs:

* Locate and address all `TODO` comments in the `foundry-example` project
* Write tests for all HTS token `keyTypes` (ADMIN, KYC, FREEZE, WIPE, SUPPLY, FEE, PAUSE)
* Investigate and adjust the ordering of `HederaResponseCodes` in the precompile mocks, ensuring consistency with the behaviour on Hedera.
* Improve tests and code coverage. `forge coverage` evaluates test coverage.
* Align gas costs and `msg.value` for all three precompile/system contract mock functions with the respective gas costs and HBAR values on the Hedera network. As far as I can tell, Foundry does not have cheat codes to play around with the perceived gas cost of an execution so this may not be easily achievable.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
