### PR TITLE
Fix relay operator balance gauge

### DIFF
--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -107,8 +107,8 @@ export class RelayImpl implements Relay {
             try {
                 const account = await mirrorNodeClient.getAccount(clientMain.operatorAccountId!.toString());
                 const accountBalance = account.balance?.balance;
-                this.labels({ 'accountId': clientMain.operatorAccountId!.toString() })
-                    .set(accountBalance.toNumber());
+                this.labels({ 'accountId': clientMain.operatorAccountId?.toString() })
+                    .set(accountBalance);
             } catch (e: any) {
                 logger.error(e, `Error collecting operator balance. Skipping balance set`);
             }


### PR DESCRIPTION
**Description**:
Fixed collect method, first change a typo of ! for ? and then avoid doing a conversion .toNumber() since the accountBalance type is already a number

**Related issue(s)**:

Fixes #1307 

**Notes for reviewer**:
After fix:
<img width="547" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/a745e154-6fcd-4892-8636-7a5a701a7b70">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
