### PR TITLE
Changes way of sending raw transaction instead of relay.call with rel…

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -46,7 +46,6 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
     const { servicesNode, mirrorNode, relay, logger } = global;
 
     // cached entities
-    let tokenId;
     let contractId;
     let contractExecuteTimestamp;
     let mirrorContract;
@@ -76,12 +75,6 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             const params = new ContractFunctionParameters().addUint256(1);
             contractExecuteTimestamp = (await accounts[0].client
                 .executeContractCall(contractId, 'createChild', params, 75000, requestId)).contractExecuteTimestamp;
-            tokenId = await servicesNode.createToken(1000, requestId);
-            logger.info('Associate and transfer tokens');
-            await accounts[0].client.associateToken(tokenId, requestId);
-            await accounts[1].client.associateToken(tokenId, requestId);
-            await servicesNode.transferToken(tokenId, accounts[0].accountId, 10, requestId);
-            await servicesNode.transferToken(tokenId, accounts[1].accountId, 10, requestId);
 
             // allow mirror node a 2 full record stream write windows (2 sec) and a buffer to persist setup details
             await new Promise(r => setTimeout(r, 5000));

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -34,7 +34,6 @@ import { predefined } from '../../../relay/src/lib/errors/JsonRpcError';
 import { EthImpl } from '../../../../packages/relay/src/lib/eth';
 import Constants from '../../../relay/src/lib/constants';
 import RelayCalls from '../../tests/helpers/constants';
-import { sign } from 'crypto';
 const Address = RelayCalls;
 
 describe('@api-batch-1 RPC Server Acceptance Tests', function () {
@@ -43,7 +42,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
     const accounts: AliasAccount[] = [];
 
     // @ts-ignore
-    const { servicesNode, mirrorNode, relay, logger } = global;
+    const { servicesNode, mirrorNode, relay } = global;
 
     // cached entities
     let contractId;

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -757,8 +757,9 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
                 const latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
                 const errorType = predefined.REQUEST_BEYOND_HEAD_BLOCK(latestBlock.number + blocksAhead, latestBlock.number);
                 const newestBlockNumberHex = ethers.utils.hexValue(latestBlock.number + blocksAhead);
+                const args = [RelayCalls.ETH_ENDPOINTS.ETH_FEE_HISTORY, ['0x1', newestBlockNumberHex, null], requestId];
 
-                await expect(relay.call(RelayCalls.ETH_ENDPOINTS.ETH_FEE_HISTORY, ['0x1', newestBlockNumberHex, null], requestId)).to.be.rejectedWith(errorType);
+                await Assertions.assertRejection(errorType, relay.call, args, true);
             });
 
             it('should call eth_feeHistory with zero block count', async function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -70,7 +70,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     let blockNumberAtStartOfTests = 0;
     let mirrorAccount0AtStartOfTests;
 
-    const signAndSendTransaction = async (transaction, accounts, requestId) => {
+    const signSendAndConfirmTransaction = async (transaction, accounts, requestId) => {
         const signedTx = await accounts.wallet.signTransaction(transaction);
         const txHash = await relay.sendRawTransaction(signedTx);
         await mirrorNode.get(`/contracts/results/${txHash}`, requestId);

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -327,11 +327,11 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
                 gasPrice: gasPrice,
             };
 
-            await signAndSendTransaction(transaction, accounts[3], requestId);
+            await signSendAndConfirmTransaction(transaction, accounts[3], requestId);
             
             const blockNumber = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_BLOCK_NUMBER, [], requestId);
 
-            await signAndSendTransaction({ ...transaction, nonce: acc3Nonce + 1 }, accounts[3], requestId);
+            await signSendAndConfirmTransaction({ ...transaction, nonce: acc3Nonce + 1 }, accounts[3], requestId);
 
             const endBalance = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, ['0x' + accounts[0].address, 'latest'], requestId);
 

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -322,7 +322,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             const signedTx1 = await accounts[3].wallet.signTransaction(transaction);
             const txHash1 = await relay.sendRawTransaction(signedTx1);
             await mirrorNode.get(`/contracts/results/${txHash1}`, requestId);
