### PR TITLE
configurable eth_call accepted errors

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -304,6 +304,9 @@ export class MirrorNodeClient {
         const acceptedErrorResponses = MirrorNodeClient.acceptedErrorStatusesResponsePerRequestPathMap.get(pathLabel);
         if (error.response && acceptedErrorResponses && acceptedErrorResponses.indexOf(effectiveStatusCode) !== -1) {
             this.logger.debug(`${requestIdPrefix} [${method}] ${path} ${effectiveStatusCode} status`);
+            if(pathLabel  === MirrorNodeClient.CONTRACT_CALL_ENDPOINT) {
+                this.logger.warn(`${requestIdPrefix} [${method}] ${path} Error details: (StatusText: '${error.response.statusText}' Data: '${JSON.stringify(error.response.data)}'"')`);
+            }
             return null;
         }
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -97,7 +97,7 @@ export class MirrorNodeClient {
         [MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_TOKENS_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_TRANSACTIONS_ENDPOINT, [400, 404]],
-        [MirrorNodeClient.CONTRACT_CALL_ENDPOINT, []],
+        [MirrorNodeClient.CONTRACT_CALL_ENDPOINT, [400,404,415,429,500]],
         [MirrorNodeClient.GET_STATE_ENDPOINT, [400, 404]]
     ]);
 
@@ -228,6 +228,13 @@ export class MirrorNodeClient {
 
         this.logger.info(`Mirror Node client successfully configured to REST url: ${this.restUrl} and Web3 url: ${this.web3Url} `);
         this.cache = new LRU({ max: constants.CACHE_MAX, ttl: constants.CACHE_TTL.ONE_HOUR });
+
+        // set  up eth call  accepted error codes.
+        if(process.env.ETH_CALL_ACCEPTED_ERRORS) {
+            MirrorNodeClient.acceptedErrorStatusesResponsePerRequestPathMap
+                .set(MirrorNodeClient.CONTRACT_CALL_ENDPOINT, JSON.parse(process.env.ETH_CALL_ACCEPTED_ERRORS));
+        }
+
     }
 
     private buildUrl(baseUrl: string) {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1166,6 +1166,11 @@ export class EthImpl implements Eth {
       }
 
       const contractCallResponse = await this.mirrorNodeClient.postContractCall(callData, requestId);
+
+      if(contractCallResponse === null) {
+        return predefined.CONTRACT_REVERT("Contract call failed: execution reverted");
+      }
+
       return contractCallResponse && contractCallResponse.result ? EthImpl.prepend0x(contractCallResponse.result) : EthImpl.emptyHex;
     } catch (e: any) {
       // Temporary workaround until mirror node web3 module implements the support of precompiles

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1163,14 +1163,9 @@ export class EthImpl implements Eth {
         gas,
         value,
         estimate: false
-      }
+      };
 
       const contractCallResponse = await this.mirrorNodeClient.postContractCall(callData, requestId);
-
-      if(contractCallResponse === null) {
-        return predefined.CONTRACT_REVERT("Contract call failed: execution reverted");
-      }
-
       return contractCallResponse && contractCallResponse.result ? EthImpl.prepend0x(contractCallResponse.result) : EthImpl.emptyHex;
     } catch (e: any) {
       // Temporary workaround until mirror node web3 module implements the support of precompiles

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3389,17 +3389,9 @@ describe('Eth calls using MirrorNode', async function () {
           ]
         }
       });
-
-      /*sdkClientStub.submitContractCallQueryWithRetry.returns({
-            asBytes: function () {
-              return Uint8Array.of(0);
-            }
-          }
-      );*/
-
+      sinon.reset();
       const result = await ethImpl.call(callData, 'latest');
-
-      // sinon.assert.calledWith(sdkClientStub.submitContractCallQueryWithRetry, contractAddress2, contractCallData, maxGasLimit, accountAddress1, 'eth_call');
+      sinon.assert.notCalled(sdkClientStub.submitContractCallQueryWithRetry);
       expect(result).to.equal("0x");
     });
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3390,17 +3390,17 @@ describe('Eth calls using MirrorNode', async function () {
         }
       });
 
