### PR TITLE
Simplify DApp tests layout

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -57,10 +57,10 @@ jobs:
       testfilter: htsprecompilev1
 
   precompilecalls:
-    name: Precompile
+    name: Precompile Calls
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
-      testfilter: precompile
+      testfilter: precompile-calls
 
   websocket:
     name: Websocket

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -55,7 +55,6 @@ jobs:
         if: always()
         uses: jwalton/gh-docker-logs@v2
         with:
-          images: 'hedera-json-rpc-relay'
           dest: './logs'
 
       - name: Tar logs

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -55,7 +55,7 @@ jobs:
         if: always()
         uses: jwalton/gh-docker-logs@v2
         with:
-          images: 'json-rpc-relay'
+          images: 'hedera-json-rpc-relay'
           dest: './logs'
 
       - name: Tar logs

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -51,6 +51,24 @@ jobs:
         run: docker-compose up --exit-code-from synpress
         working-directory: ./dapp-example/
 
+      - name: Dump relay logs
+        if: always()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          images: 'json-rpc-relay'
+          dest: './logs'
+
+      - name: Tar logs
+        if: always()
+        run: tar cvzf ./logs.tgz ./logs
+      
+      - name: Upload logs to GitHub
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logs.tgz
+          path: ./logs.tgz
+
       - name: Publish Reports
         uses: mikepenz/action-junit-report@v3
         if: always()

--- a/dapp-example/src/components/ActivateHollowAccountForm.js
+++ b/dapp-example/src/components/ActivateHollowAccountForm.js
@@ -23,7 +23,7 @@ const ActivateHollowAccountForm = ({ signer, isConnected, chain, address }) => {
         setIsLoading(true);
         setActivateHollowAccountMsg('Loading...');
 
-        const tx = await contract.transferTo(hollowAccountAddress, 3_000_000_000, { gasLimit: 1_000_0000 });
+        const tx = await contract.transferTo(hollowAccountAddress, 3_000_000_000, { gasLimit: 1_000_000 });
         const receipt = await tx.wait();
 
         setActivateHollowAccountMsg(receipt.events[0].event == 'Transferred' ? 'Done' : 'There was an error.');

--- a/dapp-example/src/components/AssociateHTSTokensForm.js
+++ b/dapp-example/src/components/AssociateHTSTokensForm.js
@@ -12,7 +12,7 @@ const AssociateHTSTokensForm = ({ signer, isConnected, chain, address }) => {
     // clear state vars on a chain or address have changed
     useEffect(() => {
         setIsLoading(false);
-        setHtsTokenAddress(bootstrapInfo.HTS_SECOND_ADDRESS);
+        setHtsTokenAddress('');
         setHtsTokenAssocaiteMsg(null);
     }, [chain, address])
 
@@ -41,7 +41,7 @@ const AssociateHTSTokensForm = ({ signer, isConnected, chain, address }) => {
             <Typography variant="h5" sx={{ textDecoration: 'underline' }}> Associate HTS Tokens </Typography>
             <br />
             <TextField
-                id="htsTokenAddressField"
+                id="htsTokenAssociateAddressField"
                 fullWidth
                 label="Token address"
                 sx={{ m: 1 }}

--- a/dapp-example/src/components/AssociateHTSTokensForm.js
+++ b/dapp-example/src/components/AssociateHTSTokensForm.js
@@ -1,7 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react'
 import { Button, TextField, Typography } from "@mui/material";
 import { ethers } from 'ethers';
-import bootstrapInfo from '../contracts/.bootstrapInfo.json'
 import IHRC from '../contracts/IHRC.json'
 
 const AssociateHTSTokensForm = ({ signer, isConnected, chain, address }) => {

--- a/dapp-example/src/components/TransferHTSTokensForm.js
+++ b/dapp-example/src/components/TransferHTSTokensForm.js
@@ -25,7 +25,8 @@ const TransferHTSTokensForm = ({ signer, isConnected, chain, address }) => {
             setHtsTokenMsg('Loading...');
 
             const contract = new ethers.Contract(htsTokenAddress, ERC20ABI, signer);
-            await contract.transfer(htsTokenReceiverAddress, htsTokenAmount, { gasLimit: 1_000_000 });
+            const tx = await contract.transfer(htsTokenReceiverAddress, htsTokenAmount, { gasLimit: 1_000_000 });
+            await tx.wait();
 
             setHtsTokenMsg('Done');
             setIsLoading(false);

--- a/dapp-example/src/components/TransferHTSTokensForm.js
+++ b/dapp-example/src/components/TransferHTSTokensForm.js
@@ -25,7 +25,7 @@ const TransferHTSTokensForm = ({ signer, isConnected, chain, address }) => {
             setHtsTokenMsg('Loading...');
 
             const contract = new ethers.Contract(htsTokenAddress, ERC20ABI, signer);
-            await contract.transfer(htsTokenReceiverAddress, htsTokenAmount);
+            await contract.transfer(htsTokenReceiverAddress, htsTokenAmount, { gasLimit: 1_000_000 });
 
             setHtsTokenMsg('Done');
             setIsLoading(false);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "acceptancetest:htsprecompilev1": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@htsprecompilev1' --exit",
         "acceptancetest:release": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@release' --exit",
         "acceptancetest:ws": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@web-socket' --exit",
-        "acceptancetest:precompile": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@precompile-calls' --exit",
+        "acceptancetest:precompile-calls": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@precompile-calls' --exit",
         "build": "npx lerna run build",
         "build-and-test": "npx lerna run build && npx lerna run test",
         "build:docker": "docker build . -t ${npm_package_name}",


### PR DESCRIPTION
**Description**:
Simplify DApp tests
- Add `await` on transfer tx
- Update gas limites on acitvate hollow account form and transfer token form
- Add retries on tests
- Reduce timeout time on tests
- Reorder DApp tests
  - Main account creates 2 hollow accounts up front and funds them 
  - both account perform a transfer and associate to token 2
  - contract creation is done once
- Update acceptence test name on Precompile calls workflow

**Related issue(s)**:

Fixes #1368 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
