### PR TITLE
Simplify this down to one container and the built-in wget

### DIFF
--- a/charts/hedera-json-rpc-relay/templates/cronjob.yaml
+++ b/charts/hedera-json-rpc-relay/templates/cronjob.yaml
@@ -59,17 +59,8 @@ spec:
               image: "{{ .Values.cronjob.image.repository }}:{{ .Values.cronjob.image.tag }}"
               imagePullPolicy: {{ .Values.cronjob.image.pullPolicy }}
               command: 
-                - newman
-                - run
-                - postman.json
-                - --env-var 
-                - baseUrl=http://{{ include "json-rpc-relay.fullname" . }}:{{ .Values.service.port }}
-              volumeMounts:
-              - name: config-json
-                mountPath: "/"
-                readOnly: true
-          volumes:
-            - name: config-json
-              emptyDir: {}                          
+                - /bin/sh
+                - -c
+                - wget https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/charts/hedera-json-rpc-relay/postman.json ; newman run postman.json --env-var baseUrl=http://{{ include "json-rpc-relay.fullname" . }}:{{ .Values.service.port }}                     
 {{- end }}
             

--- a/charts/hedera-json-rpc-relay/templates/cronjob.yaml
+++ b/charts/hedera-json-rpc-relay/templates/cronjob.yaml
@@ -43,17 +43,6 @@ spec:
         spec:
           serviceAccountName: {{ include "json-rpc-relay.serviceAccountName" . }}-test
           restartPolicy: Never
-          initContainers:
-            - name: curl-config
-              image: curlimages/curl
-              command: 
-                - curl
-                - https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/packages/server/tests/postman.json
-                - -o
-                - postman.json
-              volumeMounts:
-              - name: config-json
-                mountPath: "/"
           containers:
             - name: newman
               image: "{{ .Values.cronjob.image.repository }}:{{ .Values.cronjob.image.tag }}"


### PR DESCRIPTION
**Description**:
This PR modifies the newman cronjob test
* Removes init container, volume and volume mounts
* Utilized a single container to run this test

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Running in integration as `cronjob.integration-json-rpc-relay-test`.  The integration cronjob was edited to test the updated jobspec and then a manual job was created using ` k create job --from=cronjob/integration-json-rpc-relay-test -n integration $NAME`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
