### PR TITLE
resolveEntityType error  handling  improvement  inside promises 

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -728,7 +728,7 @@ export class MirrorNodeClient {
         }));
 
         if (searchableTypes.find(t => t === constants.TYPE_CONTRACT)) {
-            const contract = await this.getContract(entityIdentifier, requestId);
+            const contract = await this.getContract(entityIdentifier, requestId).catch(() =>  {return null;});
             if (contract) {
                 const response = {
                     type: constants.TYPE_CONTRACT,
@@ -742,12 +742,12 @@ export class MirrorNodeClient {
         let data;
         try {
             const promises = [
-                searchableTypes.find(t => t === constants.TYPE_ACCOUNT) ? buildPromise(this.getAccount(entityIdentifier, requestId)) : Promise.reject(),
+                searchableTypes.find(t => t === constants.TYPE_ACCOUNT) ? buildPromise(this.getAccount(entityIdentifier, requestId).catch(() =>  {return null;})) : Promise.reject(),
             ];
 
             // only add long zero evm addresses for tokens as they do not refer to actual contract addresses but rather encoded entity nums            
             if (entityIdentifier.startsWith(constants.LONG_ZERO_PREFIX)) {
-                promises.push(searchableTypes.find(t => t === constants.TYPE_TOKEN) ? buildPromise(this.getTokenById(`0.0.${parseInt(entityIdentifier, 16)}`, requestId)) : Promise.reject());
+                promises.push(searchableTypes.find(t => t === constants.TYPE_TOKEN) ? buildPromise(this.getTokenById(`0.0.${parseInt(entityIdentifier, 16)}`, requestId).catch(() =>  {return null;})) : Promise.reject());
             }
 
             // maps the promises with indices of the promises array

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3313,6 +3313,32 @@ describe('Eth calls using MirrorNode', async function () {
       expect(result).to.equal("0x00");
     });
 
+    it('eth_call with all fields but mirrorNode throws 504 (timeout) on pre-check', async function () {
+
+      const timeoutAddress = "0x00000000000000000000000000000000000004e2";
+      const timeoutContract  =  "0x00000000000000000000000000000000000004e3";
+      restMock.onGet(`contracts/${timeoutAddress}`).reply(504);
+      restMock.onGet(`accounts/${timeoutContract}`).reply(504);
+
+      const callData = {
+        ...defaultCallData,
+        "from": timeoutAddress,
+        "to": timeoutContract,
+        "data": contractCallData,
+        "gas": maxGasLimit
+      };
+      web3Mock.onPost('contracts/call', {...callData, estimate: false}).reply(200, {result: `0x00`});
+
+      let  error;
+      try {
+        const result = await ethImpl.call(callData, 'latest');
+      }  catch (e) {
+        error = e;
+      }
+      expect(error).to.be.not.null;
+      expect(error.message).to.equal("Non Existing Account Address: 0x00000000000000000000000000000000000004e2. Expected an Account Address.");
+    });
+
     it('eth_call with all fields, but mirror node throws NOT_SUPPORTED', async function () {
       const callData = {
         ...defaultCallData,


### PR DESCRIPTION
**Description**:
resolveEntityType uses promises, if the promises  returned an  exception,  it  was  not  being bubbled/propagated, but  instead  it  was  crashing  the  app,  the  most  common  case  is  when  the  mirror  node  returns  a  504  (timeout).  now  its  returning  null

**Related issue(s)**:

Fixes #1215 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
