### PR TITLE
Fix helm chart ingress template

### DIFF
--- a/charts/hedera-json-rpc-relay/templates/ingress.yaml
+++ b/charts/hedera-json-rpc-relay/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "json-rpc-relay.fullname" . -}}
-{{- $svcPort := .Values.port.containerPort -}}
+{{- $svcPort := .Values.ports.containerPort -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
@@ -16,15 +16,15 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   labels:
-    app: {{ template "hedera-json-rpc-relay.name" . }}
-    {{- include "json-rpc-relay.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+    app:  {{ template "json-rpc-relay.name" . }}
+    {{ include "json-rpc-relay.labels" . | nindent 4 }}
   name: {{ $fullName }}
   namespace: {{ include "json-rpc-relay.namespace" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-spec: 
+spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
@@ -38,9 +38,9 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  rules: 
-    {{- range .Vales.ingress.hosts }}
-    - hosts: {{ .hosts | quote }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
           {{- range .paths }}
@@ -49,15 +49,15 @@ spec:
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">=1.19.0" $.Capabilities.KubeVersion.GitVersion }}
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
-                {{- else }}
+              {{- else }}
                 serviceName: {{ $fullName }}
                 servicePort: {{ $svcPort }}
-                {{- end }}
+              {{- end }}
           {{- end }}
     {{- end }}
-{{- end }}                
+{{- end }}


### PR DESCRIPTION
**Description**:
Fix helm chart ingress template.

- Correct `.Values.port` for `.Values.ports`
- Correct `.Vales` spelling for `.Values`
- Move `with` for `.Values.ingress.annotations` to enclose only annotations
- Correct `semverCompare` version from `major>.<minor>.<build>` to `major>.<minor>-<build>` format

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