-            const tx1 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH, [txHash1]);
+            await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH, [txHash1]);
             await new Promise(r => setTimeout(r, 2000));
 
             const blockNumber = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_BLOCK_NUMBER, [], requestId);
@@ -330,7 +330,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             const signedTx2 = await accounts[3].wallet.signTransaction({ ...transaction, nonce: acc3Nonce + 1 });
             const txHash2 = await relay.sendRawTransaction(signedTx2);
             await mirrorNode.get(`/contracts/results/${txHash2}`, requestId);
-            const tx2 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH, [txHash2]);
+            await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH, [txHash2]);
             await new Promise(r => setTimeout(r, 2000));
 
             const endBalance = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, ['0x' + accounts[0].address, 'latest'], requestId);
@@ -695,7 +695,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             };
 
             const signedTx1 = await accounts[1].wallet.signTransaction(transaction1);
-            const transactionHash1 = await relay.sendRawTransaction(signedTx1, requestId);
+            await relay.sendRawTransaction(signedTx1, requestId);
             await new Promise(r => setTimeout(r, 2000));
 
             //Get previous state change with specific block number

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -320,7 +320,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             };
 
             const signedTx1 = await accounts[3].wallet.signTransaction(transaction);
-            const txHash1 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx1]);
+            const txHash1 = await relay.sendRawTransaction(signedTx1);
             await mirrorNode.get(`/contracts/results/${txHash1}`, requestId);
             const tx1 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH, [txHash1]);
             await new Promise(r => setTimeout(r, 2000));
@@ -328,7 +328,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             const blockNumber = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_BLOCK_NUMBER, [], requestId);
 
             const signedTx2 = await accounts[3].wallet.signTransaction({ ...transaction, nonce: acc3Nonce + 1 });
-            const txHash2 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx2]);
+            const txHash2 = await relay.sendRawTransaction(signedTx2);
             await mirrorNode.get(`/contracts/results/${txHash2}`, requestId);
             const tx2 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH, [txHash2]);
             await new Promise(r => setTimeout(r, 2000));
@@ -591,7 +591,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             };
 
             const signedTx = await accounts[1].wallet.signTransaction(transaction);
-            await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], requestId);
+            await relay.sendRawTransaction(signedTx, requestId);
 
             // wait for the transaction to propogate to mirror node
             await new Promise(r => setTimeout(r, 4000));
@@ -620,7 +620,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             };
 
             const signedTx = await accounts[1].wallet.signTransaction(transaction);
-            const transactionHash = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], requestId);
+            const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
             const txReceipt = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_RECEIPT, [transactionHash], requestId);
             const blockNumber = txReceipt.blockNumber;
 
@@ -657,7 +657,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             };
 
             const signedTx = await accounts[1].wallet.signTransaction(transaction);
-            await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], requestId);
+            await relay.sendRawTransaction(signedTx, requestId);
 
             // wait for the transaction to propogate to mirror node
             await new Promise(r => setTimeout(r, 4000));
@@ -684,7 +684,8 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             };
 
             const signedTx = await accounts[1].wallet.signTransaction(transaction);
-            const transactionHash = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], requestId);
+            const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
+            
             const blockNumber = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_RECEIPT, [transactionHash], requestId).blockNumber;
 
             const transaction1 = {
@@ -694,7 +695,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             };
 
             const signedTx1 = await accounts[1].wallet.signTransaction(transaction1);
-            const transactionHash1 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx1], requestId);
+            const transactionHash1 = await relay.sendRawTransaction(signedTx1, requestId);
             await new Promise(r => setTimeout(r, 2000));
 
             //Get previous state change with specific block number

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -439,7 +439,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: PAYABLE_METHOD_CALL_DATA
             };
             const signedTx = await accounts[0].wallet.signTransaction(transaction);
