### PR TITLE
Removed Assertion.expectedError.

### DIFF
--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -59,7 +59,6 @@ export default class RelayClient {
         try {
             const res = await this.call(methodName, params, requestId);
             this.logger.trace(`${requestIdPrefix} [POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`);
-            Assertions.expectedError();
         } catch (err) {
             Assertions.jsonRpcError(err, expectedRpcError);
         }


### PR DESCRIPTION
**Description**:
Removed Assertion.expectedError in the callFailing method.  Doing so allows the proper error to be caught and the test to pass.

**Related issue(s)**:

Fixes #1199


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
