### PR TITLE
feat(chart): Support an existing secret and configmap

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -38,7 +38,10 @@ spec:
         - configMapRef:
             name: {{ include "json-rpc-relay.fullname" . }}
         - secretRef:
-            name: {{ include "json-rpc-relay.fullname" . }}  
+            name: {{ include "json-rpc-relay.fullname" . }}
+        {{- with .Values.extraEnvFrom }}
+          {{- tpl (toYaml .) $ | nindent 8 }}
+        {{- end }}
         ports:
           - containerPort: {{ .Values.ports.containerPort }}
             name: {{ .Values.ports.name  }}

--- a/helm-chart/templates/secret.yaml
+++ b/helm-chart/templates/secret.yaml
@@ -10,4 +10,3 @@ stringData:
   OPERATOR_KEY_MAIN: {{ .Values.config.OPERATOR_KEY_MAIN | quote }}
   OPERATOR_ID_ETH_SENDRAWTRANSACTION: {{ .Values.config.OPERATOR_ID_ETH_SENDRAWTRANSACTION | default (printf "%q" "") }}
   OPERATOR_KEY_ETH_SENDRAWTRANSACTION: {{ .Values.config.OPERATOR_KEY_ETH_SENDRAWTRANSACTION | default (printf "%q" "") }}  
-  

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -46,6 +46,11 @@ config:
   TIER_3_RATE_LIMIT: 400
   WEB_SOCKET_PORT: 8546
 
+# -- Extra environment variables from existing secrets or configmaps
+extraEnvFrom: []
+# - secretRef:
+#     name: "{{ .Release.Name }}-env"
+
 cronjob:
   enabled: false
   image:


### PR DESCRIPTION
**Description**:
This PR is to support the existing secret or configmap for the relay configuration.
The typical usecase is when the sensitive data is stored in the vault software and the k8s secret is generated by external-secret operator.

**Related issue(s)**:

Fixes #1257 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
