### PR TITLE
Improve `eth_sendRawTransaction` latency by simplifying precheck

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -550,16 +550,14 @@ export class SDKClient {
         );
 
         if (fileId && callData.length > 4096) {
-            await (
-                await new FileAppendTransaction()
-                    .setFileId(fileId)
-                    .setContents(
-                        hexedCallData.substring(4096, hexedCallData.length)
-                    )
-                    .setChunkSize(4096)
-                    .setMaxChunks(this.maxChunks)
-                    .execute(client)
-            ).getReceipt(client);
+            await new FileAppendTransaction()
+                .setFileId(fileId)
+                .setContents(
+                    hexedCallData.substring(4096, hexedCallData.length)
+                )
+                .setChunkSize(4096)
+                .setMaxChunks(this.maxChunks)
+                .execute(client);
         }
 
         // Ensure that the calldata file is not empty

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -194,7 +194,7 @@ export class EthImpl implements Eth {
     this.mirrorNodeClient = mirrorNodeClient;
     this.logger = logger;
     this.chain = chain;
-    this.precheck = new Precheck(mirrorNodeClient, this.hapiService, logger, chain);
+    this.precheck = new Precheck(mirrorNodeClient, logger, chain);
     this.cache = clientCache;
 
     this.ethExecutionsCounter = this.initEthExecutionCounter(registry);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -65,7 +65,6 @@ import { SDKClientError } from '../../src/lib/errors/SDKClientError';
 import HAPIService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
 import { v4 as uuid } from 'uuid';
-import { ethers } from 'ethers';
 import { Hbar, HbarUnit, TransactionId } from '@hashgraph/sdk';
 
 const LRU = require('lru-cache');

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -66,7 +66,7 @@ import HAPIService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
 import { v4 as uuid } from 'uuid';
 import { ethers } from 'ethers';
-import { TransactionId } from '@hashgraph/sdk';
+import { Hbar, HbarUnit, TransactionId } from '@hashgraph/sdk';
 
 const LRU = require('lru-cache');
 
@@ -3897,7 +3897,13 @@ describe('Eth calls using MirrorNode', async function () {
     });
 
     it('should return a computed hash if unable to retrieve EthereumHash from record due to contract revert', async function () {
-      restMock.onGet(accountEndpoint).reply(200, { account: accountAddress });
+      restMock.onGet(accountEndpoint).reply(200, { 
+        account: accountAddress,
+        balance: {
+          balance: Hbar.from(100_000_000_000, HbarUnit.Hbar).to(HbarUnit.Tinybar)
+        }
+      });
+
       const transaction = {
         chainId: 0x12a,
         to: accountAddress1,
@@ -3907,7 +3913,6 @@ describe('Eth calls using MirrorNode', async function () {
         gasLimit: maxGasLimitHex,
       };
 
-      sdkClientStub.getAccountBalanceInTinyBar.returns(ethers.BigNumber.from('1000000000000000000000'));    
       const signed = await signTransaction(transaction);
       const id = uuid();
 
@@ -3919,7 +3924,13 @@ describe('Eth calls using MirrorNode', async function () {
     });
 
     it('should return hash from ContractResult mirror node api', async function () {
-      restMock.onGet(accountEndpoint).reply(200, { account: accountAddress });
+      restMock.onGet(accountEndpoint).reply(200, { 
+        account: accountAddress,
+        balance: {
+          balance: Hbar.from(100_000_000_000, HbarUnit.Hbar).to(HbarUnit.Tinybar)
+        }
+      });
+
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
       const transaction = {
         chainId: 0x12a,
@@ -3930,7 +3941,6 @@ describe('Eth calls using MirrorNode', async function () {
         gasLimit: maxGasLimitHex,
       };
 
-      sdkClientStub.getAccountBalanceInTinyBar.returns(ethers.BigNumber.from('1000000000000000000000'));
       sdkClientStub.submitEthereumTransaction.returns({transactionId: TransactionId.fromString(transactionIdServicesFormat)});
       const signed = await signTransaction(transaction);
       const id = uuid();

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -141,9 +141,20 @@ describe("Open RPC Specification", function () {
         mock.onGet(`contracts/${contractId1}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults2);
         mock.onGet(`contracts/${contractId2}/results/${contractTimestamp3}`).reply(200, defaultDetailedContractResults3);
         mock.onGet(`tokens/0.0.${parseInt(defaultCallData.to, 16)}`).reply(404, null);
-        mock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, { account: contractAddress1, balance:{balance: 2000000000000} });
-        mock.onGet(`accounts/${contractAddress3}${limitOrderPostFix}`).reply(200, { account: contractAddress3 });
+        mock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, { 
+            account: contractAddress1, 
+            balance: {
+                balance: 2000000000000
+            } 
+        });
+        mock.onGet(`accounts/${contractAddress3}${limitOrderPostFix}`).reply(200, { 
+            account: contractAddress3,
+            balance: {
+                balance: 100000000000
+            } 
+        });
         mock.onGet(`accounts/0xbC989b7b17d18702663F44A6004cB538b9DfcBAc?limit=100`).reply(200, { account: '0xbC989b7b17d18702663F44A6004cB538b9DfcBAc' });
+
         mock.onGet(`accounts/${defaultFromLongZeroAddress}${limitOrderPostFix}`).reply(200, {
             from: `${defaultEvmAddress}`
           });

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -23,18 +23,15 @@ import { Registry } from 'prom-client';
 import { Hbar, HbarUnit } from '@hashgraph/sdk';
 const registry = new Registry();
 
-import sinon from 'sinon';
 import pino from 'pino';
 import { Precheck } from "../../src/lib/precheck";
 import { expectedError, mockData, signTransaction } from "../helpers";
-import { ClientCache, MirrorNodeClient, SDKClient } from "../../src/lib/clients";
+import { ClientCache, MirrorNodeClient } from "../../src/lib/clients";
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { ethers } from "ethers";
 import constants from '../../src/lib/constants';
 import { predefined } from '../../src';
-import HAPIService from '../../src/lib/services/hapiService/hapiService';
-import HbarLimit from '../../src/lib/hbarlimiter';
 const logger = pino();
 
 const limitOrderPostFix = '?order=desc&limit=1';
@@ -55,8 +52,6 @@ describe('Precheck', async function() {
     const oneTinyBar = ethers.utils.parseUnits('1', 10);
     const defaultGasPrice = 720_000_000_000;
     const defaultChainId = Number('0x12a');
-    let sdkInstance;
-    let hapiServiceInstance: HAPIService;
     let precheck: Precheck;
     let mock: MockAdapter;
 
@@ -76,15 +71,7 @@ describe('Precheck', async function() {
         
         // @ts-ignore
         const mirrorNodeInstance = new MirrorNodeClient(process.env.MIRROR_NODE_URL, logger.child({ name: `mirror-node` }), registry, new ClientCache(logger.child({ name: `cache` }), registry), instance);
-
-        const duration = constants.HBAR_RATE_LIMIT_DURATION;
-        const total = constants.HBAR_RATE_LIMIT_TINYBAR;
-        const hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, registry);
-        const clientCache = new ClientCache(logger.child({ name: `cache` }), registry);
-        hapiServiceInstance = new HAPIService(logger, registry, hbarLimiter, clientCache);
-        sdkInstance = sinon.createStubInstance(SDKClient);
-        sinon.stub(hapiServiceInstance, "getSDKClient").returns(sdkInstance);
-        precheck = new Precheck(mirrorNodeInstance, hapiServiceInstance, logger, '0x12a');
+        precheck = new Precheck(mirrorNodeInstance, logger, '0x12a');
     });
 
     this.beforeEach(() => {
@@ -254,13 +241,15 @@ describe('Precheck', async function() {
         const accountId = '0.1.2';
 
         it('should not pass for 1 hbar', async function() {
-            mock.onGet(mirrorAccountsPath).reply(200, {
-                account: accountId
-            });
+            const account = {
+                account: accountId,
+                balance: {
+                    balance: Hbar.from(1, HbarUnit.Hbar).to(HbarUnit.Tinybar)
+                }
+            };
 
-            sdkInstance.getAccountBalanceInTinyBar.returns(Hbar.from(1, HbarUnit.Hbar).to(HbarUnit.Tinybar));
             try {
-                await precheck.balance(parsedTransaction, 'sendRawTransaction');
+                await precheck.balance(parsedTransaction, account);
                 expectedError();
             } catch(e: any) {
                 expect(e).to.exist;
@@ -270,18 +259,10 @@ describe('Precheck', async function() {
         });
 
         it('should not pass for no account found', async function() {
-            mock.onGet(mirrorAccountsPath).reply(404, {
-                "_status": {
-                    "messages": [
-                        {
-                            "message": "Not found"
-                        }
-                    ]
-                }
-            });
+            const account = null;
 
             try {
-                await precheck.balance(parsedTransaction, 'sendRawTransaction');
+                await precheck.balance(parsedTransaction, account);
                 expectedError();
             } catch(e: any) {
                 expect(e).to.exist;
@@ -291,69 +272,63 @@ describe('Precheck', async function() {
         });
 
         it('should pass for 10 hbar', async function() {
-            mock.onGet(mirrorAccountsPath).reply(200, {
-                account: accountId
-            });
-            
-            sdkInstance.getAccountBalanceInTinyBar.returns(Hbar.from(10, HbarUnit.Hbar).to(HbarUnit.Tinybar));
-            const result = await precheck.balance(parsedTransaction, 'sendRawTransaction');
+            const account = {
+                account: accountId,
+                balance: {
+                    balance: Hbar.from(10, HbarUnit.Hbar).to(HbarUnit.Tinybar)
+                }
+            };
+
+            const result = await precheck.balance(parsedTransaction, account);
             expect(result).to.not.exist;
         });
 
         it('should pass for 100 hbar', async function() {
-            mock.onGet(mirrorAccountsPath).reply(200, {
-                account: accountId
-            });
-            
-            sdkInstance.getAccountBalanceInTinyBar.returns(Hbar.from(100, HbarUnit.Hbar).to(HbarUnit.Tinybar));
-            const result = await precheck.balance(parsedTransaction, 'sendRawTransaction');
+            const account = {
+                account: accountId,
+                balance: {
+                    balance: Hbar.from(100, HbarUnit.Hbar).to(HbarUnit.Tinybar)
+                }
+            };
+
+            const result = await precheck.balance(parsedTransaction, account);
             expect(result).to.not.exist;
         });
 
         it('should pass for 10000 hbar', async function() {
-            mock.onGet(mirrorAccountsPath).reply(200, {
-                account: accountId
-            });
+            const account = {
+                account: accountId,
+                balance: {
+                    balance: Hbar.from(10_000, HbarUnit.Hbar).to(HbarUnit.Tinybar)
+                }
+            };
             
-            sdkInstance.getAccountBalanceInTinyBar.returns(Hbar.from(10_000, HbarUnit.Hbar).to(HbarUnit.Tinybar));
-            const result = await precheck.balance(parsedTransaction, 'sendRawTransaction');
+            const result = await precheck.balance(parsedTransaction, account);
             expect(result).to.not.exist;
         });
 
         it('should pass for 100000 hbar', async function() {
-            mock.onGet(mirrorAccountsPath).reply(200, {
-                account: accountId
-            });
+            const account = {
+                account: accountId,
+                balance: {
+                    balance: Hbar.from(100_000, HbarUnit.Hbar).to(HbarUnit.Tinybar)
+                }
+            };
             
-            sdkInstance.getAccountBalanceInTinyBar.returns(Hbar.from(100_000, HbarUnit.Hbar).to(HbarUnit.Tinybar));
-            const result = await precheck.balance(parsedTransaction, 'sendRawTransaction');
+            const result = await precheck.balance(parsedTransaction, account);
             expect(result).to.not.exist;
         });
 
         it('should pass for 50_000_000_000 hbar', async function() {
-            mock.onGet(mirrorAccountsPath).reply(200, {
-                account: accountId
-            });
+            const account = {
+                account: accountId,
+                balance: {
+                    balance: Hbar.from(50_000_000_000, HbarUnit.Hbar).to(HbarUnit.Tinybar)
+                }
+            };
             
-            sdkInstance.getAccountBalanceInTinyBar.returns(Hbar.from(50_000_000_000, HbarUnit.Hbar).to(HbarUnit.Tinybar));
-            const result = await precheck.balance(parsedTransaction, 'sendRawTransaction');
+            const result = await precheck.balance(parsedTransaction, account);
             expect(result).to.not.exist;
-        });
-
-        it('should preserve JsonRpcError if thrown', async function() {
-            mock.onGet(mirrorAccountsPath).reply(200, {
-                account: accountId
-            });
-
-            sdkInstance.getAccountBalanceInTinyBar.throws(predefined.HBAR_RATE_LIMIT_EXCEEDED);
-            try {
-                await precheck.balance(parsedTransaction, 'sendRawTransaction');
-                expectedError();
-            } catch(e: any) {
-                expect(e).to.exist;
-                expect(e.code).to.eq(predefined.HBAR_RATE_LIMIT_EXCEEDED.code);
-                expect(e.message).to.eq(predefined.HBAR_RATE_LIMIT_EXCEEDED.message);
-            }
         });
     });
 

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -237,7 +237,6 @@ describe('Precheck', async function() {
         // sending 2 hbars
         const transaction = '0x02f876820128078459682f0086018a4c7747008252089443cb701defe8fc6ed04d7bddf949618e3c575fe1881bc16d674ec8000080c001a0b8c604e08c15a7acc8c898a1bbcc41befcd0d120b64041d1086381c7fc2a5339a062eabec286592a7283c90ce90d97f9f8cf9f6c0cef4998022660e7573c046a46';
         const parsedTransaction = ethers.utils.parseTransaction(transaction);
-        const mirrorAccountsPath = `accounts/0xF8A44f9a4E4c452D25F5aE0F5d7970Ac9522a3C8${limitOrderPostFix}`;
         const accountId = '0.1.2';
 
         it('should not pass for 1 hbar', async function() {


### PR DESCRIPTION
**Description**:
This PR reduces `eth_sendRawTransaction` latency by reducing the number of requests and simplifying precheck.
Now we make 1 less request to the mirror node and 1 less request to consensus node. This reduces both hbar cost and latency. Performance test was done and metrics we collected by prometheus, by average transactions now take 10% less.

Also remove the FileAppendTransaction getReceipt, as transaction in hedera are executed in the order they are received, so we know that the next one will be executed after this one, no need to wait.

Also remove the getReceipt for file
**Related issue(s)**:

Fixes #1443 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
