### PR TITLE
Return meaningful JSON RPC errors

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1003,7 +1003,7 @@ export class EthImpl implements Eth {
       if (e instanceof JsonRpcError) {
         return e;
       }
-      return predefined.INTERNAL_ERROR();
+      return e.message ? predefined.INTERNAL_ERROR(e.message.toString()) : predefined.INTERNAL_ERROR();
     }
   }
 
@@ -1062,7 +1062,7 @@ export class EthImpl implements Eth {
       if (e instanceof JsonRpcError) {
         return e;
       }
-      return predefined.INTERNAL_ERROR();
+      return e.message ? predefined.INTERNAL_ERROR(e.message.toString()) : predefined.INTERNAL_ERROR();
     }
   }
 
@@ -1113,7 +1113,7 @@ export class EthImpl implements Eth {
       return await this.callConsensusNode(call, gas, requestId);
     } catch (e: any) {
       this.logger.error(e, `${requestIdPrefix} Failed to successfully submit eth_call`);
-      return e instanceof JsonRpcError ? e : predefined.INTERNAL_ERROR();
+      return e instanceof JsonRpcError ? e : e.message ? predefined.INTERNAL_ERROR(e.message) : predefined.INTERNAL_ERROR();
     }
   }
 
@@ -1145,7 +1145,7 @@ export class EthImpl implements Eth {
         return await this.callConsensusNode(call, gas, requestId);
       } 
       this.logger.error(e, `${requestIdPrefix} Failed to successfully submit eth_call`);
-      return e instanceof JsonRpcError ? e : predefined.INTERNAL_ERROR();
+      return e instanceof JsonRpcError ? e : e.message ? predefined.INTERNAL_ERROR(e.message) : predefined.INTERNAL_ERROR();
     }
   }
 
@@ -1185,7 +1185,7 @@ export class EthImpl implements Eth {
       if (e instanceof JsonRpcError) {
         return e;
       }
-      return predefined.INTERNAL_ERROR();
+      return e.message ? predefined.INTERNAL_ERROR(e.message.toString()) : predefined.INTERNAL_ERROR();
     }
   }
 
@@ -1592,8 +1592,7 @@ export class EthImpl implements Eth {
           e,
           `${requestIdPrefix} Failed to retrieve contract result details for contract address ${to} at timestamp=${timestamp}`
         );
-
-        throw predefined.INTERNAL_ERROR();
+        throw e.message ? predefined.INTERNAL_ERROR(e.message.toString()) : predefined.INTERNAL_ERROR();
       });
   }
 
@@ -1762,8 +1761,7 @@ export class EthImpl implements Eth {
     if (error instanceof JsonRpcError) {
       throw error;
     }
-
-    return predefined.INTERNAL_ERROR();
+    return error.message ? predefined.INTERNAL_ERROR(error.message.toString()) : predefined.INTERNAL_ERROR();
   }
 
   /**************************************************

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3434,8 +3434,8 @@ describe('Eth calls using MirrorNode', async function () {
         await ethImpl.sendRawTransaction(txHash);
       } catch (e) {
         hasError = true;
-        expect(e.code).to.equal(predefined.INTERNAL_ERROR().code);
-        expect(e.message).to.equal(predefined.INTERNAL_ERROR().message);
+        expect(e.code).to.equal(predefined.INTERNAL_ERROR(e.message).code);
+        expect(e.message).to.equal(predefined.INTERNAL_ERROR(e.message).message);
       }
       expect(hasError).to.be.true;
     });

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -498,6 +498,24 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 Assertions.transactionReceipt(res, mirrorResult);
             });
 
+            it('@release should fail to execute "eth_getTransactionReceipt" for hash of London transaction', async function () {
+                const gasPrice = await relay.gasPrice(requestId);
+                const transaction = {
+                    ...defaultLondonTransactionData,
+                    to: mirrorContract.evm_address,
+                    nonce: await relay.getAccountNonce('0x' + accounts[2].address, requestId),
+                    maxFeePerGas: gasPrice,
+                    maxPriorityFeePerGas: gasPrice
+                };
+
+                const signedTx = await accounts[2].wallet.signTransaction(transaction);
+                try {
+                    await relay.sendRawTransaction(signedTx+"11", requestId);
+                } catch (error) {
+                    expect(`Error invoking RPC: ${error.message}`).to.equal(predefined.INTERNAL_ERROR(error.message).message);
+                } 
+            });
+
             it('should execute "eth_getTransactionReceipt" for non-existing hash', async function () {
                 const res = await relay.call('eth_getTransactionReceipt', [NON_EXISTING_TX_HASH], requestId);
                 expect(res).to.be.null;


### PR DESCRIPTION
**Description**:
This PR expands relay error handling to return more meaningful errors and increase the dev experience.
Internal Errors before looked like this:

```
body=“{\“jsonrpc\“:\“2.0\“,\“id\“:45,\“error\“:{\“code\“:-32603,\“name\“:\“Internal error\“,\“message\“:\“[Request ID: x] Unknown error invoking RPC\“}}”
```

After this PR will look like this:

```
body=“{\“jsonrpc\“:\“2.0\“,\“id\“:45,\“error\“:{\“code\“:-32603,\“name\“:\“Internal error\“,\“message\“:\“[Request ID: x] Error invoking RPC: invalid rlp data (argument=\\\“data\\\“, value=Uint8Array(0x81287c), code=INVALID_ARGUMENT, version=rlp/5.7.0)\“}}”
```
**Related issue(s)**:

Fixes #1211 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
