### PR TITLE
Remove `from` check from `eth_call` prechecks

### DIFF
--- a/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
@@ -571,7 +571,7 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
             await relay.callFailing(
                 Constants.ETH_ENDPOINTS.ETH_CALL,
                 [callData, 'latest'],
-                predefined.NON_EXISTING_ACCOUNT('0x' + NON_EXISTING_ACCOUNT),
+                predefined.CONTRACT_REVERT(),
                 requestId
             );
         });

--- a/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
@@ -41,6 +41,7 @@ import TokenManagementContractJson from '../../contracts/TokenManagementContract
 import { predefined } from '../../../../relay/src/lib/errors/JsonRpcError';
 import { Utils } from '../../helpers/utils';
 import { EthImpl } from "@hashgraph/json-rpc-relay/dist/lib/eth";
+import RelayCall from "../../helpers/constants";
 
 describe('@precompile-calls Tests for eth_call with HTS', async function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -544,7 +545,7 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
         const CALLDATA_ALLOWANCE = '0xdd62ed3e';
         const NON_EXISTING_ACCOUNT = '123abc123abc123abc123abc123abc123abc123a';
 
-        it("Call to non-existing HTS token returns error", async () => {
+        it("Call to non-existing HTS token returns 0x", async () => {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: '0x' + NON_EXISTING_ACCOUNT,
@@ -552,12 +553,8 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
                 data: CALLDATA_BALANCE_OF + accounts[0].address
             };
 
-            await relay.callFailing(
-                Constants.ETH_ENDPOINTS.ETH_CALL,
-                [callData, 'latest'],
-                predefined.NON_EXISTING_CONTRACT('0x' + NON_EXISTING_ACCOUNT),
-                requestId
-            );
+            const res = await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId);
+            expect(res).to.eq('0x'); // confirm no error
         });
 
         it("Call to HTS token from non-existing account returns error", async () => {

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -127,17 +127,6 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             await relay.callFailing(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], predefined.NON_EXISTING_CONTRACT(Address.NON_EXISTING_ADDRESS), requestId);
         });
 
-        it('should fail "eth_call" for non-existing to account address', async function () {
-            const callData = {
-                from: Address.NON_EXISTING_ADDRESS,
-                to: evmAddress,
-                gas: EthImpl.numberTo0x(30000),
-                data: BASIC_CONTRACT_PING_CALL_DATA
-            };
-
-            await relay.callFailing(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], predefined.NON_EXISTING_ACCOUNT(Address.NON_EXISTING_ADDRESS), requestId);
-        });
-
         it('should execute "eth_call" without from field', async function () {
             const callData = {
                 to: evmAddress,
@@ -411,6 +400,17 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                             } catch (e) {
                                 Assertions.jsonRpcError(e, predefined.CONTRACT_REVERT());
                             }
+                        });
+
+                        it("012 should work for wrong 'from' field", async function () {
+                            const callData = {
+                                from: "0x0000000000000000000000000000000000000000",
+                                to: callerAddress,
+                                data: '0x0ec1551d'
+                            };
+
+                            const res = await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId);
+                            expect(res).to.eq('0x0000000000000000000000000000000000000000000000000000000000000004');
                         });
                     }
                 });

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -116,15 +116,15 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             expect(res).to.eq('0x'); // confirm no error
         });
 
-        it('should fail "eth_call" for non-existing contract address', async function () {
+        it('"eth_call" for non-existing contract address returns 0x', async function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: Address.NON_EXISTING_ADDRESS,
                 gas: EthImpl.numberTo0x(30000),
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
-
-            await relay.callFailing(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], predefined.NON_EXISTING_CONTRACT(Address.NON_EXISTING_ADDRESS), requestId);
+            const res = await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId);
+            expect(res).to.eq('0x'); // confirm no error
         });
 
         it('should execute "eth_call" without from field', async function () {


### PR DESCRIPTION
**Description**:
This PR removes the from check when we call `eth_call`. More context: 

Now with the archive node, we are using only the mirror-node for `eth_call` and since there are already existing checks for the from field, we don't need to check it with a mirror-node call.
Previously we needed to check to avoid unnecessary consensus node, if the from field doesn't exist. But now we can make calls to mirror node with wrong from field without any issues as in the `evm` it doesn't matter if it exists.

**Related issue(s)**:

Fixes #1346 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
