### PR TITLE
Ignore test files in sonar cloud checks

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,10 @@
+sonar.sources=.
+sonar.exclusions=**/*spec.ts
+sonar.exclusions=**/*spec.js
+
+sonar.tests=.
+sonar.test.inclusions=**/*spec.ts
+sonar.test.inclusions=**/*spec.js
+
+sonar.cpd.exclusions=**/*spec.ts
+sonar.cpd.exclusions=**/*spec.js

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,10 +1,4 @@
 sonar.sources=.
 sonar.exclusions=**/*spec.ts
-sonar.exclusions=**/*spec.js
-
-sonar.tests=.
-sonar.test.inclusions=**/*spec.ts
-sonar.test.inclusions=**/*spec.js
 
 sonar.cpd.exclusions=**/*spec.ts
-sonar.cpd.exclusions=**/*spec.js

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -92,8 +92,6 @@ let clientServiceStub;
 let cache;
 let mirrorNodeCache;
 
-// FIXME change file to trigger sonar cloud
-
 describe('Eth calls using MirrorNode', async function () {
   this.timeout(10000);
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -92,6 +92,8 @@ let clientServiceStub;
 let cache;
 let mirrorNodeCache;
 
+// FIXME change file to trigger sonar cloud
+
 describe('Eth calls using MirrorNode', async function () {
   this.timeout(10000);
 


### PR DESCRIPTION
**Description**:

Something seems to have changed in the default SonarCloud configuration and every PR has a lot of code smells and code duplication warnings that cause the SonarCloud check to fail. All of the warnings are related to very old code and I think that the test files used to be ignored by default. This PR brings back the previous default behaviour.

- Adds a config file for SonarCloud
- Ignores all test files from SonarCloud checks

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
