### PR TITLE
Handle invalid call response from consensus node

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1244,10 +1244,14 @@ export class EthImpl implements Eth {
       }
 
       const contractCallResponse = await this.hapiService.getSDKClient().submitContractCallQueryWithRetry(call.to, call.data, gas, call.from, EthImpl.ethCall, requestId);
-      const formattedCallReponse = EthImpl.prepend0x(Buffer.from(contractCallResponse.asBytes()).toString('hex'));
+      if (contractCallResponse) {
+        const formattedCallReponse = EthImpl.prepend0x(Buffer.from(contractCallResponse.asBytes()).toString('hex'));
 
-      this.cache.set(cacheKey, formattedCallReponse, { ttl: this.ethCallCacheTtl });
-      return formattedCallReponse;
+        this.cache.set(cacheKey, formattedCallReponse, { ttl: this.ethCallCacheTtl });
+        return formattedCallReponse;
+      }
+
+      return predefined.INTERNAL_ERROR(`Invalid contractCallResponse from consensus-node: ${JSON.stringify(contractCallResponse)}`);
     } catch (e: any) {
       this.logger.error(e, `${requestIdPrefix} Failed to successfully submit contractCallQuery`);
       if (e instanceof JsonRpcError) {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3523,6 +3523,23 @@ describe('Eth calls using MirrorNode', async function () {
         expect(error.message).to.equal(`Invalid Contract Address: ${wrongContractAddress}. Expected length of 42 chars but was ${wrongContractAddress.length}.`);
       }
     });
+
+    it('eth_call throws internal error when consensus node times out and submitContractCallQueryWithRetry returns undefined', async function () {
+      restMock.onGet(`contracts/${contractAddress2}`).reply(200, defaultContract2);
+
+      sdkClientStub.submitContractCallQueryWithRetry.returns(undefined);
+
+      const result = await ethImpl.call({
+        "to": contractAddress2,
+        "data": contractCallData,
+        "gas": 50_000_000
+      }, 'latest');
+
+      expect(result).to.exist;
+      expect(result.code).to.equal(-32603);
+      expect(result.name).to.equal('Internal error');
+      expect(result.message).to.equal('Error invoking RPC: Invalid contractCallResponse from consensus-node: undefined');
+    });
   });
 
   describe('eth_call using mirror node', async function () {


### PR DESCRIPTION
**Description**:
Occasionally time outs are observed from consensus nodes on contractCallQueries, these weren't being handled

- Add logic to check `callResponse` in `callConsensusNode()`
- Add test case

**Related issue(s)**:

Fixes #1292 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
