### PR TITLE
Fixes try catch tests and remove unecessary asseritons

### DIFF
--- a/dapp-example/tests/e2e/specs/index.spec.js
+++ b/dapp-example/tests/e2e/specs/index.spec.js
@@ -35,6 +35,9 @@ describe('Test Core Hedera User Scenarios', function() {
 
       // deploy the contract
       cy.get('#btnDeployContract').should('not.be.disabled').click();
+
+      //Adding cy.wait аs temporary fix due to issue in synpress library https://github.com/Synthetixio/synpress/issues/795
+      cy.wait(10000);
       cy.confirmMetamaskTransaction();
 
       // test a view call
@@ -44,6 +47,7 @@ describe('Test Core Hedera User Scenarios', function() {
       // test a update call
       cy.get('#updateGreetingText').type('updated_text');
       cy.get('#btnUpdateGreeting').should('not.be.disabled').click();
+      cy.wait(10000);
       cy.confirmMetamaskTransaction();
       cy.waitUntil(() => cy.get('#contractUpdateMsg').should('have.text', ' Updated text: updated_text '));
 
@@ -59,6 +63,7 @@ describe('Test Core Hedera User Scenarios', function() {
       cy.get('#htsReceiverAddressField').type(hollowAccount1.address);
       cy.get('#htsTokenAmountField').clear().type(1000).trigger('change');
       cy.get('#htsTokenTransferBtn').should('not.be.disabled').click();
+      cy.wait(10000);
       cy.confirmMetamaskTransaction();
 
       cy.waitUntil(() => cy.get('#htsTokenMsg').should('have.text', ' Done '));
@@ -68,6 +73,7 @@ describe('Test Core Hedera User Scenarios', function() {
       cy.get('#sendHbarsToField').clear().type(hollowAccount1.address);
       cy.get('#sendHbarsAmountField').clear().type('10000000000000000').trigger('change');
       cy.get('#sendHbarsBtn').should('not.be.disabled').click();
+      cy.wait(10000);
       cy.confirmMetamaskTransaction();
 
       cy.waitUntil(() => cy.get('#sendHbarMsg').should('have.text', ' Done '));
@@ -78,6 +84,7 @@ describe('Test Core Hedera User Scenarios', function() {
       cy.get('#sendHbarsToField').clear().type(hollowAccount1.address);
       cy.get('#sendHbarsAmountField').clear().type('60000000000000000000').trigger('change');
       cy.get('#sendHbarsBtn').should('not.be.disabled').click();
+      cy.wait(10000);
       cy.confirmMetamaskTransaction();
 
       cy.waitUntil(() => cy.get('#sendHbarMsg').should('have.text', ' Done '));
@@ -87,6 +94,7 @@ describe('Test Core Hedera User Scenarios', function() {
     it('Create hollow account 2 via HBARs transfer transaction in contract', { retries: retries }, function() {
       cy.get('#hollowAccountAddressField').clear().type(hollowAccount2.address);
       cy.get('#activateHollowAccountBtn').should('not.be.disabled').click();
+      cy.wait(10000)
       cy.confirmMetamaskTransaction();
 
       cy.waitUntil(() => cy.get('#activateHollowAccountMsg').should('have.text', ' Done '));
@@ -127,6 +135,7 @@ describe('Test Core Hedera User Scenarios', function() {
       cy.get('#sendHbarsToField').clear().type(randomHollowAccountAddress);
       cy.get('#sendHbarsAmountField').clear().type('10000000000000000').trigger('change');
       cy.get('#sendHbarsBtn').should('not.be.disabled').click();
+      cy.wait(10000);
       cy.confirmMetamaskTransaction();
 
       cy.waitUntil(() => cy.get('#sendHbarMsg').should('have.text', ' Done '));
@@ -137,6 +146,7 @@ describe('Test Core Hedera User Scenarios', function() {
         console.log(`Associate with ${bootstrapInfo.HTS_SECOND_ADDRESS}`);
         cy.get('#htsTokenAssociateAddressField').clear().type(bootstrapInfo.HTS_SECOND_ADDRESS).trigger('change');
         cy.get('#htsTokenAssociateBtn').should('not.be.disabled').click();
+        cy.wait(10000);
         cy.confirmMetamaskTransaction();
   
         cy.waitUntil(() => cy.get('#htsTokenAssociateMsg').should('have.text', ' Done '));

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,11 @@
                 "typescript": "^4.6.3"
             },
             "devDependencies": {
+                "@types/chai-as-promised": "^7.1.5",
                 "@typescript-eslint/eslint-plugin": "^5.11.0",
                 "@typescript-eslint/parser": "^5.11.0",
                 "axios-mock-adapter": "^1.20.0",
+                "chai-as-promised": "^7.1.1",
                 "codecov": "^3.8.3",
                 "eslint": "^7.32.0",
                 "eslint-config-airbnb-base": "^15.0.0",
@@ -4850,6 +4852,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/chai-as-promised": {
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+            "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/chai": "*"
+            }
+        },
         "node_modules/@types/connect": {
             "version": "3.4.35",
             "dev": true,
@@ -6386,6 +6397,18 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/chai-as-promised": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+            "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+            "dev": true,
+            "dependencies": {
+                "check-error": "^1.0.2"
+            },
+            "peerDependencies": {
+                "chai": ">= 2.1.2 < 5"
             }
         },
         "node_modules/chalk": {
@@ -22280,6 +22303,15 @@
             "version": "4.3.4",
             "dev": true
         },
+        "@types/chai-as-promised": {
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz",
+            "integrity": "sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==",
+            "dev": true,
+            "requires": {
+                "@types/chai": "*"
+            }
+        },
         "@types/connect": {
             "version": "3.4.35",
             "dev": true,
@@ -23310,6 +23342,15 @@
                 "loupe": "^2.3.1",
                 "pathval": "^1.1.1",
                 "type-detect": "^4.0.5"
+            }
+        },
+        "chai-as-promised": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+            "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+            "dev": true,
+            "requires": {
+                "check-error": "^1.0.2"
             }
         },
         "chalk": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
     "name": "root",
     "devDependencies": {
+        "@types/chai-as-promised": "^7.1.5",
         "@typescript-eslint/eslint-plugin": "^5.11.0",
         "@typescript-eslint/parser": "^5.11.0",
         "axios-mock-adapter": "^1.20.0",
+        "chai-as-promised": "^7.1.1",
         "codecov": "^3.8.3",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^15.0.0",

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -17,18 +17,22 @@
  * limitations under the License.
  *
  */
-
+import chai from 'chai';
 import dotenv from 'dotenv';
 import path from 'path';
 import shell from 'shelljs';
 import pino from 'pino';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
+
 import fs from 'fs';
 import ServicesClient from '../clients/servicesClient';
 import MirrorClient from '../clients/mirrorClient';
 import RelayClient from '../clients/relayClient';
 import app from '../../dist/server';
-import {app as wsApp} from '@hashgraph/json-rpc-ws-server/dist/webSocketServer';
-import {Hbar} from "@hashgraph/sdk";
+import { app as wsApp } from '@hashgraph/json-rpc-ws-server/dist/webSocketServer';
+import { Hbar } from "@hashgraph/sdk";
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 import constants from '@hashgraph/json-rpc-relay/dist/lib/constants';
 
@@ -77,13 +81,13 @@ describe('RPC Server Acceptance Tests', function () {
         logger.info(`MIRROR_NODE_URL: ${process.env.MIRROR_NODE_URL}`);
         logger.info(`E2E_RELAY_HOST: ${process.env.E2E_RELAY_HOST}`);
 
-        if (USE_LOCAL_NODE === 'true') {
-            runLocalHederaNetwork();
-        }
+        // if (USE_LOCAL_NODE === 'true') {
+        //     runLocalHederaNetwork();
+        // }
 
-        if (global.relayIsLocal) {
-            runLocalRelay();
-        }
+        // if (global.relayIsLocal) {
+        //     runLocalRelay();
+        // }
 
         // cache start balance
         startOperatorBalance = await global.servicesNode.getOperatorBalance();
@@ -95,17 +99,17 @@ describe('RPC Server Acceptance Tests', function () {
         logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
 
 
-        if (USE_LOCAL_NODE === 'true') {
-            // stop local-node
-            logger.info('Shutdown local node');
-            shell.exec('hedera stop');
-        }
+        // if (USE_LOCAL_NODE === 'true') {
+        //     // stop local-node
+        //     logger.info('Shutdown local node');
+        //     shell.exec('hedera stop');
+        // }
 
         // stop relay
-        logger.info('Stop relay');
-        if (relayServer !== undefined) {
-            relayServer.close();
-        }
+        // logger.info('Stop relay');
+        // if (relayServer !== undefined) {
+        //     relayServer.close();
+        // }
 
         if (process.env.TEST_WS_SERVER === 'true' && socketServer !== undefined) {
             socketServer.close();

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -81,13 +81,13 @@ describe('RPC Server Acceptance Tests', function () {
         logger.info(`MIRROR_NODE_URL: ${process.env.MIRROR_NODE_URL}`);
         logger.info(`E2E_RELAY_HOST: ${process.env.E2E_RELAY_HOST}`);
 
-        // if (USE_LOCAL_NODE === 'true') {
-        //     runLocalHederaNetwork();
-        // }
+        if (USE_LOCAL_NODE === 'true') {
+            runLocalHederaNetwork();
+        }
 
-        // if (global.relayIsLocal) {
-        //     runLocalRelay();
-        // }
+        if (global.relayIsLocal) {
+            runLocalRelay();
+        }
 
         // cache start balance
         startOperatorBalance = await global.servicesNode.getOperatorBalance();
@@ -99,17 +99,17 @@ describe('RPC Server Acceptance Tests', function () {
         logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
 
 
-        // if (USE_LOCAL_NODE === 'true') {
-        //     // stop local-node
-        //     logger.info('Shutdown local node');
-        //     shell.exec('hedera stop');
-        // }
+        if (USE_LOCAL_NODE === 'true') {
+            // stop local-node
+            logger.info('Shutdown local node');
+            shell.exec('hedera stop');
+        }
 
-        // stop relay
-        // logger.info('Stop relay');
-        // if (relayServer !== undefined) {
-        //     relayServer.close();
-        // }
+        //stop relay
+        logger.info('Stop relay');
+        if (relayServer !== undefined) {
+            relayServer.close();
+        }
 
         if (process.env.TEST_WS_SERVER === 'true' && socketServer !== undefined) {
             socketServer.close();

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -19,16 +19,13 @@
  */
 
 // external resources
-import chai from 'chai';
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 import { AliasAccount } from '../clients/servicesClient';
 import Assertions from '../helpers/assertions';
 import { Utils } from '../helpers/utils';
 import { ContractFunctionParameters } from '@hashgraph/sdk';
-import chaiAsPromised from 'chai-as-promised';
 
-chai.use(chaiAsPromised);
 
 // local resources
 import parentContractJson from '../contracts/Parent.json';

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -822,6 +822,79 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], predefined.GAS_PRICE_TOO_LOW(GAS_PRICE_TOO_LOW, GAS_PRICE_REF), requestId);
                 });
+
+                it('@release fail "eth_getTransactionReceipt" on precheck with wrong nonce error when sending a tx with the same nonce twice', async function () {
+                    const nonce = await relay.getAccountNonce('0x' + accounts[2].address, requestId);
+
+                    const transaction = {
+                        ...default155TransactionData,
+                        to: mirrorContract.evm_address,
+                        nonce: nonce,
+                        gasPrice: await relay.gasPrice(requestId)
+                    };
+
+                    const signedTx = await accounts[2].wallet.signTransaction(transaction);
+                    const txHash1 = await relay.sendRawTransaction(signedTx, requestId);
+                    const mirrorResult = await mirrorNode.get(`/contracts/results/${txHash1}`, requestId);
+                    const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_RECEIPT, [txHash1], requestId);
+                    Assertions.transactionReceipt(res, mirrorResult);
+
+                    await relay.callFailing(
+                        RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION,
+                        [signedTx],
+                        predefined.NONCE_TOO_LOW(nonce + 1, nonce), requestId
+                    );
+                });
+
+                it('@release fail "eth_getTransactionReceipt" on precheck with wrong nonce error when sending a tx with a higher nonce', async function () {
+                    const nonce = await relay.getAccountNonce('0x' + accounts[2].address, requestId);
+
+                    const transaction = {
+                        ...default155TransactionData,
+                        to: mirrorContract.evm_address,
+                        nonce: nonce + 100,
+                        gasPrice: await relay.gasPrice(requestId)
+                    };
+
+                    const signedTx = await accounts[2].wallet.signTransaction(transaction);
+
+                    await relay.callFailing(
+                        RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION,
+                        [signedTx],
+                        predefined.NONCE_TOO_HIGH(nonce + 100, nonce), requestId
+                    );
+                });
+
+                it('@release fail "eth_getTransactionReceipt" on submitting with wrong nonce error when sending a tx with the same nonce twice', async function () {
+                    const nonce = await relay.getAccountNonce('0x' + accounts[2].address, requestId);
+
+                    const transaction1 = {
+                        ...default155TransactionData,
+                        to: mirrorContract.evm_address,
+                        nonce: nonce,
+                        gasPrice: await relay.gasPrice(requestId)
+                    };
+
+                    const signedTx1 = await accounts[2].wallet.signTransaction(transaction1);
+
+                    await Promise.all([
+                        Promise.allSettled([
+                            relay.sendRawTransaction(signedTx1, requestId),
+                            relay.sendRawTransaction(signedTx1, requestId)
+                        ])
+                            .then((values) => {
+                                const fulfilled = values.find(obj => obj.status === 'fulfilled');
+                                const rejected = values.find(obj => obj.status === 'rejected');
+
+                                expect(fulfilled).to.exist;
+                                expect(fulfilled).to.have.property('value');
+                                expect(rejected).to.exist;
+                                expect(rejected).to.have.property('reason');
+
+                                Assertions.jsonRpcError(rejected.reason, predefined.NONCE_TOO_LOW(nonce + 1, nonce));
+                            })
+                    ]);
+                });
             });
 
             it('@release should execute "eth_getTransactionCount" primary', async function () {

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -19,12 +19,16 @@
  */
 
 // external resources
+import chai from 'chai';
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 import { AliasAccount } from '../clients/servicesClient';
 import Assertions from '../helpers/assertions';
 import { Utils } from '../helpers/utils';
 import { ContractFunctionParameters } from '@hashgraph/sdk';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
 
 // local resources
 import parentContractJson from '../contracts/Parent.json';
@@ -293,7 +297,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     'address': [contractAddress, contractAddress2]
                 }], requestId);
                 expect(logs.length).to.be.greaterThan(2);
-            })
+            });
         });
 
         describe('Block related RPC calls', () => {
@@ -307,7 +311,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const timestampQuery = `timestamp=gte:${mirrorBlock.timestamp.from}&timestamp=lte:${mirrorBlock.timestamp.to}`;
                 mirrorContractResults = (await mirrorNode.get(`/contracts/results?${timestampQuery}`, requestId)).results;
 
-                for ( let res of mirrorContractResults ) {
+                for ( const res of mirrorContractResults ) {
                     mirrorTransactions.push((await mirrorNode.get(`/contracts/${res.contract_id}/results/${res.timestamp}`, requestId)));
                 }
 
@@ -506,11 +510,10 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 };
 
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                try {
-                    await relay.sendRawTransaction(signedTx+"11", requestId);
-                } catch (error) {
-                    expect(`Error invoking RPC: ${error.message}`).to.equal(predefined.INTERNAL_ERROR(error.message).message);
-                } 
+
+                await expect(relay.sendRawTransaction(signedTx + "11", requestId)).to.be.rejectedWith(
+                    predefined.INTERNAL_ERROR()
+                );
             });
 
             it('should execute "eth_getTransactionReceipt" for non-existing hash', async function () {
@@ -526,13 +529,10 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     chainId: INCORRECT_CHAIN_ID
                 };
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                try {
-                    await relay.sendRawTransaction(signedTx, requestId);
-                    Assertions.expectedError();
-                }
-                catch (e) {
-                    Assertions.jsonRpcError(e, predefined.UNSUPPORTED_CHAIN_ID(ethers.utils.hexValue(INCORRECT_CHAIN_ID), CHAIN_ID));
-                }
+
+                await expect(relay.sendRawTransaction(signedTx, requestId)).to.be.rejectedWith(
+                    predefined.UNSUPPORTED_CHAIN_ID(ethers.utils.hexValue(INCORRECT_CHAIN_ID), CHAIN_ID)
+                );
             });
 
             it('@release should execute "eth_sendRawTransaction" for legacy EIP 155 transactions', async function () {
@@ -599,11 +599,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     gasPrice: await relay.gasPrice(requestId)
                 };
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                try {
-                    await relay.sendRawTransaction(signedTx, requestId);
-                } catch (error) {
-                    expect(`Error invoking RPC: ${error.message}`).to.equal(predefined.INTERNAL_ERROR(error.message).message);
-                } 
+
+                await expect(relay.sendRawTransaction(signedTx, requestId)).to.be.rejectedWith(predefined.INTERNAL_ERROR());
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions (with gas price too low)', async function () {
@@ -741,13 +738,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 };
 
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                let hasError = false;
-                try {
-                    await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], requestId);
-                } catch (e) {
-                    hasError = true;
-                }
-                expect(hasError).to.be.true;
+
+                await expect(relay.sendRawTransaction(signedTx, requestId)).to.be.rejectedWith(predefined.INTERNAL_ERROR());
             });
 
             describe('Prechecks', async function () {
@@ -759,13 +751,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                         chainId: INCORRECT_CHAIN_ID
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    try {
-                        await relay.sendRawTransaction(signedTx, requestId);
-                        Assertions.expectedError();
-                    }
-                    catch (e) {
-                        Assertions.jsonRpcError(e, predefined.UNSUPPORTED_CHAIN_ID('0x3e7', CHAIN_ID));
-                    }
+
+                    await expect(relay.sendRawTransaction(signedTx, requestId)).to.be.rejectedWith(predefined.UNSUPPORTED_CHAIN_ID('0x3e7', CHAIN_ID));
                 });
 
                 it('should fail "eth_sendRawTransaction" for EIP155 transaction with not enough gas', async function () {
@@ -779,13 +766,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     };
 
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    try {
-                        await relay.sendRawTransaction(signedTx, requestId);
-                        Assertions.expectedError();
-                    }
-                    catch (e) {
-                        Assertions.jsonRpcError(e, predefined.GAS_LIMIT_TOO_LOW(gasLimit, Constants.BLOCK_GAS_LIMIT));
-                    }
+
+                    await expect(relay.sendRawTransaction(signedTx, requestId)).to.be.rejectedWith(predefined.GAS_LIMIT_TOO_LOW(gasLimit, Constants.BLOCK_GAS_LIMIT));
                 });
 
                 it('should fail "eth_sendRawTransaction" for EIP155 transaction with a too high gasLimit', async function () {
@@ -799,12 +781,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     };
 
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    try {
-                        await relay.sendRawTransaction(signedTx, requestId);
-                        Assertions.expectedError();
-                    } catch (e) {
-                        Assertions.jsonRpcError(e, predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT));
-                    }
+
+                    await expect(relay.sendRawTransaction(signedTx, requestId)).to.be.rejectedWith(predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT));
                 });
 
 
@@ -817,13 +795,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                         gasLimit: gasLimit
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    try {
-                        await relay.sendRawTransaction(signedTx, requestId);
-                        Assertions.expectedError();
-                    }
-                    catch (e) {
-                        Assertions.jsonRpcError(e, predefined.GAS_LIMIT_TOO_LOW(gasLimit, Constants.BLOCK_GAS_LIMIT));
-                    }
+
+                    await expect(relay.sendRawTransaction(signedTx, requestId)).to.be.rejectedWith(predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT));
                 });
 
                 it('should fail "eth_sendRawTransaction" for London transaction with a too high gasLimit', async function () {
@@ -835,12 +808,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                         gasLimit: gasLimit
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    try {
-                        await relay.sendRawTransaction(signedTx, requestId);
-                        Assertions.expectedError();
-                    } catch (e) {
-                        Assertions.jsonRpcError(e, predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT));
-                    }
+
+                    await expect(relay.sendRawTransaction(signedTx, requestId)).to.be.rejectedWith(predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT));
                 });
 
                 it('should fail "eth_sendRawTransaction" for legacy EIP 155 transactions (with gas price too low)', async function () {
@@ -852,79 +821,6 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     };
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     await relay.callFailing(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], predefined.GAS_PRICE_TOO_LOW(GAS_PRICE_TOO_LOW, GAS_PRICE_REF), requestId);
-                });
-
-                it('@release fail "eth_getTransactionReceipt" on precheck with wrong nonce error when sending a tx with the same nonce twice', async function () {
-                    const nonce = await relay.getAccountNonce('0x' + accounts[2].address, requestId);
-
-                    const transaction = {
-                        ...default155TransactionData,
-                        to: mirrorContract.evm_address,
-                        nonce: nonce,
-                        gasPrice: await relay.gasPrice(requestId)
-                    };
-
-                    const signedTx = await accounts[2].wallet.signTransaction(transaction);
-                    const txHash1 = await relay.sendRawTransaction(signedTx, requestId);
-                    const mirrorResult = await mirrorNode.get(`/contracts/results/${txHash1}`, requestId);
-                    const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_RECEIPT, [txHash1], requestId);
-                    Assertions.transactionReceipt(res, mirrorResult);
-
-                    await relay.callFailing(
-                        RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION,
-                        [signedTx],
-                        predefined.NONCE_TOO_LOW(nonce + 1, nonce), requestId
-                    );
-                });
-
-                it('@release fail "eth_getTransactionReceipt" on precheck with wrong nonce error when sending a tx with a higher nonce', async function () {
-                    const nonce = await relay.getAccountNonce('0x' + accounts[2].address, requestId);
-
-                    const transaction = {
-                        ...default155TransactionData,
-                        to: mirrorContract.evm_address,
-                        nonce: nonce + 100,
-                        gasPrice: await relay.gasPrice(requestId)
-                    };
-
-                    const signedTx = await accounts[2].wallet.signTransaction(transaction);
-
-                    await relay.callFailing(
-                        RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION,
-                        [signedTx],
-                        predefined.NONCE_TOO_HIGH(nonce + 100, nonce), requestId
-                    );
-                });
-
-                it('@release fail "eth_getTransactionReceipt" on submitting with wrong nonce error when sending a tx with the same nonce twice', async function () {
-                    const nonce = await relay.getAccountNonce('0x' + accounts[2].address, requestId);
-
-                    const transaction1 = {
-                        ...default155TransactionData,
-                        to: mirrorContract.evm_address,
-                        nonce: nonce,
-                        gasPrice: await relay.gasPrice(requestId)
-                    };
-
-                    const signedTx1 = await accounts[2].wallet.signTransaction(transaction1);
-
-                    await Promise.all([
-                        Promise.allSettled([
-                            relay.sendRawTransaction(signedTx1, requestId),
-                            relay.sendRawTransaction(signedTx1, requestId)
-                        ])
-                            .then((values) => {
-                                const fulfilled = values.find(obj => obj.status === 'fulfilled');
-                                const rejected = values.find(obj => obj.status === 'rejected');
-
-                                expect(fulfilled).to.exist;
-                                expect(fulfilled).to.have.property('value');
-                                expect(rejected).to.exist;
-                                expect(rejected).to.have.property('reason');
-
-                                Assertions.jsonRpcError(rejected.reason, predefined.NONCE_TOO_LOW(nonce + 1, nonce))
-                            })
-                    ]);
                 });
             });
 

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -31,14 +31,13 @@ import TokenCreateJson from '../contracts/TokenCreateContract.json';
 import parentContractJson from '../contracts/Parent.json';
 import basicContractJson from '../contracts/Basic.json';
 import storageContractJson from '../contracts/Storage.json';
