### PR TITLE
Remove AcceptedErrorCodes from MirrorNodeClient - GET_ACCOUNTS_BY_ID_ENDPOINT

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -84,7 +84,7 @@ export class MirrorNodeClient {
     private static CONTRACT_RESULT_LOGS_PROPERTY = 'logs';
 
     static acceptedErrorStatusesResponsePerRequestPathMap: Map<string, Array<number>> = new Map([
-        [MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT, [400, 404]],
+        [MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT, []],
         [MirrorNodeClient.GET_BALANCE_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_BLOCK_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_BLOCKS_ENDPOINT, [400, 404]],
@@ -325,7 +325,8 @@ export class MirrorNodeClient {
         this.logger.error(new Error(error.message), `${requestIdPrefix} [${method}] ${path} ${effectiveStatusCode} status`);
 
         // we only need contract revert errors here as it's not the same as not supported
-        if (mirrorError.isContractReverted() && !mirrorError.isNotSupported() && !mirrorError.isNotSupportedSystemContractOperaton()) {
+        // Contract Revert error is valid only for contract calls
+        if (pathLabel == MirrorNodeClient.CONTRACT_CALL_ENDPOINT && mirrorError.isContractReverted() && !mirrorError.isNotSupported() && !mirrorError.isNotSupportedSystemContractOperaton()) {
             throw predefined.CONTRACT_REVERT(mirrorError.errorMessage);
         }
 

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -373,9 +373,12 @@ describe('MirrorNodeClient', async function () {
   it('`getAccount` not found', async () => {
     const evmAddress = '0x00000000000000000000000000000000000003f6';
     mock.onGet(`accounts/${evmAddress}${limitOrderPostFix}`).reply(404, mockData.notFound);
+    try {
+      await mirrorNodeInstance.getAccount(evmAddress);
+    } catch (error) {
+        expect(error.statusCode).equal(404);
+    }
 
-    const result = await mirrorNodeInstance.getAccount(evmAddress);
-    expect(result).to.be.null;
   });
 
   it('`getTokenById`', async () => {


### PR DESCRIPTION
**Description**:
Refactored code around MirrorNodeClient calls to GET_ACCOUNTS_BY_ID_ENDPOINT so it does not return null, but instead throws the corresponding error and the methods that consume that endpoint handle the errors as they see fit.
**Related issue(s)**:
#1276 
Fixes 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
