### PR TITLE
SdkClient Hbar Limitter Fix

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -162,6 +162,7 @@ export class EthImpl implements Eth {
     this.cache = cache;
     this.registry = register;
     if (!cache) this.cache = new LRU(this.options);
+    this.hederaClient = SDKClient.initClient(this.logger, this.hederaNetwork);
   }
 
   /* Temporary code duplication for a temporary HotFix workaround while the definitive  fix is implemented
@@ -172,6 +173,8 @@ export class EthImpl implements Eth {
   private ethSdkClient: SDKClient | undefined;
   private isInTest = typeof global.it === 'function';
 
+  private hederaClient;
+
   getSdkClient() {
 
     // for unit tests we need to use the mocked sdk client using DI
@@ -181,9 +184,9 @@ export class EthImpl implements Eth {
 
     // if we have reached the max number of requests per sdk client instance, or if the sdk client instance is undefined, create a new one
     if (this.requestsPerSdkClient >= this.maxRequestsPerSdkClient || this.ethSdkClient == undefined) {
-      const hederaClient = SDKClient.initClient(this.logger, this.hederaNetwork);
-      this.ethSdkClient = new SDKClient(hederaClient, this.logger, this.registry);
+      this.ethSdkClient = new SDKClient(this.hederaClient, this.logger, this.registry);
       this.requestsPerSdkClient = 0;
+      this.logger.debug(`Limit of requests per instance ${this.maxRequestsPerSdkClient} was reached. Created new SDK client instance`);
     }
 
     // increment the number of requests per sdk client instance


### PR DESCRIPTION
sdkClient creates dependencies on the constructor that are meant to be used as singletons, this was okay when the sdkClient itself was a singleton, but  now  that  we  are  refreshing the sdkInstance every X amount of  requests  we need to  set create  this instances  only once and re-used  them throughout   the  lifecycle  of the app, for  that  purpose  we  have refactored these dependencies  as  private  static  and only  initialized them  once (when  they  are  undefined)

The following dependencies  were  refactored:

consensusNodeClientHistogramCost
consensusNodeClientHistogramGasFee
operatorAccountGauge
hbarLimiter

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #1248

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
*First SDK instance created:*
<img width="1167" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/1c3a3c9c-643d-4de4-a5de-e6beab4709d1">


*All other instances:*
<img width="1222" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/f1c95f02-6579-4139-b725-8731f978ebee">
<img width="1194" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/97f7fdab-b418-4786-9bfa-9c6770a99030">
<img width="1158" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/b2327181-9cca-4b80-9966-35f384ed6d64">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