-import { JsonRpcError, predefined } from '../../../relay/src/lib/errors/JsonRpcError';
+import { predefined } from '../../../relay/src/lib/errors/JsonRpcError';
 import { EthImpl } from '../../../../packages/relay/src/lib/eth';
 //Constants are imported with different definitions for better readability in the code.
 import Constants from '../../../../packages/relay/src/lib/constants';
 import RelayCalls from '../../tests/helpers/constants';
 import Helper from '../../tests/helpers/constants';
 import Address from '../../tests/helpers/constants';
-import { error } from 'console';
 
 describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -31,13 +31,14 @@ import TokenCreateJson from '../contracts/TokenCreateContract.json';
 import parentContractJson from '../contracts/Parent.json';
 import basicContractJson from '../contracts/Basic.json';
 import storageContractJson from '../contracts/Storage.json';
-import { predefined } from '../../../relay/src/lib/errors/JsonRpcError';
+import { JsonRpcError, predefined } from '../../../relay/src/lib/errors/JsonRpcError';
 import { EthImpl } from '../../../../packages/relay/src/lib/eth';
 //Constants are imported with different definitions for better readability in the code.
 import Constants from '../../../../packages/relay/src/lib/constants';
 import RelayCalls from '../../tests/helpers/constants';
 import Helper from '../../tests/helpers/constants';
 import Address from '../../tests/helpers/constants';