-            const transactionHash = await relay.call(RelayCall.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], requestId);
+            const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
 
             // Wait until receipt is available in mirror node
             await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
@@ -494,7 +494,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                         data: payableMethodsData[i].data
                     };
                     const signedTx = await accounts[0].wallet.signTransaction(transaction);
-                    const hash = await relay.call(RelayCall.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], requestId);
+                    const hash = await relay.sendRawTransaction(signedTx, requestId);
                     hashes.push(hash);
 
                     // Wait until receipt is available in mirror node

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -36,6 +36,7 @@ import Constants from '../../../../packages/relay/src/lib/constants';
 import RelayCall from '../../tests/helpers/constants';
 import Helper from '../../tests/helpers/constants';
 import Address from '../../tests/helpers/constants';
+import Assertions from '../helpers/assertions';
 
 describe('@api-batch-3 RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -191,8 +192,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
             const errorType = predefined.INVALID_PARAMETER(1, `${errorMessagePrefixedStr}, value: newest`);
+            const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'newest'], requestId];
 
-            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'newest'], requestId)).to.be.rejectedWith(errorType);
+            await Assertions.assertRejection(errorType, relay.call, args, false);
         });
 
         it('should fail to execute "eth_call" with wrong block number', async function () {
@@ -202,8 +204,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
             const errorType = predefined.INVALID_PARAMETER(1, `${errorMessagePrefixedStr}, value: 123`);
+            const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, '123'], requestId];
 
-            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, '123'], requestId)).to.be.rejectedWith(errorType);
+            await Assertions.assertRejection(errorType, relay.call, args, false);
         });
 
         it('should fail to execute "eth_call" with wrong block hash object', async function () {
@@ -213,8 +216,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
             const errorType = predefined.INVALID_PARAMETER(`'blockHash' for BlockHashObject`, 'Expected 0x prefixed string representing the hash (32 bytes) of a block, value: 0x123');
-
-            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId)).to.be.rejectedWith(errorType);
+            const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId];
+            
+            await Assertions.assertRejection(errorType, relay.call, args, false);
         });
 
         it('should fail to execute "eth_call" with wrong block number object', async function () {
@@ -224,8 +228,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
             const errorType = predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, `${errorMessagePrefixedStr}, value: 123`);
-
-            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId)).to.be.rejectedWith(errorType);
+            const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId];
+            
+            await Assertions.assertRejection(errorType, relay.call, args, false);
         });
 
         describe('Caller contract', () => {
@@ -377,8 +382,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                                 value: '0x3e80000000'
                             };
                             const errorType = predefined.CONTRACT_REVERT();
+                            const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId];
 
-                            await expect(relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId)).to.be.rejectedWith(errorType);
+                            await Assertions.assertRejection(errorType, relay.call, args, true);
                         });
 
                         it("012 should work for wrong 'from' field", async function () {

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -228,11 +228,20 @@ export default class Assertions {
         for(let i = 0; i < args.length; i++) {
             expect(decodedLog1.args[i]).to.be.eq(args[i]);
         }
-    }
+    };
 
     static expectAnonymousLog = (log, contract, data) => {
         expect(log.data).to.equal(data);
         expect(log.address.toLowerCase()).to.equal(contract.address.toLowerCase());
-    }
+    };
+
+    static assertRejection = async (error: JsonRpcError, method: () => Promise<any>, args: any[], checkMessage: boolean): Promise<any> => {
+        return await expect(method.apply(relay, args)).to.eventually.be.rejected.and.satisfy((err) => {
+            if(!checkMessage) {
+                return [error.code, error.name].every(substring => err.body.includes(substring));
+            }
+            return [error.code, error.name, error.message].every(substring => err.body.includes(substring));
+        });
+    };
 
 }


### PR DESCRIPTION
**Description**:
This PR unifies the way raw transactions are sent. Instead of using relay.call, we use directly relay.sendRawTransaction

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/1402