-      sdkClientStub.submitContractCallQueryWithRetry.returns({
+      /*sdkClientStub.submitContractCallQueryWithRetry.returns({
             asBytes: function () {
               return Uint8Array.of(0);
             }
           }
-      );
+      );*/
 
       const result = await ethImpl.call(callData, 'latest');
 
-      sinon.assert.calledWith(sdkClientStub.submitContractCallQueryWithRetry, contractAddress2, contractCallData, maxGasLimit, accountAddress1, 'eth_call');
-      expect(result).to.equal("0x00");
+      // sinon.assert.calledWith(sdkClientStub.submitContractCallQueryWithRetry, contractAddress2, contractCallData, maxGasLimit, accountAddress1, 'eth_call');
+      expect(result).to.equal("0x");
     });
 
     it('caps gas at 15_000_000', async function () {

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -50,7 +50,6 @@ describe('MirrorNodeClient', async function () {
       },
       timeout: 20 * 1000
     });
-    //  process.env.ETH_CALL_ACCEPTED_ERRORS =
     mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, instance);
   });
 

--- a/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
@@ -748,6 +748,7 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
             expect(res).to.eq('0x'); // confirm no error
         });
 
+
         it("Call to allowance method of an HTS token with non-existing spender account in call data returns error", async () => {
             const callData = {
                 from: '0x' + accounts[0].address,

--- a/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
@@ -738,12 +738,6 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
                 data: CALLDATA_ALLOWANCE + NON_EXISTING_ACCOUNT.padStart(64, '0') + account2LongZero.replace('0x', '').padStart(64, '0')
             };
 
-            /*await relay.callFailing(
-                'eth_call',
-                [callData, 'latest'],
-                predefined.CONTRACT_REVERT(),
-                requestId
-            );*/
             const res = await relay.call('eth_call', [callData, 'latest'], requestId);
             expect(res).to.eq('0x'); // confirm no error
         });
@@ -757,12 +751,6 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
                 data: CALLDATA_ALLOWANCE + adminAccountLongZero.replace('0x', '').padStart(64, '0') + NON_EXISTING_ACCOUNT.padStart(64, '0')
             };
 
-            /*await relay.callFailing(
-                'eth_call',
-                [callData, 'latest'],
-                predefined.CONTRACT_REVERT(),
-                requestId
-            );*/
             const res = await relay.call('eth_call', [callData, 'latest'], requestId);
             expect(res).to.eq('0x'); // confirm no error
         });

--- a/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
@@ -738,12 +738,14 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
                 data: CALLDATA_ALLOWANCE + NON_EXISTING_ACCOUNT.padStart(64, '0') + account2LongZero.replace('0x', '').padStart(64, '0')
             };
 
-            await relay.callFailing(
+            /*await relay.callFailing(
                 'eth_call',
                 [callData, 'latest'],
                 predefined.CONTRACT_REVERT(),
                 requestId
-            );
+            );*/
+            const res = await relay.call('eth_call', [callData, 'latest'], requestId);
+            expect(res).to.eq('0x'); // confirm no error
         });
 
         it("Call to allowance method of an HTS token with non-existing spender account in call data returns error", async () => {
@@ -754,12 +756,14 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
                 data: CALLDATA_ALLOWANCE + adminAccountLongZero.replace('0x', '').padStart(64, '0') + NON_EXISTING_ACCOUNT.padStart(64, '0')
             };
 
-            await relay.callFailing(
+            /*await relay.callFailing(
                 'eth_call',
                 [callData, 'latest'],
                 predefined.CONTRACT_REVERT(),
                 requestId
-            );
+            );*/
+            const res = await relay.call('eth_call', [callData, 'latest'], requestId);
+            expect(res).to.eq('0x'); // confirm no error
         });
     });
 });

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -425,12 +425,6 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: PURE_METHOD_CALL_DATA
             };
 
-            /*await relay.callFailing('eth_call', [callData, 'latest'], {
-                code: -32008,
-                message: PURE_METHOD_ERROR_MESSAGE,
-                data: PURE_METHOD_ERROR_DATA
-            }, requestId);*/
-
             const res = await relay.call('eth_call', [callData, 'latest'], requestId);
             expect(res).to.eq('0x'); // confirm no error
         });
@@ -442,12 +436,6 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 gas: EthImpl.numberTo0x(30000),
                 data: VIEW_METHOD_CALL_DATA
             };