+import { error } from 'console';
 
 describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -178,87 +179,56 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
         });
 
         it('should not be able to execute "eth_estimateGas" with no transaction object', async function () {
-            try {
-                await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-                const err = JSON.parse(error.body);
-                expect(error).to.not.be.null;
-                expect(err.error.name).to.be.equal('Missing required parameters');
-                expect(err.error.message.endsWith('Missing value for required parameter 0')).to.be.true;
-            }
+            const errorMessage = 'Missing value for required parameter 0';
+            await expect(relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [], requestId)).to.be.rejectedWith('Missing required parameters').and.eventually.have.property('message').that.include(errorMessage);
         });
 
         it('should not be able to execute "eth_estimateGas" with wrong from field', async function () {
-            try {
-                await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
-                    from: '0x114f60009ee6b84861c0cdae8829751e517b',
+            const from = '0x114f60009ee6b84861c0cdae8829751e517b';
+            const errorMessage = `Invalid parameter 'from' for TransactionObject: Expected 0x prefixed string representing the address (20 bytes), value: ${from}`;
+            await expect(relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
+                    from: from,
                     to: '0xae410f34f7487e2cd03396499cebb09b79f45d6e',
                     value: '0xa688906bd8b00000',
                     gas: '0xd97010',
                     accessList: []
-                }], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-                const err = JSON.parse(error.body);
-                expect(error).to.not.be.null;
-                expect(err.error.name).to.be.equal('Invalid parameter');
-                expect(err.error.message.endsWith(`Invalid parameter 'from' for TransactionObject: Expected 0x prefixed string representing the address (20 bytes), value: 0x114f60009ee6b84861c0cdae8829751e517b`)).to.be.true;
-            }
+                }], requestId)).to.be.rejectedWith('Invalid parameter').and.eventually.have.property('message').that.include(errorMessage);
         });
 
         it('should not be able to execute "eth_estimateGas" with wrong to field', async function () {
-            try {
-                await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
-                    from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
-                    to: '0xae410f34f7487e2cd03396499cebb09b79f45',
-                    value: '0xa688906bd8b00000',
-                    gas: '0xd97010',
-                    accessList: []
-                }], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-                const err = JSON.parse(error.body);
-                expect(error).to.not.be.null;
-                expect(err.error.name).to.be.equal('Invalid parameter');
-                expect(err.error.message.endsWith(`Invalid parameter 'to' for TransactionObject: Expected 0x prefixed string representing the address (20 bytes), value: 0xae410f34f7487e2cd03396499cebb09b79f45`)).to.be.true;
-            }
+            const to = '0xae410f34f7487e2cd03396499cebb09b79f45';
+            const errorMessage = `Invalid parameter 'to' for TransactionObject: Expected 0x prefixed string representing the address (20 bytes), value: ${to}`;
+            await expect(relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
+                from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
+                to: to,
+                value: '0xa688906bd8b00000',
+                gas: '0xd97010',
+                accessList: []
+            }], requestId)).to.be.rejectedWith('Invalid parameter').and.eventually.have.property('message').that.include(errorMessage);
         });
 
         it('should not be able to execute "eth_estimateGas" with wrong value field', async function () {
-            try {
-                await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
-                    from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
-                    to: '0xae410f34f7487e2cd03396499cebb09b79f45d6e',
-                    value: '123',
-                    gas: '0xd97010',
-                    accessList: []
-                }], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-                const err = JSON.parse(error.body);
-                expect(error).to.not.be.null;
-                expect(err.error.name).to.be.equal('Invalid parameter');
-                expect(err.error.message.endsWith(`Invalid parameter 'value' for TransactionObject: Expected 0x prefixed hexadecimal value, value: 123`)).to.be.true;
-            }
+            const value = '123';
+            const errorMessage = `Invalid parameter 'value' for TransactionObject: Expected 0x prefixed hexadecimal value, value: ${value}`;
+            await expect(relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
+                from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
+                to: '0xae410f34f7487e2cd03396499cebb09b79f45d6e',
+                value: value,
+                gas: '0xd97010',
+                accessList: []
+            }], requestId)).to.be.rejectedWith('Invalid parameter').and.eventually.have.property('message').that.include(errorMessage);
         });
 
         it('should not be able to execute "eth_estimateGas" with wrong gas field', async function () {
-            try {
-                await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
-                    from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
-                    to: '0xae410f34f7487e2cd03396499cebb09b79f45d6e',
-                    value: '0xa688906bd8b00000',
-                    gas: '123',
-                    accessList: []
-                }], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-                const err = JSON.parse(error.body);
-                expect(error).to.not.be.null;
-                expect(err.error.name).to.be.equal('Invalid parameter');
-                expect(err.error.message.endsWith(`Invalid parameter 'gas' for TransactionObject: Expected 0x prefixed hexadecimal value, value: 123`)).to.be.true;
-            }
+            const gas = '123';
+            const errorMessage = `Invalid parameter 'gas' for TransactionObject: Expected 0x prefixed hexadecimal value, value: ${gas}`;
+            await expect(relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
+                from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
+                to: '0xae410f34f7487e2cd03396499cebb09b79f45d6e',
+                value: '0xa688906bd8b00000',
+                gas: gas,
+                accessList: []
+            }], requestId)).to.be.rejectedWith('Invalid parameter').and.eventually.have.property('message').that.include(errorMessage);
         });
     });
 
