### PR TITLE
Set initialErrorCodes to [50] by default if missing (#1325)

### DIFF
--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -95,7 +95,7 @@ export default class HAPIService {
     const currentDateNow = Date.now();
     this.initialTransactionCount = parseInt(process.env.HAPI_CLIENT_TRANSACTION_RESET!) || 0;
     this.initialResetDuration = parseInt(process.env.HAPI_CLIENT_DURATION_RESET!) || 0;
-    this.initialErrorCodes = JSON.parse(process.env.HAPI_CLIENT_ERROR_RESET || "[]");
+    this.initialErrorCodes = JSON.parse(process.env.HAPI_CLIENT_ERROR_RESET || "[50]");
 
     this.transactionCount = this.initialTransactionCount;
     this.resetDuration = currentDateNow + this.initialResetDuration;


### PR DESCRIPTION
Set initialErrorCodes to [50] by default if missing**Related issue(s)**:

Fixes #1324

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
