### PR TITLE
Fix performCallBlockParamChecks latest block check

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1360,12 +1360,12 @@ export class EthImpl implements Eth {
         throw predefined.UNSUPPORTED_HISTORICAL_EXECUTION(blockNum.toString());
       }
 
-      const block = await this.mirrorNodeClient.getLatestBlock(requestId);
-      if(!block) {
+      const latestBlockResponse = await this.mirrorNodeClient.getLatestBlock(requestId);
+      if(!latestBlockResponse || latestBlockResponse.blocks.length === 0) {
         throw predefined.RESOURCE_NOT_FOUND(`unable to retrieve latest block from mirror node`);
       }
 
-      const trailingBlockCount = block.number - blockNum;
+      const trailingBlockCount = latestBlockResponse.blocks[0].number - blockNum;
       if(trailingBlockCount > this.maxBlockRange) {
         this.logger.warn(`${formatRequestIdMessage(requestId)} referenced block '${blockParam}' trails latest by ${trailingBlockCount}, max trailing count is ${this.maxBlockRange}. Throwable UNSUPPORTED_HISTORICAL_EXECUTION scenario.`);
       }   

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3573,6 +3573,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet(`blocks?limit=1&order=desc`).reply(404);
 
       const block = '0x10';
+      let errorEncountered = false;
       try {
         await ethImpl.call({
           "from": accountAddress1,
@@ -3581,11 +3582,14 @@ describe('Eth calls using MirrorNode', async function () {
           "gas": maxGasLimitHex
         }, block);
       } catch (error) {
+        errorEncountered = true;
         const predefineError = predefined.RESOURCE_NOT_FOUND(`unable to retrieve latest block from mirror node`);
         expect(error.code).to.equal(predefineError.code);
         expect(error.name).to.equal(predefineError.name);
         expect(error.message).to.equal(predefineError.message);
       }
+
+      expect(errorEncountered).to.equal(true);
     });
 
     it('to field is not a contract or token', async function () {


### PR DESCRIPTION
**Description**:
performCallBlockParamChecks latest block check was not handling the response correctly
- Update logic to check for correct mirror node schema on blocks
- Update test case to verify for error thrown

**Related issue(s)**:

Addresses #1297 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