@@ -272,13 +242,13 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
                 expect(Number(res)).to.be.gt(0);
             }
         });
-    })
+    });
 
     describe('eth_getBalance', async function () {
         let getBalanceContractId;
         before(async function () {
             getBalanceContractId = await accounts[0].client.createParentContract(parentContractJson, requestId);
-        })
+        });
 
         it('@release should execute "eth_getBalance" for newly created account with 10 HBAR', async function () {
             const account = await servicesNode.createAliasAccount(10, null, requestId);
@@ -539,7 +509,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
         it('should execute "eth_getCode" for hts token', async function () {
             const tokenAddress = NftHTSTokenContractAddress.slice(2);
-            redirectBytecode = `6080604052348015600f57600080fd5b506000610167905077618dc65e${tokenAddress}600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033`
+            redirectBytecode = `6080604052348015600f57600080fd5b506000610167905077618dc65e${tokenAddress}600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033`;
             const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_CODE, [NftHTSTokenContractAddress, 'latest'], requestId);
             expect(res).to.equal(redirectBytecode);
         });
@@ -782,15 +752,13 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             });
 
             it('should call eth_feeHistory with newest block > latest', async function () {
-                let latestBlock;
                 const blocksAhead = 10;
-                try {
-                    latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
-                    const newestBlockNumberHex = ethers.utils.hexValue(latestBlock.number + blocksAhead);
-                    await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_FEE_HISTORY, ['0x1', newestBlockNumberHex, null], requestId);
-                } catch (error) {
-                    Assertions.jsonRpcError(error, predefined.REQUEST_BEYOND_HEAD_BLOCK(latestBlock.number + blocksAhead, latestBlock.number));
-                }
+
+                const latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
+                const errorType = predefined.REQUEST_BEYOND_HEAD_BLOCK(latestBlock.number + blocksAhead, latestBlock.number);
+                const newestBlockNumberHex = ethers.utils.hexValue(latestBlock.number + blocksAhead);
+
+                await expect(relay.call(RelayCalls.ETH_ENDPOINTS.ETH_FEE_HISTORY, ['0x1', newestBlockNumberHex, null], requestId)).to.be.rejectedWith(errorType);
             });
 
             it('should call eth_feeHistory with zero block count', async function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -496,7 +496,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
         before(async () => {
             basicContract = await servicesNode.deployContract(basicContractJson);
-            mainContractAddress = await deploymainContract(accounts[3].wallet);
+            mainContractAddress = await deploymainContract();
 
             // Wait for creation to propagate
             const basicMirror = await mirrorNode.get(`/contracts/${basicContract.contractId}`, requestId);

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -28,7 +28,6 @@ import { Utils } from '../helpers/utils';
 import reverterContractJson from '../contracts/Reverter.json';
 import { EthImpl } from '../../../../packages/relay/src/lib/eth';
 import { predefined } from '../../../../packages/relay';
-import Assertions from "../helpers/assertions";
 import basicContractJson from '../contracts/Basic.json';
 import callerContractJson from '../contracts/Caller.json';
 import HederaTokenServiceImplJson from '../contracts/HederaTokenServiceImpl.json';

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -62,6 +62,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
     const PAYABLE_METHOD_ERROR_DATA = '0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000013526576657274526561736f6e50617961626c6500000000000000000000000000';
     const PURE_METHOD_ERROR_MESSAGE = 'execution reverted: RevertReasonPure';
     const VIEW_METHOD_ERROR_MESSAGE = 'execution reverted: RevertReasonView';
+    const errorMessagePrefixedStr = 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending"';
 
     beforeEach(async () => {
         requestId = Utils.generateRequestId();
@@ -189,7 +190,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 to: evmAddress,
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
-            const errorType = predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: newest');
+            const errorType = predefined.INVALID_PARAMETER(1, `${errorMessagePrefixedStr}, value: newest`);
 
             await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'newest'], requestId)).to.be.rejectedWith(errorType);
         });