-
-            /*await relay.callFailing('eth_call', [callData, 'latest'], {
-                code: -32008,
-                message: VIEW_METHOD_ERROR_MESSAGE,
-                data: VIEW_METHOD_ERROR_DATA
-            }, requestId);*/
 
             const res = await relay.call('eth_call', [callData, 'latest'], requestId);
             expect(res).to.eq('0x'); // confirm no error
@@ -597,12 +585,6 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                         gas: EthImpl.numberTo0x(30000),
                         data: pureMethodsData[i].data
                     };
-
-                    /*await relay.callFailing('eth_call', [callData, 'latest'], {
-                        code: -32008,
-                        message: pureMethodsData[i].message,
-                        data: pureMethodsData[i].errorData
-                    }, requestId);*/
 
                     const res = await relay.call('eth_call', [callData, 'latest'], requestId);
                     expect(res).to.eq('0x'); // confirm no error

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -348,7 +348,6 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                             data: '0x3ec4de3800000000000000000000000067d8d32e9bf1a9968a5ff53b87d777aa8ebbee69'
                         };
 
-                        // await relay.callFailing('eth_call', [callData, 'latest'], predefined.CONTRACT_REVERT(), requestId);
                         const res = await relay.call('eth_call', [callData, 'latest'], requestId);
                         expect(res).to.eq('0x'); // confirm no error
                     });

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -348,7 +348,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                             data: '0x3ec4de3800000000000000000000000067d8d32e9bf1a9968a5ff53b87d777aa8ebbee69'
                         };
 
-                        await relay.callFailing('eth_call', [callData, 'latest'], predefined.CONTRACT_REVERT(), requestId);
+                        // await relay.callFailing('eth_call', [callData, 'latest'], predefined.CONTRACT_REVERT(), requestId);
+                        const res = await relay.call('eth_call', [callData, 'latest'], requestId);
+                        expect(res).to.eq('0x'); // confirm no error
                     });
 
                     it("007 'data' from request body with wrong encoded parameter", async function () {
@@ -423,11 +425,14 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: PURE_METHOD_CALL_DATA
             };
 
-            await relay.callFailing('eth_call', [callData, 'latest'], {
+            /*await relay.callFailing('eth_call', [callData, 'latest'], {
                 code: -32008,
                 message: PURE_METHOD_ERROR_MESSAGE,
                 data: PURE_METHOD_ERROR_DATA
-            }, requestId);
+            }, requestId);*/
+
+            const res = await relay.call('eth_call', [callData, 'latest'], requestId);
+            expect(res).to.eq('0x'); // confirm no error
         });
 
         it('Returns revert message for view methods', async () => {
@@ -438,11 +443,14 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: VIEW_METHOD_CALL_DATA
             };
 
-            await relay.callFailing('eth_call', [callData, 'latest'], {
+            /*await relay.callFailing('eth_call', [callData, 'latest'], {
                 code: -32008,
                 message: VIEW_METHOD_ERROR_MESSAGE,
                 data: VIEW_METHOD_ERROR_DATA
-            }, requestId);
+            }, requestId);*/
+
+            const res = await relay.call('eth_call', [callData, 'latest'], requestId);
+            expect(res).to.eq('0x'); // confirm no error
         });
 
         it('Returns revert reason in receipt for payable methods', async () => {
@@ -590,11 +598,14 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                         data: pureMethodsData[i].data
                     };
 
-                    await relay.callFailing('eth_call', [callData, 'latest'], {
+                    /*await relay.callFailing('eth_call', [callData, 'latest'], {
                         code: -32008,
                         message: pureMethodsData[i].message,
                         data: pureMethodsData[i].errorData
-                    }, requestId);
+                    }, requestId);*/
+
+                    const res = await relay.call('eth_call', [callData, 'latest'], requestId);
+                    expect(res).to.eq('0x'); // confirm no error
                 });
             }
         });


### PR DESCRIPTION
**Description**:
make accepted error codes from mirror node for eth_call configurable and added initial default ones

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Whenever the mirror node returns an acceptedErrorCode  the  mirrorNode  request  will return null, and in response  we will  return empty hex.

<img width="866" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/a8652019-ca5f-4576-ac34-9950029e6364">





**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
