### PR TITLE
Reorganize latency calculation logic

### DIFF
--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -95,7 +95,6 @@ export default class KoaJsonRpc {
       let body, result;
 
       this.requestId = ctx.state.reqId;
-      const requestIdPrefix =  formatRequestIdMessage(this.requestId);
       
       if (this.token) {
         const headerToken = ctx.get('authorization').split(' ').pop();
@@ -174,9 +173,5 @@ export default class KoaJsonRpc {
 
   getRequestId(): string {
     return this.requestId;
-  }
-
-  getStartTimestamp(): number {
-    return this.startTimestamp;
   }
 }

--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -26,7 +26,6 @@ import parse from 'co-body';
 import dotenv from 'dotenv';
 import path from 'path';
 import { Logger } from 'pino';
-import { formatRequestIdMessage } from '../formatters';
 
 import {
   ParseError,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -43,8 +43,8 @@ const mainLogger = pino({
 const cors = require('koa-cors');
 const logger = mainLogger.child({ name: 'rpc-server' });
 const register = new Registry();
-const relay: Relay = new RelayImpl(logger, register);
-const app = new KoaJsonRpc(logger, register, {
+const relay: Relay = new RelayImpl(logger.child({ name: 'relay' }), register);
+const app = new KoaJsonRpc(logger.child({ name: 'koa-rpc' }), register, {
   limit: process.env.INPUT_SIZE_LIMIT ? process.env.INPUT_SIZE_LIMIT + 'mb' : null
 });
 
@@ -68,11 +68,16 @@ const methodResponseHistogram = new Histogram({
  */
 app.getKoaApp().use(async (ctx, next) => {
   const start = Date.now();
+  ctx.state.start = start;
   await next();
 
+  const ms = Date.now() - start;
   if (ctx.method !== 'POST') {
-    const ms = Date.now() - start;
-    logger.info(`[${ctx.method}]: ${ctx.url} ${ms} ms`);
+    logger.info(`[${ctx.method}]: ${ctx.url} ${ctx.status} ${ms} ms`);
+  } else {
+    // log call type, method, status code and latency
+    logger.info(`${formatRequestIdMessage(ctx.state.reqId)} [${ctx.method}]: ${ctx.state.methodName} ${ctx.state.status} ${ms} ms`);
+    methodResponseHistogram.labels(ctx.state.methodName, `${ctx.status}`).observe(ms);
   }
 });
 
@@ -134,6 +139,15 @@ app.getKoaApp().use(async (ctx, next) => {
   }
 });
 
+/**
+ * middleware to end for non POST requests asides health, metrics and openrpc
+ */
+app.getKoaApp().use(async (ctx, next) => {
+  if (ctx.method === 'POST') {
+    await next();
+  }
+});
+
 app.getKoaApp().use(async (ctx, next) => {
   const options = {
     expose: ctx.get('Request-Id'),
@@ -165,7 +179,6 @@ app.getKoaApp().use(async (ctx, next) => {
     ctx.set(options.expose, id);
   }
 
-  ctx.state.start = Date.now();
   ctx.state.reqId = id;
 
   return next();
@@ -176,8 +189,6 @@ const logAndHandleResponse = async (methodName: any, methodParams: any, methodFu
 
   const requestId = app.getRequestId();
   const requestIdPrefix = requestId ? formatRequestIdMessage(requestId) : '';
-  logger.debug(`${requestIdPrefix} ${methodName}`);
-  const messagePrefix = `${requestIdPrefix} [POST] ${methodName}:`;
 
   try {
 
@@ -186,13 +197,9 @@ const logAndHandleResponse = async (methodName: any, methodParams: any, methodFu
       Validator.validateParams(methodParams, methodValidations);
     }
 
-    const response = await methodFunction(requestId);
-    const status = response instanceof JsonRpcError ? response.code.toString() : responseSuccessStatusCode;
-    ms = Date.now() - app.getStartTimestamp();
-    methodResponseHistogram.labels(methodName, status).observe(ms);
-    logger.info(`${messagePrefix} ${status} ${ms} ms `);
+    const response = await methodFunction(requestIdPrefix);
     if (response instanceof JsonRpcError) {
-      logger.error(`${requestIdPrefix} returning error to sender: ${response.message}`);
+      logger.error(`${requestIdPrefix} ${response.message}`);
       return new JsonRpcError({
         name: response.name,
         code: response.code,
@@ -202,10 +209,6 @@ const logAndHandleResponse = async (methodName: any, methodParams: any, methodFu
     }
     return response;
   } catch (e: any) {
-    ms = Date.now() - app.getStartTimestamp();
-    methodResponseHistogram.labels(methodName, responseInternalErrorCode).observe(ms);
-    logger.error(e, `${messagePrefix} ${responseInternalErrorCode} ${ms} ms`);
-
     let error = predefined.INTERNAL_ERROR();
     if (e instanceof MirrorNodeClientError) {
       if (e.isTimeout()) {
@@ -216,7 +219,7 @@ const logAndHandleResponse = async (methodName: any, methodParams: any, methodFu
       error = e;
     }
 
-    logger.error(`${requestIdPrefix} returning error to sender: ${error.message}`);
+    logger.error(`${requestIdPrefix} ${error.message}`);
     return new JsonRpcError({
       name: error.name,
       code: error.code,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -185,8 +185,6 @@ app.getKoaApp().use(async (ctx, next) => {
 });
 
 const logAndHandleResponse = async (methodName: any, methodParams: any, methodFunction: any) => {
-  let ms;
-
   const requestId = app.getRequestId();
   const requestIdPrefix = requestId ? formatRequestIdMessage(requestId) : '';
 


### PR DESCRIPTION
**Description**:
Simplify relay E2E latency calculation

- move E2E log into single handler
- centralize happy path in server.ts
- update error flows in index.ts for clear messages

**Related issue(s)**:

Fixes #1348 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