@@ -200,7 +201,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 to: evmAddress,
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
-            const errorType = predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: 123');
+            const errorType = predefined.INVALID_PARAMETER(1, `${errorMessagePrefixedStr}, value: 123`);
 
             await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, '123'], requestId)).to.be.rejectedWith(errorType);
         });
@@ -222,7 +223,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 to: evmAddress,
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
-            const errorType = predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, 'Expected 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: 123');
+            const errorType = predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, `${errorMessagePrefixedStr}, value: 123`);
 
             await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId)).to.be.rejectedWith(errorType);
         });

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -190,13 +190,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 to: evmAddress,
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
+            const errorType = predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: newest');
 
-            try {
-                await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'newest'], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-                Assertions.jsonRpcError(error, predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: newest'));
-            }
+            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'newest'], requestId)).to.be.rejectedWith(errorType);
         });
 
         it('should fail to execute "eth_call" with wrong block number', async function () {
@@ -205,13 +201,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 to: evmAddress,
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
+            const errorType = predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: 123');
 
-            try {
-                await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, '123'], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-                Assertions.jsonRpcError(error, predefined.INVALID_PARAMETER(1, 'Expected 0x prefixed string representing the hash (32 bytes) in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: 123'));
-            }
+            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, '123'], requestId)).to.be.rejectedWith(errorType);
         });
 
         it('should fail to execute "eth_call" with wrong block hash object', async function () {
@@ -220,14 +212,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 to: evmAddress,
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
+            const errorType = predefined.INVALID_PARAMETER(`'blockHash' for BlockHashObject`, 'Expected 0x prefixed string representing the hash (32 bytes) of a block, value: 0x123');
 
-            try {
-                await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-
-                Assertions.jsonRpcError(error, predefined.INVALID_PARAMETER(`'blockHash' for BlockHashObject`, 'Expected 0x prefixed string representing the hash (32 bytes) of a block, value: 0x123'));
-            }
+            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId)).to.be.rejectedWith(errorType);
         });
 
         it('should fail to execute "eth_call" with wrong block number object', async function () {
@@ -236,13 +223,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 to: evmAddress,
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
+            const errorType = predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, 'Expected 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: 123');
 
-            try {
-                await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockNumber': '123' }], requestId);
-                Assertions.expectedError();
-            } catch (error) {
-                Assertions.jsonRpcError(error, predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, 'Expected 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending", value: 123'));
-            }
+            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId)).to.be.rejectedWith(errorType);
         });
 
         describe('Caller contract', () => {
@@ -281,7 +264,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 }
             ];
 
