### PR TITLE
Fix Label of mirror node metric `contracts/{address}/results/{timestamp}`

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -66,6 +66,7 @@ export class MirrorNodeClient {
     private static TIMESTAMP_PLACEHOLDER = '{timestamp}';
     private static CONTRACT_ID_PLACEHOLDER = '{contractId}';
     private static GET_CONTRACT_RESULTS_BY_ADDRESS_ENDPOINT = `contracts/${MirrorNodeClient.ADDRESS_PLACEHOLDER}/results`;
+    private static GET_CONTRACT_RESULTS_BY_ADDRESS_AND_TIMESTAMP_ENDPOINT = `contracts/${MirrorNodeClient.ADDRESS_PLACEHOLDER}/results/${MirrorNodeClient.TIMESTAMP_PLACEHOLDER}`
     private static GET_CONTRACT_RESULTS_DETAILS_BY_CONTRACT_ID_ENDPOINT =
         `contracts/${MirrorNodeClient.CONTRACT_ID_PLACEHOLDER}/results/${MirrorNodeClient.TIMESTAMP_PLACEHOLDER}`;
     private static GET_CONTRACT_RESULT_ENDPOINT = 'contracts/results/';
@@ -590,7 +591,7 @@ export class MirrorNodeClient {
 
     public async getContractResultsByAddressAndTimestamp(contractIdOrAddress: string, timestamp: string, requestId?: string) {
         return this.get(`${MirrorNodeClient.getContractResultsByAddressPath(contractIdOrAddress)}/${timestamp}`,
-            MirrorNodeClient.GET_CONTRACT_RESULTS_BY_ADDRESS_ENDPOINT,
+            MirrorNodeClient.GET_CONTRACT_RESULTS_BY_ADDRESS_AND_TIMESTAMP_ENDPOINT,
             requestId);
     }
 


### PR DESCRIPTION
**Description**:
Fixed label for mirror node metric label contracts/{address}/results/{timestamp}

**Related issue(s)**:

Fixes #1400 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
