### PR TITLE
Adding bigger buckets to JSON RPC method statusCode latency

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -231,7 +231,7 @@ export class MirrorNodeClient {
             help: 'Mirror node response method statusCode latency histogram',
             labelNames: ['method', 'statusCode'],
             registers: [register],
-            buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000] // ms (milliseconds)
+            buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 20000, 30000] // ms (milliseconds)
         });
 
         this.logger.info(`Mirror Node client successfully configured to REST url: ${this.restUrl} and Web3 url: ${this.web3Url} `);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -60,7 +60,7 @@ const methodResponseHistogram = new Histogram({
   help: 'JSON RPC method statusCode latency histogram',
   labelNames: ['method', 'statusCode'],
   registers: [register],
-  buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 20000, 30000, 40000, 50000, 60000] // ms (milliseconds)
+  buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 20000, 30000, 40000, 50000, 60000] // ms (milliseconds)
 });
 
 /**

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -60,7 +60,7 @@ const methodResponseHistogram = new Histogram({
   help: 'JSON RPC method statusCode latency histogram',
   labelNames: ['method', 'statusCode'],
   registers: [register],
-  buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000] // ms (milliseconds)
+  buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 20000, 30000, 40000, 50000, 60000] // ms (milliseconds)
 });
 
 /**

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -60,7 +60,7 @@ const methodResponseHistogram = new Histogram({
   help: 'JSON RPC method statusCode latency histogram',
   labelNames: ['method', 'statusCode'],
   registers: [register],
-  buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 20000, 30000, 40000, 50000, 60000] // ms (milliseconds)
+  buckets: [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 20000, 30000, 40000, 50000, 60000] // ms (milliseconds)
 });
 
 /**


### PR DESCRIPTION
**Description**:
Adding bigger buckets to JSON RPC method statusCode latency so we are aware of timeouts surpassing 30 seconds and above.



**Related issue(s)**:

Fixes #1378 

**Notes for reviewer**:
<img width="730" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/631f1235-b21e-4c50-a640-8a826ba57eff">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