-            for (let desc of describes) {
+            for (const desc of describes) {
                 describe(desc.title, () => {
                     before(desc.beforeFunc);
 
@@ -393,13 +376,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                                 data: '0xddf363d7',
                                 value: '0x3e80000000'
                             };
+                            const errorType = predefined.CONTRACT_REVERT();
 
-                            try {
-                                await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId);
-                                Assertions.expectedError();
-                            } catch (e) {
-                                Assertions.jsonRpcError(e, predefined.CONTRACT_REVERT());
-                            }
+                            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId)).to.be.rejectedWith(errorType);
                         });
 
                         it("012 should work for wrong 'from' field", async function () {
@@ -639,7 +618,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: IS_TOKEN_ADDRESS_SIGNATURE + tokenAddress.replace('0x', '')
             };
 
-            relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'])
+            relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest']);
             const res = await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId);
 
             expect(res).to.eq(RESULT_TRUE);


### PR DESCRIPTION
**Description**:
Currently in the acceptance tests try catch logic is used, however we do not check whether an error is actually thrown and we enter the catch. Therefore, this PR changes the logic so we take the maximum of the chai library in order to make the tests effective and intuitive

**What is included**

1. Added chai as promised library for testing on promises
2. Replaced try catch with suitable chai methods, which detect if an error is not thrown
3. Added missing semicolons
4. Replaced some uses of let with const
5. Removed the unnecessary use of Assertions