### PR TITLE
Optimize mirror node get accounts call with limit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18791,7 +18791,7 @@
         },
         "packages/relay": {
             "name": "@hashgraph/json-rpc-relay",
-            "version": "0.25.0-SNAPSHOT",
+            "version": "0.26.0-SNAPSHOT",
             "dependencies": {
                 "@ethersproject/asm": "^5.7.0",
                 "@hashgraph/sdk": "^2.24.2",
@@ -18834,7 +18834,7 @@
         },
         "packages/server": {
             "name": "@hashgraph/json-rpc-server",
-            "version": "0.25.0-SNAPSHOT",
+            "version": "0.26.0-SNAPSHOT",
             "dependencies": {
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "axios": "^0.27.2",
@@ -18892,7 +18892,7 @@
         },
         "packages/ws-server": {
             "name": "@hashgraph/json-rpc-ws-server",
-            "version": "0.25.0-SNAPSHOT",
+            "version": "0.26.0-SNAPSHOT",
             "dependencies": {
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "@hashgraph/json-rpc-server": "file:../server",

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -57,7 +57,7 @@ export interface IContractLogsResultsParams {
 }
 
 export class MirrorNodeClient {
-    private static GET_ACCOUNTS_ENDPOINT = 'accounts/';
+    private static GET_ACCOUNTS_BY_ID_ENDPOINT = 'accounts/';
     private static GET_BALANCE_ENDPOINT = 'balances';
     private static GET_BLOCK_ENDPOINT = 'blocks/';
     private static GET_BLOCKS_ENDPOINT = 'blocks';
@@ -80,10 +80,9 @@ export class MirrorNodeClient {
     private static CONTRACT_CALL_ENDPOINT = 'contracts/call';
 
     private static CONTRACT_RESULT_LOGS_PROPERTY = 'logs';
-    private static CONTRACT_STATE_PROPERTY = 'state';
 
     static acceptedErrorStatusesResponsePerRequestPathMap: Map<string, Array<number>> = new Map([
-        [MirrorNodeClient.GET_ACCOUNTS_ENDPOINT, [400, 404]],
+        [MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_BALANCE_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_BLOCK_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_BLOCKS_ENDPOINT, [400, 404]],
@@ -344,21 +343,15 @@ export class MirrorNodeClient {
         }
     }
 
-    public async getAccountLatestTransactionByAddress(idOrAliasOrEvmAddress: string, requestId?: string): Promise<object> {
-        return this.get(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}?order=desc&limit=1`,
-            MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
-            requestId);
-    }
-
     public async getAccount(idOrAliasOrEvmAddress: string, requestId?: string) {
-        return this.get(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}`,
-            MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
+        return this.get(`${MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT}${idOrAliasOrEvmAddress}?order=desc&limit=1`,
+            MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT,
             requestId);
     }
 
     public async getAccountPageLimit(idOrAliasOrEvmAddress: string, requestId?: string) {
-        return this.get(`${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${idOrAliasOrEvmAddress}?limit=${constants.MIRROR_NODE_QUERY_LIMIT}`,
-            MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
+        return this.get(`${MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT}${idOrAliasOrEvmAddress}?limit=${constants.MIRROR_NODE_QUERY_LIMIT}`,
+            MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT,
             requestId);
     }
     /*******************************************************************************
@@ -375,8 +368,8 @@ export class MirrorNodeClient {
         const queryParams = this.getQueryParams(queryParamObject);
 
         return this.getPaginatedResults(
-            `${MirrorNodeClient.GET_ACCOUNTS_ENDPOINT}${accountId}${queryParams}`,
-            MirrorNodeClient.GET_ACCOUNTS_ENDPOINT,
+            `${MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT}${accountId}${queryParams}`,
+            MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT,
             'transactions',
             requestId
         );

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -35,8 +35,8 @@ import { SDKClientError } from '../../src/lib/errors/SDKClientError';
 const logger = pino();
 import { v4 as uuid } from 'uuid';
 import { formatRequestIdMessage } from '../../src/formatters';
-import { MirrorNodeClientError } from '../../src';
 
+const limitOrderPostFix = '?order=desc&limit=1';
 
 describe('MirrorNodeClient', async function () {
   this.timeout(20000);
@@ -241,10 +241,9 @@ describe('MirrorNodeClient', async function () {
     }
   });
 
-  // move following methods to eth.spec.ts once it starts using mirrorNodeClient
-  it('`getAccountLatestTransactionByAddress` works', async () => {
+  it('`getAccount` works', async () => {
     const alias = 'HIQQEXWKW53RKN4W6XXC4Q232SYNZ3SZANVZZSUME5B5PRGXL663UAQA';
-    mock.onGet(`accounts/${alias}?order=desc&limit=1`).reply(200, {
+    mock.onGet(`accounts/${alias}${limitOrderPostFix}`).reply(200, {
       'transactions': [
         {
           'nonce': 3,
@@ -255,7 +254,7 @@ describe('MirrorNodeClient', async function () {
       }
     });
 
-    const result = await mirrorNodeInstance.getAccountLatestTransactionByAddress(alias);
+    const result = await mirrorNodeInstance.getAccount(alias);
     expect(result).to.exist;
     expect(result.links).to.exist;
     expect(result.links.next).to.equal(null);
@@ -362,7 +361,7 @@ describe('MirrorNodeClient', async function () {
   });
 
   it('`getAccount`', async () => {
-    mock.onGet(`accounts/${mockData.accountEvmAddress}`).reply(200, mockData.account);
+    mock.onGet(`accounts/${mockData.accountEvmAddress}${limitOrderPostFix}`).reply(200, mockData.account);
 
     const result = await mirrorNodeInstance.getAccount(mockData.accountEvmAddress);
     expect(result).to.exist;
@@ -371,7 +370,7 @@ describe('MirrorNodeClient', async function () {
 
   it('`getAccount` not found', async () => {
     const evmAddress = '0x00000000000000000000000000000000000003f6';
-    mock.onGet(`accounts/${evmAddress}`).reply(404, mockData.notFound);
+    mock.onGet(`accounts/${evmAddress}${limitOrderPostFix}`).reply(404, mockData.notFound);
 
     const result = await mirrorNodeInstance.getAccount(evmAddress);
     expect(result).to.be.null;
@@ -387,7 +386,7 @@ describe('MirrorNodeClient', async function () {
 
   it('`getTokenById` not found', async () => {
     const tokenId = '0.0.132';
-    mock.onGet(`accounts/${tokenId}`).reply(404, mockData.notFound);
+    mock.onGet(`accounts/${tokenId}${limitOrderPostFix}`).reply(404, mockData.notFound);
 
     const result = await mirrorNodeInstance.getTokenById(tokenId);
     expect(result).to.be.null;
@@ -770,7 +769,7 @@ describe('MirrorNodeClient', async function () {
     const notFoundAddress = random20BytesAddress();
     it('returns `contract` when CONTRACTS endpoint returns a result', async() => {
       mock.onGet(`contracts/${mockData.contractEvmAddress}`).reply(200, mockData.contract);
-      mock.onGet(`accounts/${mockData.contractEvmAddress}`).reply(200, mockData.account);
+      mock.onGet(`accounts/${mockData.contractEvmAddress}${limitOrderPostFix}`).reply(200, mockData.account);
       mock.onGet(`tokens/${mockData.contractEvmAddress}`).reply(404, mockData.notFound);
 
       const entityType = await mirrorNodeInstance.resolveEntityType(mockData.contractEvmAddress);
@@ -784,7 +783,7 @@ describe('MirrorNodeClient', async function () {
 
     it('returns `account` when CONTRACTS and TOKENS endpoint returns 404 and ACCOUNTS endpoint returns a result', async() => {
       mock.onGet(`contracts/${mockData.accountEvmAddress}`).reply(404, mockData.notFound);
-      mock.onGet(`accounts/${mockData.accountEvmAddress}`).reply(200, mockData.account);
+      mock.onGet(`accounts/${mockData.accountEvmAddress}${limitOrderPostFix}`).reply(200, mockData.account);
       mock.onGet(`tokens/${mockData.tokenId}`).reply(404, mockData.notFound);
 
       const entityType = await mirrorNodeInstance.resolveEntityType(mockData.accountEvmAddress);
@@ -798,7 +797,7 @@ describe('MirrorNodeClient', async function () {
 
     it('returns `token` when CONTRACTS and ACCOUNTS endpoints returns 404 and TOKEN endpoint returns a result', async() => {
       mock.onGet(`contracts/${notFoundAddress}`).reply(404, mockData.notFound);
-      mock.onGet(`accounts/${notFoundAddress}`).reply(404, mockData.notFound);
+      mock.onGet(`accounts/${notFoundAddress}${limitOrderPostFix}`).reply(404, mockData.notFound);
       mock.onGet(`tokens/${mockData.tokenId}`).reply(200, mockData.token);
 
       const entityType = await mirrorNodeInstance.resolveEntityType(mockData.tokenLongZero);
@@ -811,7 +810,7 @@ describe('MirrorNodeClient', async function () {
 
     it('returns null when CONTRACTS and ACCOUNTS endpoints return 404', async() => {
       mock.onGet(`contracts/${notFoundAddress}`).reply(404, mockData.notFound);
-      mock.onGet(`accounts/${notFoundAddress}`).reply(404, mockData.notFound);
+      mock.onGet(`accounts/${notFoundAddress}${limitOrderPostFix}`).reply(404, mockData.notFound);
       mock.onGet(`tokens/${notFoundAddress}`).reply(404, mockData.notFound);
 
       const entityType = await mirrorNodeInstance.resolveEntityType(notFoundAddress);

--- a/packages/relay/tests/lib/net.spec.ts
+++ b/packages/relay/tests/lib/net.spec.ts
@@ -20,7 +20,7 @@
 
 import { expect } from 'chai';
 import { Registry } from 'prom-client';
-import { RelayImpl } from '../../../../packages/relay';
+import { RelayImpl } from '../../src/lib/relay';
 
 import pino from 'pino';
 const logger = pino();

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -29,7 +29,7 @@ import axios from 'axios';
 import sinon from 'sinon';
 import dotenv from 'dotenv';
 import MockAdapter from 'axios-mock-adapter';
-import { RelayImpl } from '../../../../packages/relay';
+import { RelayImpl } from '../../src/lib/relay';
 import { Registry } from 'prom-client';
 
 import { EthImpl } from '../../src/lib/eth';
@@ -82,6 +82,7 @@ let mirrorNodeInstance: MirrorNodeClient;
 let clientServiceInstance: ClientService;
 let sdkClientStub: any;
 
+const limitOrderPostFix = '?order=desc&limit=1';
 
 describe("Open RPC Specification", function () {
 
@@ -139,9 +140,9 @@ describe("Open RPC Specification", function () {
         mock.onGet(`contracts/${contractId2}/results/${contractTimestamp3}`).reply(200, defaultDetailedContractResults3);
         mock.onGet(`tokens/0.0.${parseInt(defaultCallData.to, 16)}`).reply(404, null);
         mock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, { account: contractAddress1 });
-        mock.onGet(`accounts/${contractAddress3}`).reply(200, { account: contractAddress3 });
+        mock.onGet(`accounts/${contractAddress3}${limitOrderPostFix}`).reply(200, { account: contractAddress3 });
         mock.onGet(`accounts/0xbC989b7b17d18702663F44A6004cB538b9DfcBAc?limit=100`).reply(200, { account: '0xbC989b7b17d18702663F44A6004cB538b9DfcBAc' });
-        mock.onGet(`accounts/${defaultFromLongZeroAddress}`).reply(200, {
+        mock.onGet(`accounts/${defaultFromLongZeroAddress}${limitOrderPostFix}`).reply(200, {
             from: `${defaultEvmAddress}`
           });
         for (const log of defaultLogs.logs) {
@@ -200,7 +201,7 @@ describe("Open RPC Specification", function () {
     });
 
     it('should execute "eth_estimateGas"', async function () {
-        mock.onGet(`accounts/undefined`).reply(404);
+        mock.onGet(`accounts/undefined${limitOrderPostFix}`).reply(404);
         const response = await ethImpl.estimateGas({}, null);
 
         validateResponseSchema(methodsResponseSchema.eth_estimateGas, response);
@@ -328,7 +329,7 @@ describe("Open RPC Specification", function () {
     });
 
     it('should execute "eth_getTransactionCount"', async function () {
-        mock.onGet(`accounts/${contractAddress1}`).reply(200, { account: contractAddress1 });
+        mock.onGet(`accounts/${contractAddress1}${limitOrderPostFix}`).reply(200, { account: contractAddress1 });
         const response = await ethImpl.getTransactionCount(contractAddress1, 'latest');
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionCount, response);

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -37,6 +37,8 @@ import HAPIService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
 const logger = pino();
 
+const limitOrderPostFix = '?order=desc&limit=1';
+
 describe('Precheck', async function() {
 
     const txWithMatchingChainId = '0x02f87482012a0485a7a358200085a7a3582000832dc6c09400000000000000000000000000000000000003f78502540be40080c001a006f4cd8e6f84b76a05a5c1542a08682c928108ef7163d9c1bf1f3b636b1cd1fba032097cbf2dda17a2dcc40f62c97964d9d930cdce2e8a9df9a8ba023cda28e4ad';
@@ -247,7 +249,7 @@ describe('Precheck', async function() {
         // sending 2 hbars
         const transaction = '0x02f876820128078459682f0086018a4c7747008252089443cb701defe8fc6ed04d7bddf949618e3c575fe1881bc16d674ec8000080c001a0b8c604e08c15a7acc8c898a1bbcc41befcd0d120b64041d1086381c7fc2a5339a062eabec286592a7283c90ce90d97f9f8cf9f6c0cef4998022660e7573c046a46';
         const parsedTransaction = ethers.utils.parseTransaction(transaction);
-        const mirrorAccountsPath = 'accounts/0xF8A44f9a4E4c452D25F5aE0F5d7970Ac9522a3C8';
+        const mirrorAccountsPath = `accounts/0xF8A44f9a4E4c452D25F5aE0F5d7970Ac9522a3C8${limitOrderPostFix}`;
         const accountId = '0.1.2';
 
         it('should not pass for 1 hbar', async function() {
@@ -359,7 +361,7 @@ describe('Precheck', async function() {
             const signed = await signTransaction(tx);
             const parsedTx = ethers.utils.parseTransaction(signed);
 
-            mock.onGet(`accounts/${parsedTx.from}`).reply(200, mirrorAccount);
+            mock.onGet(`accounts/${parsedTx.from}${limitOrderPostFix}`).reply(200, mirrorAccount);
 
 
             try {
@@ -378,7 +380,7 @@ describe('Precheck', async function() {
             const signed = await signTransaction(tx);
             const parsedTx = ethers.utils.parseTransaction(signed);
 
-            mock.onGet(`accounts/${parsedTx.from}`).reply(200, mirrorAccount);
+            mock.onGet(`accounts/${parsedTx.from}${limitOrderPostFix}`).reply(200, mirrorAccount);
 
             await precheck.nonce(parsedTx, mirrorAccount.ethereum_nonce);
         });
@@ -403,7 +405,7 @@ describe('Precheck', async function() {
         };
 
         it(`should fail for missing account`, async function () {
-            mock.onGet(`accounts/${mockData.accountEvmAddress}`).reply(404, mockData.notFound);
+            mock.onGet(`accounts/${mockData.accountEvmAddress}${limitOrderPostFix}`).reply(404, mockData.notFound);
 
 
             try {
@@ -418,7 +420,7 @@ describe('Precheck', async function() {
         });
 
         it(`should not fail for matched account`, async function () {
-            mock.onGet(`accounts/${mockData.accountEvmAddress}`).reply(200, mirrorAccount);
+            mock.onGet(`accounts/${mockData.accountEvmAddress}${limitOrderPostFix}`).reply(200, mirrorAccount);
             const account = await precheck.verifyAccount(parsedTx);
 
 

--- a/packages/relay/tests/lib/web3.spec.ts
+++ b/packages/relay/tests/lib/web3.spec.ts
@@ -22,7 +22,7 @@ import path from 'path';
 import dotenv from 'dotenv';
 import { expect } from 'chai';
 import { Registry } from 'prom-client';
-import { RelayImpl } from '../../../../packages/relay';
+import { RelayImpl } from '../../src/lib/relay';
 
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 


### PR DESCRIPTION
**Description**:
Mirror node calls for account has the unintended effect of getting the page limit of tranactions

- Updated get account call to use `order=desc` and `limit = 1`
- Updated spect ts
- Add missing mocks in some spec tests

**Related issue(s)**:

Fixes #1339 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
