### PR TITLE
903 automate branch tag

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -1,0 +1,172 @@
+name: Release Production Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release Version (semver ie. 0.30.0):"
+        type: string
+        required: true
+
+env:
+  OWNER: hashgraph
+  PACKAGE_NAME: hedera-json-rpc-relay
+  REGISTRY: ghcr.io
+
+jobs:
+  branch_bump_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      create_pr: ${{ env.CREATE_PR }}
+      next_version_snapshot: ${{ env.NEXT_VERSION_SNAPSHOT }}
+      pr_title: ${{ env.PR_TITLE }}
+      release_branch: ${{ env.RELEASE_BRANCH }}
+
+    steps:
+      - name: Parse Version
+        id: version_parser
+        uses: madhead/semver-utils@latest
+        with:
+          lenient: false
+          version: ${{ github.event.inputs.version }}
+
+      - name: Set Release Environment Variables
+        run: |
+          PREMINOR_VERSION=${{ steps.version_parser.outputs.inc-preminor }}
+          NEXT_VERSION_SNAPSHOT=${PREMINOR_VERSION//-0/-SNAPSHOT}
+          RELEASE_BRANCH="release/${{ steps.version_parser.outputs.major }}.${{ steps.version_parser.outputs.minor }}"
+          [[ -z "${{ steps.version_parser.outputs.prerelease }}" ]] && \
+            VERSION=${{ steps.version_parser.outputs.release }} || \
+            VERSION="${{ steps.version_parser.outputs.release }}-${{ steps.version_parser.outputs.prerelease }}"
+          RELEASE_TAG="v${VERSION}"
+          cat >> $GITHUB_ENV <<EOF
+          NEXT_VERSION_SNAPSHOT=$NEXT_VERSION_SNAPSHOT
+          RELEASE_BRANCH=$RELEASE_BRANCH
+          RELEASE_TAG=$RELEASE_TAG
+          VERSION=$VERSION
+          EOF
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ secrets.HEDERA_BOT_TOKEN }}
+
+      - name: Import GPG Key
+        id: gpg_importer
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        with:
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_user_signingkey: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      
+      - name: Create and Switch to Release Branch
+        run: |
+          if ! git ls-remote --exit-code --heads --quiet origin refs/heads/${RELEASE_BRANCH}; then
+            git checkout -b ${RELEASE_BRANCH}
+            git push -u origin ${RELEASE_BRANCH}
+
+            # create a PR to bump main branch to the next snapshot version
+            echo "CREATE_PR=true" >> $GITHUB_ENV
+            echo "PR_TITLE=Bump versions for v$NEXT_VERSION_SNAPSHOT" >> $GITHUB_ENV
+          else
+            git checkout ${RELEASE_BRANCH}
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lerna Bootstrap
+        run: npm run setup
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Build Typescript
+        run: npm run build
+
+      - name: Bump Versions
+        run: npm run bump-version --semver=${{ env.VERSION }}
+
+      - name: Commit and Tag
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
+          commit_message: Bump versions for ${{ env.RELEASE_TAG }}
+          commit_options: '--no-verify --signoff'
+          commit_user_name: ${{ steps.gpg_importer.outputs.name }}
+          commit_user_email: ${{ steps.gpg_importer.outputs.email }}
+          tagging_message: ${{ env.RELEASE_TAG }}
+
+      - name: Create Github Release
+        uses: ncipollo/release-action@v1
+        with:
+          bodyFile: ${{ env.RELEASE_NOTES_FILENAME }}.md
+          commit: ${{ env.RELEASE_BRANCH }}
+          draft: true
+          name: ${{ env.RELEASE_TAG }}
+          omitBody: ${{ steps.milestone.outputs.milestone_id == '' }}
+          prerelease: ${{ steps.version_parser.outputs.prerelease != '' }}
+          tag: ${{ env.RELEASE_TAG }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  create_snapshot_pr:
+    name: Create snapshot PR
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ needs.release.outputs.create_pr == 'true' }}
+    env:
+      NEXT_VERSION_SNAPSHOT: ${{ needs.release.outputs.next_version_snapshot }}
+      RELEASE_BRANCH: ${{ needs.release.outputs.release_branch }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Import GPG Key
+        id: gpg_importer
+        uses: crazy-max/ghaction-import-gpg@v5.2.0
+        with:
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_user_signingkey: true
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Reset main to release branch
+        run: |
+          git fetch origin $RELEASE_BRANCH:$RELEASE_BRANCH
+          git reset --hard $RELEASE_BRANCH
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lerna Bootstrap
+        run: npm run setup
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Build Typescript
+        run: npm run build
+
+      - name: Bump Versions
+        run: npm run bump-version --semver=${{ env.NEXT_VERSION_SNAPSHOT }} --snapshot=true
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          body: ''
+          branch: create-pull-request/${{ env.RELEASE_BRANCH }}
+          commit-message: Bump versions for v${{ env.NEXT_VERSION_SNAPSHOT }}
+          committer: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
+          author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
+          delete-branch: true
+          signoff: true
+          title: ${{ needs.release.outputs.pr_title }}
+          token: ${{ secrets.HEDERA_BOT_TOKEN }}

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -116,7 +116,7 @@ jobs:
   create_snapshot_pr:
     name: Create snapshot PR
     runs-on: ubuntu-latest
-    needs: release
+    needs: branch_bump_tag
     if: ${{ needs.release.outputs.create_pr == 'true' }}
     env:
       NEXT_VERSION_SNAPSHOT: ${{ needs.release.outputs.next_version_snapshot }}

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -1,4 +1,4 @@
-name: Release Production Environment
+name: Release Branch Automation
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.HEDERA_BOT_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Import GPG Key
         id: gpg_importer

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -28,7 +28,7 @@ jobs:
         uses: madhead/semver-utils@latest
         with:
           lenient: false
-          version: '0.24.0-alpha0'
+          version: '0.27.0-alpha0'
 
       - name: Set Release Environment Variables
         run: |
@@ -60,8 +60,8 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
           git_user_signingkey: true
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
       
       - name: Create and Switch to Release Branch
         run: |
@@ -111,7 +111,7 @@ jobs:
           omitBody: ${{ steps.milestone.outputs.milestone_id == '' }}
           prerelease: ${{ steps.version_parser.outputs.prerelease != '' }}
           tag: ${{ env.RELEASE_TAG }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
   create_snapshot_pr:
     name: Create snapshot PR
@@ -135,8 +135,8 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
           git_user_signingkey: true
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
       - name: Reset main to release branch
         run: |

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -28,7 +28,7 @@ jobs:
         uses: madhead/semver-utils@latest
         with:
           lenient: false
-          version: '0.27.0-alpha1'
+          version: '0.27.0-alpha2'
 
       - name: Set Release Environment Variables
         run: |
@@ -171,4 +171,4 @@ jobs:
           delete-branch: true
           signoff: true
           title: ${{ needs.branch_bump_tag.outputs.pr_title }}
-          token: ${{ secrets.HEDERA_BOT_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -28,7 +28,7 @@ jobs:
         uses: madhead/semver-utils@latest
         with:
           lenient: false
-          version: '0.27.0-alpha2'
+          version: '0.27.0-alpha3'
 
       - name: Set Release Environment Variables
         run: |
@@ -131,7 +131,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
+          fetch-depth: 0
           ref: main
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -142,11 +144,6 @@ jobs:
           git_user_signingkey: true
           gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
-
-      - name: Reset main to release branch
-        run: |
-          git fetch origin $RELEASE_BRANCH:$RELEASE_BRANCH
-          git reset --hard $RELEASE_BRANCH
 
       - name: Install dependencies
         run: npm ci
@@ -164,7 +161,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           body: ''
-          branch: create-pull-request/${{ env.RELEASE_BRANCH }}
+          branch: create-pull-request/${{ env.NEXT_VERSION_SNAPSHOT }}
           commit-message: Bump versions for v${{ env.NEXT_VERSION_SNAPSHOT }}
           committer: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
           author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -7,6 +7,9 @@ on:
         description: "Release Version (semver ie. 0.24.0):"
         type: string
         required: true
+  push:
+    branches:
+      - '903-automate-branch-tag'
 
 jobs:
   branch_bump_tag:
@@ -25,7 +28,7 @@ jobs:
         uses: madhead/semver-utils@latest
         with:
           lenient: false
-          version: ${{ github.event.inputs.version }}
+          version: '0.24.0-alpha0'
 
       - name: Set Release Environment Variables
         run: |

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -4,18 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release Version (semver ie. 0.30.0):"
+        description: "Release Version (semver ie. 0.24.0):"
         type: string
         required: true
-
-env:
-  OWNER: hashgraph
-  PACKAGE_NAME: hedera-json-rpc-relay
-  REGISTRY: ghcr.io
 
 jobs:
   branch_bump_tag:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_NOTES_FILENAME: release_notes
     outputs:
       create_pr: ${{ env.CREATE_PR }}
       next_version_snapshot: ${{ env.NEXT_VERSION_SNAPSHOT }}
@@ -34,7 +31,7 @@ jobs:
         run: |
           PREMINOR_VERSION=${{ steps.version_parser.outputs.inc-preminor }}
           NEXT_VERSION_SNAPSHOT=${PREMINOR_VERSION//-0/-SNAPSHOT}
-          RELEASE_BRANCH="release/${{ steps.version_parser.outputs.major }}.${{ steps.version_parser.outputs.minor }}"
+          RELEASE_BRANCH="test-release/${{ steps.version_parser.outputs.major }}.${{ steps.version_parser.outputs.minor }}"
           [[ -z "${{ steps.version_parser.outputs.prerelease }}" ]] && \
             VERSION=${{ steps.version_parser.outputs.release }} || \
             VERSION="${{ steps.version_parser.outputs.release }}-${{ steps.version_parser.outputs.prerelease }}"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -79,9 +79,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lerna Bootstrap
-        run: npm run setup
-
       - name: Install pnpm
         run: npm install -g pnpm
 
@@ -145,9 +142,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Lerna Bootstrap
-        run: npm run setup
 
       - name: Install pnpm
         run: npm install -g pnpm

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -7,9 +7,6 @@ on:
         description: "Release Version (semver ie. 0.24.0):"
         type: string
         required: true
-  push:
-    branches:
-      - '903-automate-branch-tag'
 
 jobs:
   branch_bump_tag:
@@ -28,13 +25,13 @@ jobs:
         uses: madhead/semver-utils@latest
         with:
           lenient: false
-          version: '0.27.0-alpha3'
+          version: ${{ github.event.inputs.version }}
 
       - name: Set Release Environment Variables
         run: |
           PREMINOR_VERSION=${{ steps.version_parser.outputs.inc-preminor }}
           NEXT_VERSION_SNAPSHOT=${PREMINOR_VERSION//-0/-SNAPSHOT}
-          RELEASE_BRANCH="test-release/${{ steps.version_parser.outputs.major }}.${{ steps.version_parser.outputs.minor }}"
+          RELEASE_BRANCH="release/${{ steps.version_parser.outputs.major }}.${{ steps.version_parser.outputs.minor }}"
           [[ -z "${{ steps.version_parser.outputs.prerelease }}" ]] && \
             VERSION=${{ steps.version_parser.outputs.release }} || \
             VERSION="${{ steps.version_parser.outputs.release }}-${{ steps.version_parser.outputs.prerelease }}"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -28,7 +28,7 @@ jobs:
         uses: madhead/semver-utils@latest
         with:
           lenient: false
-          version: '0.27.0-alpha0'
+          version: '0.27.0-alpha1'
 
       - name: Set Release Environment Variables
         run: |
@@ -88,6 +88,14 @@ jobs:
       - name: Bump Versions
         run: npm run bump-version --semver=${{ env.VERSION }}
 
+      - name: Create Release Notes
+        if: ${{ steps.milestone.outputs.milestone_id != '' }}
+        uses: Decathlon/release-notes-generator-action@v3.1.6
+        env:
+          FILENAME: ${{ env.RELEASE_NOTES_FILENAME }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          MILESTONE_NUMBER: ${{ steps.milestone.outputs.milestone_id }}
+
       - name: Commit and Tag
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
@@ -114,10 +122,10 @@ jobs:
     name: Create snapshot PR
     runs-on: ubuntu-latest
     needs: branch_bump_tag
-    if: ${{ needs.release.outputs.create_pr == 'true' }}
+    if: ${{ needs.branch_bump_tag.outputs.create_pr == 'true' }}
     env:
-      NEXT_VERSION_SNAPSHOT: ${{ needs.release.outputs.next_version_snapshot }}
-      RELEASE_BRANCH: ${{ needs.release.outputs.release_branch }}
+      NEXT_VERSION_SNAPSHOT: ${{ needs.branch_bump_tag.outputs.next_version_snapshot }}
+      RELEASE_BRANCH: ${{ needs.branch_bump_tag.outputs.release_branch }}
 
     steps:
       - name: Checkout Repository
@@ -162,5 +170,5 @@ jobs:
           author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
           delete-branch: true
           signoff: true
-          title: ${{ needs.release.outputs.pr_title }}
+          title: ${{ needs.branch_bump_tag.outputs.pr_title }}
           token: ${{ secrets.HEDERA_BOT_TOKEN }}


### PR DESCRIPTION
**Description**:
Added automated release branching support through a new github workflow to
- create a `release/{currentRelease}` branch if it doesn't and bump to `rc1` if new
- tag the new rc
- automatically create a github pre-release
- open a new pr on main to bump the snapshot version

**Related issue(s)**:

Addresses #903 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
