### PR TITLE
Add clientCache to centralize cache

### DIFF
--- a/packages/relay/src/lib/clients/clientCache.ts
+++ b/packages/relay/src/lib/clients/clientCache.ts
@@ -56,12 +56,11 @@ export class ClientCache {
      */
     private readonly register: Registry;
     private cacheKeyCounter;
-
+    
     public constructor(logger: Logger, register: Registry) {
         this.cache = new LRU(this.options);
         this.logger = logger;
         this.register = register;
-
         const cacheSizeCollect = () => {
             this.purgeStale();
             this.cacheKeyCounter.set(this.cache.size);

--- a/packages/relay/src/lib/clients/clientCache.ts
+++ b/packages/relay/src/lib/clients/clientCache.ts
@@ -56,7 +56,7 @@ export class ClientCache {
      */
     private readonly register: Registry;
     private cacheKeyCounter;
-    
+
     public constructor(logger: Logger, register: Registry) {
         this.cache = new LRU(this.options);
         this.logger = logger;

--- a/packages/relay/src/lib/clients/clientCache.ts
+++ b/packages/relay/src/lib/clients/clientCache.ts
@@ -61,6 +61,7 @@ export class ClientCache {
         this.cache = new LRU(this.options);
         this.logger = logger;
         this.register = register;
+
         const cacheSizeCollect = () => {
             this.purgeStale();
             this.cacheKeyCounter.set(this.cache.size);
@@ -82,8 +83,13 @@ export class ClientCache {
     public get(key: string, callingMethod?: string, requestIdPrefix?: string): any {
         let value = this.cache.get(key);
         if (value) {
-            this.logger.trace(`${requestIdPrefix} returning cached value ${key}:${JSON.stringify(value)}`);
-            this.cacheKeyCounter.labels(key, callingMethod).inc(1);
+            if (callingMethod) {
+                this.cacheKeyCounter.labels(key, callingMethod).inc(1);
+            } else {
+                this.cacheKeyCounter.labels(key, null).inc(1);
+            }
+
+            this.logger.trace(`${requestIdPrefix} returning cached value ${key}:${JSON.stringify(value)} on ${callingMethod} call`);
             return value;
         }
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -471,7 +471,7 @@ export class MirrorNodeClient {
 
     public async getBlock(hashOrBlockNumber: string | number, requestId?: string) {
         const cachedLabel = `${constants.CACHE_KEY.GET_BLOCK}.${hashOrBlockNumber}`;
-        const cachedResponse: any = this.cache.get(cachedLabel);
+        const cachedResponse: any = this.cache.get(cachedLabel, MirrorNodeClient.GET_BLOCK_ENDPOINT);
         if (cachedResponse) {
             return cachedResponse;
         }
@@ -503,7 +503,7 @@ export class MirrorNodeClient {
 
     public async isValidContract(contractIdOrAddress: string, requestId?: string) {
         const cachedLabel = `${constants.CACHE_KEY.GET_CONTRACT}.valid.${contractIdOrAddress}`;
-        const cachedResponse: any = this.cache.get(cachedLabel);
+        const cachedResponse: any = this.cache.get(cachedLabel, MirrorNodeClient.GET_CONTRACT_ENDPOINT);
         if (cachedResponse != undefined) {
             return cachedResponse;
         }
@@ -517,7 +517,7 @@ export class MirrorNodeClient {
 
     public async getContractId(contractIdOrAddress: string, requestId?: string) {
         const cachedLabel = `${constants.CACHE_KEY.GET_CONTRACT}.id.${contractIdOrAddress}`;
-        const cachedResponse: any = this.cache.get(cachedLabel);
+        const cachedResponse: any = this.cache.get(cachedLabel, MirrorNodeClient.GET_CONTRACT_ENDPOINT);
         if (cachedResponse != undefined) {
             return cachedResponse;
         }
@@ -537,7 +537,7 @@ export class MirrorNodeClient {
 
     public async getContractResult(transactionIdOrHash: string, requestId?: string) {
         const cacheKey = `${constants.CACHE_KEY.GET_CONTRACT_RESULT}.${transactionIdOrHash}`;
-        const cachedResponse = this.cache.get(cacheKey);
+        const cachedResponse = this.cache.get(cacheKey, MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT);
 
         if(cachedResponse) {
             return cachedResponse;
@@ -664,7 +664,7 @@ export class MirrorNodeClient {
 
     public async getEarliestBlock(requestId?: string) {
         const cachedLabel = `${constants.CACHE_KEY.GET_BLOCK}.earliest`;
-        const cachedResponse: any = this.cache.get(cachedLabel);
+        const cachedResponse: any = this.cache.get(cachedLabel, MirrorNodeClient.GET_BLOCKS_ENDPOINT);
         if (cachedResponse != undefined) {
             return cachedResponse;
         }

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -55,6 +55,7 @@ import HbarLimit from '../hbarlimiter';
 import constants from './../constants';
 import { SDKClientError } from './../errors/SDKClientError';
 import { JsonRpcError, predefined } from './../errors/JsonRpcError';
+import { ClientCache } from './clientCache';
 
 const _ = require('lodash');
 const LRU = require('lru-cache');
@@ -95,7 +96,7 @@ export class SDKClient {
     private maxChunks;
 
     // populate with consensusnode requests via SDK
-    constructor(clientMain: Client, logger: Logger, hbarLimiter: HbarLimit, metrics: any) {
+    constructor(clientMain: Client, logger: Logger, hbarLimiter: HbarLimit, metrics: any, clientCache: ClientCache) {
         this.clientMain = clientMain;
 
         if (process.env.CONSENSUS_MAX_EXECUTION_TIME) {
@@ -110,7 +111,7 @@ export class SDKClient {
         this.operatorAccountGauge = metrics.operatorGauge;
 
         this.hbarLimiter = hbarLimiter;
-        this.cache = new LRU({ max: constants.CACHE_MAX, ttl: constants.CACHE_TTL.ONE_HOUR });
+        this.cache = clientCache;
         this.maxChunks = Number(process.env.FILE_APPEND_MAX_CHUNKS) || 20;
     }
 
@@ -163,7 +164,7 @@ export class SDKClient {
 
     async getTinyBarGasFee(callerName: string, requestId?: string): Promise<number> {
         const cachedResponse: number | undefined = this.cache.get(constants.CACHE_KEY.GET_TINYBAR_GAS_FEE);
-        if (cachedResponse != undefined) {
+        if (cachedResponse) {
             return cachedResponse;
         }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -88,7 +88,7 @@ export class SDKClient {
      * LRU cache container.
      * @private
      */
-    private readonly cache;
+    private readonly cache: ClientCache;
 
     private consensusNodeClientHistogramCost;
     private consensusNodeClientHistogramGasFee;

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -413,8 +413,7 @@ export class EthImpl implements Eth {
     if (Array.isArray(blocks) && blocks.length > 0) {
       const currentBlock = EthImpl.numberTo0x(blocks[0].number);
       // save the latest block number in cache
-      this.cache.set(cacheKey, currentBlock, { ttl: this.ethBlockNumberCacheTtlMs });
-      this.logger.trace(`${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(currentBlock)} for ${this.ethBlockNumberCacheTtlMs} ms`);
+      this.cache.set(cacheKey, currentBlock,this.ethBlockNumberCacheTtlMs);
 
       return currentBlock;
     }
@@ -438,12 +437,7 @@ export class EthImpl implements Eth {
       const timestamp = blocks[0].timestamp.to;
       const blockTimeStamp: LatestBlockNumberTimestamp = { blockNumber: currentBlock, timeStampTo: timestamp };
       // save the latest block number in cache
-      this.cache.set(cacheKey, currentBlock, { ttl: this.ethBlockNumberCacheTtlMs });
-      this.logger.trace(
-        `${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(currentBlock)}:${JSON.stringify(timestamp)} for ${
-          this.ethBlockNumberCacheTtlMs
-        } ms`
-      );
+      this.cache.set(cacheKey, currentBlock, this.ethBlockNumberCacheTtlMs);
 
       return blockTimeStamp;
     }
@@ -535,8 +529,7 @@ export class EthImpl implements Eth {
       if (!gasPrice) {
         gasPrice = await this.getFeeWeibars(EthImpl.ethGasPrice, requestId);
         // fees should not change so often we are safe with 1 day instead of 1 hour
-        this.logger.trace(`${requestIdPrefix} caching ${constants.CACHE_KEY.GAS_PRICE}:${gasPrice} for ${constants.CACHE_TTL.ONE_DAY} ms`);
-        this.cache.set(constants.CACHE_KEY.GAS_PRICE, gasPrice, {ttl: constants.CACHE_TTL.ONE_DAY});
+        this.cache.set(constants.CACHE_KEY.GAS_PRICE, gasPrice, constants.CACHE_TTL.ONE_DAY);
       }
 
       return EthImpl.numberTo0x(gasPrice);
@@ -847,10 +840,7 @@ export class EthImpl implements Eth {
       }
 
       // save in cache the current balance for the account and blockNumberOrTag
-      this.cache.set(cacheKey, EthImpl.numberTo0x(weibars), { ttl: this.ethGetBalanceCacheTtlMs });
-      this.logger.trace(
-        `${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(cachedBalance)} for ${this.ethGetBalanceCacheTtlMs} ms`
-      );
+      this.cache.set(cacheKey, EthImpl.numberTo0x(weibars), this.ethGetBalanceCacheTtlMs);
 
       return EthImpl.numberTo0x(weibars);
     } catch (error: any) {
@@ -1104,8 +1094,7 @@ export class EthImpl implements Eth {
     }
 
     const cacheTtl = blockNumOrTag === EthImpl.blockEarliest || !isNaN(blockNum) ? constants.CACHE_TTL.ONE_DAY : this.ethGetTransactionCountCacheTtl; // cache historical values longer as they don't change
-    this.logger.trace(`${requestIdPrefix} caching ${cacheKey}:${nonceCount} for ${cacheTtl} ms`);
-    this.cache.set(cacheKey, nonceCount, { ttl: cacheTtl }); 
+    this.cache.set(cacheKey, nonceCount, cacheTtl); 
 
     return nonceCount;
   }
@@ -1327,7 +1316,7 @@ export class EthImpl implements Eth {
       if (contractCallResponse) {
         const formattedCallReponse = EthImpl.prepend0x(Buffer.from(contractCallResponse.asBytes()).toString('hex'));
 
-        this.cache.set(cacheKey, formattedCallReponse, { ttl: this.ethCallCacheTtl });
+        this.cache.set(cacheKey, formattedCallReponse, this.ethCallCacheTtl);
         return formattedCallReponse;
       }
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -24,7 +24,7 @@ import { BigNumber } from '@hashgraph/sdk/lib/Transfer';
 import {BigNumber as BN} from "bignumber.js";
 import { Logger } from 'pino';
 import { Block, Transaction, Log } from './model';
-import { MirrorNodeClient } from './clients';
+import { ClientCache, MirrorNodeClient } from './clients';
 import { JsonRpcError, predefined } from './errors/JsonRpcError';
 import { SDKClientError } from './errors/SDKClientError';
 import { MirrorNodeClientError } from './errors/MirrorNodeClientError';
@@ -125,7 +125,7 @@ export class EthImpl implements Eth {
    *
    * @private
    */
-  private readonly cache;
+  private readonly cache: ClientCache;
 
   /**
    * The client service which is responsible for client all logic related to initialization, reinitialization and error/transactions tracking.
@@ -177,15 +177,14 @@ export class EthImpl implements Eth {
     logger: Logger,
     chain: string,
     registry: Registry,
-    cache?
+    clientCache?
   ) {
     this.hapiService = hapiService;
     this.mirrorNodeClient = mirrorNodeClient;
     this.logger = logger;
     this.chain = chain;
     this.precheck = new Precheck(mirrorNodeClient, this.hapiService, logger, chain);
-    this.cache = cache;
-    if (!cache) this.cache = new LRU(this.options);
+    this.cache = clientCache;
 
     this.ethExecutionsCounter = this.initEthExecutionCounter(registry);
   }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -270,7 +270,6 @@ export class EthImpl implements Eth {
         if (!feeHistory) {
           feeHistory = await this.getFeeHistory(blockCount, newestBlockNumber, latestBlockNumber, rewardPercentiles, requestId);
           if (newestBlock != EthImpl.blockLatest && newestBlock != EthImpl.blockPending) {
-            this.logger.trace(`${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(feeHistory)} for ${constants.CACHE_TTL.ONE_HOUR} ms`);
             this.cache.set(cacheKey, feeHistory);
           }
         }
@@ -497,7 +496,6 @@ export class EthImpl implements Eth {
 
           // when account exists return default base gas, otherwise return the minimum amount of gas to create an account entity
           if (toAccount) {
-            this.logger.trace(`${requestIdPrefix} caching ${accountCacheKey}:${JSON.stringify(toAccount)} for ${constants.CACHE_TTL.ONE_HOUR} ms`);
             this.cache.set(accountCacheKey, toAccount);
 
             gas = EthImpl.gasTxBaseCost;
@@ -951,7 +949,6 @@ export class EthImpl implements Eth {
       });
 
       if (blockNumOrTag != EthImpl.blockLatest && blockNumOrTag != EthImpl.blockPending) {
-        this.logger.trace(`${requestIdPrefix} caching ${cacheKey}:${JSON.stringify(block)} for ${constants.CACHE_TTL.ONE_HOUR} ms`);
         this.cache.set(cacheKey, block);
       }
     }
@@ -1414,7 +1411,6 @@ export class EthImpl implements Eth {
       if (!accountResult) {
         accountResult = await this.mirrorNodeClient.getAccount(fromAddress, requestId);
         if (accountResult) {
-          this.logger.trace(`${requestIdPrefix} caching ${accountCacheKey}:${JSON.stringify(accountResult)} for ${constants.CACHE_TTL.ONE_HOUR} ms`);
           this.cache.set(accountCacheKey, accountResult);
         }
       }

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -57,13 +57,12 @@ export class RelayImpl implements Relay {
     const total = constants.HBAR_RATE_LIMIT_TINYBAR;
     const hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, register);
 
-    const hapiService = new HAPIService(logger, register, hbarLimiter);
+    this.clientCache = new ClientCache(logger.child({ name: 'client-cache' }), register);
+    const hapiService = new HAPIService(logger, register, hbarLimiter, this.clientCache);
     this.clientMain = hapiService.getMainClientInstance();
 
     this.web3Impl = new Web3Impl(this.clientMain);
     this.netImpl = new NetImpl(this.clientMain, chainId);
-
-    this.clientCache = new ClientCache(logger.child({ name: 'client-cache' }), register);
 
     this.mirrorNodeClient = new MirrorNodeClient(
       process.env.MIRROR_NODE_URL || '',

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -79,7 +79,8 @@ export class RelayImpl implements Relay {
       this.mirrorNodeClient,
       logger.child({ name: 'relay-eth' }),
       chainId,
-      register,);
+      register,
+      this.clientCache);
 
     if (process.env.SUBSCRIPTIONS_ENABLED && process.env.SUBSCRIPTIONS_ENABLED === 'true') {
       const poller = new Poller(this.ethImpl, logger, register);

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -92,6 +92,7 @@ export default class HAPIService {
     this.consensusNodeClientHistogramGasFee = this.initGasMetric(register);
 
     this.metrics = { costHistogram: this.consensusNodeClientHistogramCost, gasHistogram: this.consensusNodeClientHistogramGasFee };
+    this.cache = clientCache;
     this.client = this.initSDKClient(logger, this.metrics);
 
     const currentDateNow = Date.now();
@@ -120,7 +121,6 @@ export default class HAPIService {
       registers: [register],
       labelNames: ['transactions', 'duration', 'errors'],
     });
-    this.cache = clientCache;
   }
 
   /**

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -26,6 +26,7 @@ import { Registry, Counter, Gauge, Histogram } from 'prom-client';
 import { SDKClient } from '../../clients/sdkClient';
 import constants from '../../constants';
 import HbarLimit from '../../hbarlimiter';
+import { ClientCache } from '../../clients';
 
 export default class HAPIService {
   private transactionCount: number;
@@ -72,12 +73,13 @@ export default class HAPIService {
   private consensusNodeClientHistogramCost: Histogram;
   private consensusNodeClientHistogramGasFee: Histogram;
   private metrics: any;
+  private readonly cache: ClientCache;
 
   /**
    * @param {Logger} logger
    * @param {Registry} register
    */
-  constructor(logger: Logger, register: Registry, hbarLimiter: HbarLimit) {
+  constructor(logger: Logger, register: Registry, hbarLimiter: HbarLimit, clientCache) {
     dotenv.config({ path: findConfig('.env') || '' });
 
     this.logger = logger;
@@ -118,6 +120,7 @@ export default class HAPIService {
       registers: [register],
       labelNames: ['transactions', 'duration', 'errors'],
     });
+    this.cache = clientCache;
   }
 
   /**
@@ -186,7 +189,7 @@ export default class HAPIService {
    * @returns SDK Client
    */
   private initSDKClient(logger: Logger, metrics: any): SDKClient {
-    return new SDKClient(this.clientMain, logger.child({ name: `consensus-node` }), this.hbarLimiter, metrics);
+    return new SDKClient(this.clientMain, logger.child({ name: `consensus-node` }), this.hbarLimiter, metrics, this.cache);
   }
 
   /**

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -93,7 +93,7 @@ describe('Eth calls using MirrorNode', async function () {
   const ethFeeHistoryValue = process.env.ETH_FEE_HISTORY_FIXED || 'true';
 
   this.beforeAll(() => {
-    const clientCache = new ClientCache(logger.child({ name: `cache` }), registry,);
+    const clientCache = new ClientCache(logger.child({ name: `cache` }), registry);
     // @ts-ignore
     mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, clientCache);
 

--- a/packages/relay/tests/lib/ethGetBlockBy.spec.ts
+++ b/packages/relay/tests/lib/ethGetBlockBy.spec.ts
@@ -32,6 +32,7 @@ import pino from 'pino';
 import constants from '../../src/lib/constants';
 import HAPIService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
+import { ClientCache } from '../../src/lib/clients';
 
 const LRU = require('lru-cache');
 
@@ -255,8 +256,9 @@ describe('eth_getBlockBy', async function () {
         const duration = constants.HBAR_RATE_LIMIT_DURATION;
         const total = constants.HBAR_RATE_LIMIT_TINYBAR;
         const hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, registry);
-    
-        hapiServiceInstance = new HAPIService(logger, registry, hbarLimiter);
+        const clientCache = new ClientCache(logger.child({ name: `cache` }), registry);
+        
+        hapiServiceInstance = new HAPIService(logger, registry, hbarLimiter, clientCache);
     
         cache = new LRU({
           max: constants.CACHE_MAX,

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -55,7 +55,7 @@ describe('MirrorNodeClient', async function () {
       },
       timeout: 20 * 1000
     });
-    mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, new ClientCache(logger.child({ name: `cache` }), registry) instance);
+    mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, new ClientCache(logger.child({ name: `cache` }), registry), instance);
   });
 
   beforeEach(() => {

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -33,6 +33,7 @@ const registry = new Registry();
 import pino from 'pino';
 import { SDKClientError } from '../../src/lib/errors/SDKClientError';
 import { predefined } from '../../src/lib/errors/JsonRpcError';
+import { ClientCache } from '../../src/lib/clients';
 const logger = pino();
 import { v4 as uuid } from 'uuid';
 import { formatRequestIdMessage } from '../../src/formatters';
@@ -54,7 +55,7 @@ describe('MirrorNodeClient', async function () {
       },
       timeout: 20 * 1000
     });
-    mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
+    mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, new ClientCache(logger.child({ name: `cache` }), registry) instance);
   });
 
   beforeEach(() => {
@@ -118,7 +119,7 @@ describe('MirrorNodeClient', async function () {
 
   it('`restUrl` is exposed and correct', async () => {
     const domain = process.env.MIRROR_NODE_URL.replace(/^https?:\/\//, "");
-    const prodMirrorNodeInstance = new MirrorNodeClient(domain, logger.child({ name: `mirror-node` }), registry);
+    const prodMirrorNodeInstance = new MirrorNodeClient(domain, logger.child({ name: `mirror-node` }), registry, new ClientCache(logger.child({ name: `cache` }), registry));
     expect(prodMirrorNodeInstance.restUrl).to.eq(`https://${domain}/api/v1/`);
   });
 

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -33,7 +33,7 @@ import { RelayImpl } from '../../src/lib/relay';
 import { Registry } from 'prom-client';
 
 import { EthImpl } from '../../src/lib/eth';
-import { SDKClient } from '../../src/lib/clients';
+import { ClientCache, SDKClient } from '../../src/lib/clients';
 import { MirrorNodeClient } from '../../src/lib/clients/mirrorNodeClient';
 
 import openRpcSchema from "../../../../docs/openrpc.json";
@@ -110,8 +110,9 @@ describe("Open RPC Specification", function () {
 
         // @ts-ignore
         mock = new MockAdapter(instance, { onNoMatch: "throwException" });
+        const clientCache = new ClientCache(logger.child({ name: `cache` }), registry);
         // @ts-ignore
-        mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
+        mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, clientCache, instance);
         const duration = constants.HBAR_RATE_LIMIT_DURATION;
         const total = constants.HBAR_RATE_LIMIT_TINYBAR;
         const hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, registry);
@@ -120,7 +121,7 @@ describe("Open RPC Specification", function () {
         sdkClientStub = sinon.createStubInstance(SDKClient);
         sinon.stub(clientServiceInstance, "getSDKClient").returns(sdkClientStub);
         // @ts-ignore
-        ethImpl = new EthImpl(clientServiceInstance, mirrorNodeInstance, logger, '0x12a', registry);
+        ethImpl = new EthImpl(clientServiceInstance, mirrorNodeInstance, logger, '0x12a', registry, clientCache);
 
         // mocked data
         mock.onGet('blocks?limit=1&order=desc').reply(200, { blocks: [defaultBlock] });

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -117,7 +117,7 @@ describe("Open RPC Specification", function () {
         const total = constants.HBAR_RATE_LIMIT_TINYBAR;
         const hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, registry);
 
-        clientServiceInstance = new ClientService(logger, registry, hbarLimiter);
+        clientServiceInstance = new ClientService(logger, registry, hbarLimiter, clientCache);
         sdkClientStub = sinon.createStubInstance(SDKClient);
         sinon.stub(clientServiceInstance, "getSDKClient").returns(sdkClientStub);
         // @ts-ignore

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -27,7 +27,7 @@ import sinon from 'sinon';
 import pino from 'pino';
 import { Precheck } from "../../src/lib/precheck";
 import { expectedError, mockData, signTransaction } from "../helpers";
-import { MirrorNodeClient, SDKClient } from "../../src/lib/clients";
+import { ClientCache, MirrorNodeClient, SDKClient } from "../../src/lib/clients";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { ethers } from "ethers";
@@ -73,9 +73,9 @@ describe('Precheck', async function() {
 
         // @ts-ignore
         mock = new MockAdapter(instance, { onNoMatch: "throwException" });
-
+        
         // @ts-ignore
-        const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
+        const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, new ClientCache(logger.child({ name: `cache` }), registry), instance);
 
         const duration = constants.HBAR_RATE_LIMIT_DURATION;
         const total = constants.HBAR_RATE_LIMIT_TINYBAR;

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -80,7 +80,8 @@ describe('Precheck', async function() {
         const duration = constants.HBAR_RATE_LIMIT_DURATION;
         const total = constants.HBAR_RATE_LIMIT_TINYBAR;
         const hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, registry);
-        hapiServiceInstance = new HAPIService(logger, registry, hbarLimiter);
+        const clientCache = new ClientCache(logger.child({ name: `cache` }), registry);
+        hapiServiceInstance = new HAPIService(logger, registry, hbarLimiter, clientCache);
         sdkInstance = sinon.createStubInstance(SDKClient);
         sinon.stub(hapiServiceInstance, "getSDKClient").returns(sdkInstance);
         precheck = new Precheck(mirrorNodeInstance, hapiServiceInstance, logger, '0x12a');

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -24,13 +24,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { Registry } from 'prom-client';
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
-import {SDKClient} from '../../src/lib/clients/sdkClient';
 const registry = new Registry();
 import pino from 'pino';
 import {AccountId, Client, ContractCallQuery, PrivateKey, TransactionId, Hbar, Status} from "@hashgraph/sdk";
 const logger = pino();
 import constants from '../../src/lib/constants';
 import HbarLimit from '../../src/lib/hbarlimiter';
+import { ClientCache, SDKClient } from '../../src/lib/clients';
 
 describe('SdkClient', async function () {
     this.timeout(20000);
@@ -45,7 +45,7 @@ describe('SdkClient', async function () {
         const duration = constants.HBAR_RATE_LIMIT_DURATION;
         const total = constants.HBAR_RATE_LIMIT_TINYBAR;
         hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, registry);
-        sdkClient = new SDKClient(client, logger.child({ name: `consensus-node` }), hbarLimiter, { costHistogram: undefined, gasHistogram: undefined });
+        sdkClient = new SDKClient(client, logger.child({ name: `consensus-node` }), hbarLimiter, { costHistogram: undefined, gasHistogram: undefined }, new ClientCache(logger.child({ name: `cache` }), registry));
     })
 
     describe('increaseCostAndRetryExecution', async () => {

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -37,7 +37,13 @@ describe('SdkClient', async function () {
     let sdkClient, client, hbarLimiter;
 
     before(() => {
-        client = Client.forNetwork(JSON.parse(process.env.HEDERA_NETWORK!));
+        const hederaNetwork = process.env.HEDERA_NETWORK!;
+        if (hederaNetwork in constants.CHAIN_IDS) {
+          client = Client.forName(hederaNetwork);
+        } else {
+          client = Client.forNetwork(JSON.parse(hederaNetwork));
+        }
+        
         client = client.setOperator(
             AccountId.fromString(process.env.OPERATOR_ID_MAIN!),
             PrivateKey.fromString(process.env.OPERATOR_KEY_MAIN!)


### PR DESCRIPTION
**Description**:
Centralize caching logic for client calls

- Add a `clientCache class that encapsulates LRU implementation
- Update mirrornode and sdkclient calls
- create instance in relay and pass it along
- add metrics to capture cache hits to observe

**Related issue(s)**:

Fixes #1116 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
