### PR TITLE
Improve handling of boolean cache retrieval and metric labels (#1469)

### DIFF
--- a/packages/relay/src/lib/clients/clientCache.ts
+++ b/packages/relay/src/lib/clients/clientCache.ts
@@ -35,7 +35,7 @@ export class ClientCache {
         max: Number.parseInt(process.env.CACHE_MAX ?? constants.CACHE_MAX.toString()),
         // Max time to live in ms, for items before they are considered stale.
         ttl: Number.parseInt(process.env.CACHE_TTL ?? constants.CACHE_TTL.ONE_HOUR.toString()),
-    }
+    };
 
     /**
      * The LRU cache used for caching items from requests.
@@ -57,6 +57,9 @@ export class ClientCache {
     private readonly register: Registry;
     private cacheKeyGauge: Gauge<string>;
 
+    private static getCacheLabel = 'get';
+    private static setCacheLabel = 'set';
+
     public constructor(logger: Logger, register: Registry) {
         this.cache = new LRU(this.options);
         this.logger = logger;
@@ -72,7 +75,7 @@ export class ClientCache {
         this.cacheKeyGauge = new Gauge({
             name: metricCounterName,
             help: 'Relay cache gauge',
-            labelNames: ['key', 'method'],
+            labelNames: ['key', 'type', 'method'],
             registers: [register],
             async collect() {
                 cacheSizeCollect();
@@ -80,11 +83,10 @@ export class ClientCache {
         });
     }
 
-    public get(key: string, callingMethod?: string, requestIdPrefix?: string): any {
+    public get(key: string, callingMethod: string, requestIdPrefix?: string): any {
         const value = this.cache.get(key);
-        if (value) {
-            this.cacheKeyGauge.labels(key, callingMethod || '').inc(1);
-
+        if (value !== undefined) {
+            this.cacheKeyGauge.labels('', ClientCache.getCacheLabel, callingMethod || '').inc(1);
             this.logger.trace(`${requestIdPrefix} returning cached value ${key}:${JSON.stringify(value)} on ${callingMethod} call`);
             return value;
         }
@@ -92,10 +94,11 @@ export class ClientCache {
         return null;
     }
 
-    public set(key: string, value: any, ttl?: number, requestIdPrefix?: string): void {
+    public set(key: string, value: any, callingMethod: string, ttl?: number, requestIdPrefix?: string): void {
         const resolvedTtl = ttl ?? this.options.ttl;    
         this.logger.trace(`${requestIdPrefix} caching ${key}:${JSON.stringify(value)} for ${resolvedTtl} ms`);
         this.cache.set(key, value, { ttl: resolvedTtl });
+        this.cacheKeyGauge.labels('', ClientCache.setCacheLabel, callingMethod || '').inc(1);
     }
 
     public purgeStale(): void {

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -459,7 +459,7 @@ export class MirrorNodeClient {
           MirrorNodeClient.GET_BLOCK_ENDPOINT,
           requestId);
 
-        this.cache.set(cachedLabel, block, undefined, requestId);
+        this.cache.set(cachedLabel, block, MirrorNodeClient.GET_BLOCK_ENDPOINT, undefined, requestId);
         return block;
     }
 
@@ -490,7 +490,7 @@ export class MirrorNodeClient {
         const contract = await this.getContractId(contractIdOrAddress, requestId);
         const valid = contract != null;
 
-        this.cache.set(cachedLabel, valid, constants.CACHE_TTL.ONE_DAY, requestId);
+        this.cache.set(cachedLabel, valid, MirrorNodeClient.GET_CONTRACT_ENDPOINT, constants.CACHE_TTL.ONE_DAY, requestId);
         return valid;
     }
 
@@ -507,7 +507,7 @@ export class MirrorNodeClient {
 
         if (contract != null) {
             const id = contract.contract_id;
-            this.cache.set(cachedLabel, id, constants.CACHE_TTL.ONE_DAY, requestId);
+            this.cache.set(cachedLabel, id, MirrorNodeClient.GET_CONTRACT_ENDPOINT, constants.CACHE_TTL.ONE_DAY, requestId);
             return id;
         }
 
@@ -527,7 +527,7 @@ export class MirrorNodeClient {
             requestId);
 
         if(response != undefined && response.transaction_index != undefined && response.block_number != undefined && response.result === "SUCCESS") {
-            this.cache.set(cacheKey, response, constants.CACHE_TTL.ONE_HOUR, requestId);
+            this.cache.set(cacheKey, response, MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT, constants.CACHE_TTL.ONE_HOUR, requestId);
         }
 
         return response;
@@ -652,7 +652,7 @@ export class MirrorNodeClient {
         const blocks = await this.getBlocks(undefined, undefined, this.getLimitOrderQueryParam(1, MirrorNodeClient.ORDER.ASC), requestId);
         if (blocks && blocks.blocks.length > 0) {
             const block = blocks.blocks[0];
-            this.cache.set(cachedLabel, block, constants.CACHE_TTL.ONE_DAY, requestId);       
+            this.cache.set(cachedLabel, block, MirrorNodeClient.GET_BLOCKS_ENDPOINT, constants.CACHE_TTL.ONE_DAY, requestId);       
             return block;     
         }
 
@@ -838,17 +838,19 @@ export class MirrorNodeClient {
     /**
      * Get the contract results for a given address
      * @param entityIdentifier the address of the contract
-     * @param requestId the request id
      * @param searchableTypes the types to search for
+     * @param callerName calling method name
+     * @param requestId the request id
      * @returns entity object or null if not found
      */
     public async resolveEntityType(
       entityIdentifier: string,
       searchableTypes: any[] = [constants.TYPE_CONTRACT, constants.TYPE_ACCOUNT, constants.TYPE_TOKEN],
+      callerName: string,
       requestId?: string
     ) {
         const cachedLabel = `${constants.CACHE_KEY.RESOLVE_ENTITY_TYPE}_${entityIdentifier}`;
-        const cachedResponse: { type: string, entity: any } | undefined = this.cache.get(cachedLabel);
+        const cachedResponse: { type: string, entity: any } | undefined = this.cache.get(cachedLabel, callerName, requestId);
         if (cachedResponse) {
             return cachedResponse;
         }
@@ -865,7 +867,7 @@ export class MirrorNodeClient {
                     type: constants.TYPE_CONTRACT,
                     entity: contract
                 };
-                this.cache.set(cachedLabel, response, undefined, requestId);
+                this.cache.set(cachedLabel, response, callerName, undefined, requestId);
                 return response;
             }
         }
@@ -906,7 +908,7 @@ export class MirrorNodeClient {
             type,
             entity: data.value
         };
-        this.cache.set(cachedLabel, response, undefined, requestId);
+        this.cache.set(cachedLabel, response, callerName, undefined, requestId);
         return response;
     }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -163,7 +163,7 @@ export class SDKClient {
     }
 
     async getTinyBarGasFee(callerName: string, requestId?: string): Promise<number> {
-        const cachedResponse: number | undefined = this.cache.get(constants.CACHE_KEY.GET_TINYBAR_GAS_FEE);
+        const cachedResponse: number | undefined = this.cache.get(constants.CACHE_KEY.GET_TINYBAR_GAS_FEE, callerName);
         if (cachedResponse) {
             return cachedResponse;
         }
@@ -179,7 +179,7 @@ export class SDKClient {
                 const exchangeRates = await this.getExchangeRate(callerName, requestId);
                 const tinyBars = this.convertGasPriceToTinyBars(schedule.fees[0].servicedata, exchangeRates);
 
-                this.cache.set(constants.CACHE_KEY.GET_TINYBAR_GAS_FEE, tinyBars, undefined, requestId);
+                this.cache.set(constants.CACHE_KEY.GET_TINYBAR_GAS_FEE, tinyBars, callerName, undefined, requestId);
                 return tinyBars;
             }
         }

--- a/packages/relay/tests/lib/clients/clientCache.spec.ts
+++ b/packages/relay/tests/lib/clients/clientCache.spec.ts
@@ -1,0 +1,138 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { expect } from 'chai';
+import { Registry } from 'prom-client';
+import pino from 'pino';
+import { ClientCache } from '../../../src/lib/clients';
+import constants from '../../../src/lib/constants';
+
+
+const logger = pino();
+const registry = new Registry();
+let clientCache: ClientCache;
+
+const callingMethod = 'clientCacheTest';
+
+describe('Simple ClientCache', async function () {
+    this.timeout(10000);
+
+    this.beforeAll(() => {
+      clientCache = new ClientCache(logger.child({ name: `cache` }), registry);
+    });    
+    
+    this.beforeEach(() => {
+      clientCache.clear();
+    });
+    
+    describe('verify simple cache', async function () {
+      it('get on empty cache return null', async function () {
+        const cacheValue = clientCache.get('test', callingMethod);
+        expect(cacheValue).to.be.null;
+      }); 
+  
+      it('get on valid string cache returns non null', async function () {
+        const key = 'key';
+        const expectedValue = 'value';
+        clientCache.set(key, expectedValue, callingMethod);
+        const cacheValue = clientCache.get(key, callingMethod);
+        expect(cacheValue).to.be.equal(expectedValue);
+      });
+
+      it('get on valid int cache returns non null', async function () {
+        const key = 'key';
+        const expectedValue = 1;
+        clientCache.set(key, expectedValue, callingMethod);
+        const cacheValue = clientCache.get(key, callingMethod);
+        expect(cacheValue).to.be.equal(expectedValue);
+      });
+  
+      it('get on valid false boolean cache returns non null', async function () {
+        const key = 'key';
+        const expectedValue = false;
+        clientCache.set(key, expectedValue, callingMethod);
+        const cacheValue = clientCache.get(key, callingMethod);
+        expect(cacheValue).to.be.equal(expectedValue);
+      });
+
+      it('get on valid true boolean cache returns non null', async function () {
+        const key = 'key';
+        const expectedValue = true;
+        clientCache.set(key, expectedValue, callingMethod);
+        const cacheValue = clientCache.get(key, callingMethod);
+        expect(cacheValue).to.be.equal(expectedValue);
+      });
+  
+      it('get on valid object cache returns non null', async function () {
+        const key = 'key';
+        const expectedValue = { key: 'value' };
+        clientCache.set(key, expectedValue, callingMethod);
+        const cacheValue = clientCache.get(key, callingMethod);
+        expect(cacheValue).to.be.equal(expectedValue);
+      });
+    });
+
+    describe('verify cache management', async function () {
+      this.beforeEach(() => {
+        process.env.CACHE_MAX = constants.CACHE_MAX.toString();
+      });
+
+      it('verify cache size', async function () {
+        const cacheMaxSize = 2;
+        process.env.CACHE_MAX = `${cacheMaxSize}`;
+        const customClientCache = new ClientCache(logger.child({ name: `cache` }), registry);
+        const keyValuePairs = {
+          key1: 'value1',
+          key2: 'value2',
+          key3: 'value3',
+        };
+
+        Object.entries(keyValuePairs).forEach(([key, value]) => {
+          customClientCache.set(key, value, callingMethod);
+        });
+
+        // expect cache to have capped at max size
+        expect(customClientCache.get('key1', callingMethod)).to.be.null; // key1 should have been evicted
+        expect(customClientCache.get('key2', callingMethod)).to.be.equal(keyValuePairs.key2);
+        expect(customClientCache.get('key3', callingMethod)).to.be.equal(keyValuePairs.key3);
+      });
+
+      it('verify cache LRU nature', async function () {
+        const customClientCache = new ClientCache(logger.child({ name: `cache` }), registry);
+        const key = 'key';
+        let valueCount = 0; // keep track of values sets
+        customClientCache.set(key, ++valueCount, callingMethod);
+        customClientCache.set(key, ++valueCount, callingMethod);
+        customClientCache.set(key, ++valueCount, callingMethod);
+        const cacheValue = customClientCache.get(key, callingMethod);
+        // expect cache to have latest value for key
+        expect(cacheValue).to.be.equal(valueCount);
+      });
+
+      it('verify cache ttl nature', async function () {
+        const customClientCache = new ClientCache(logger.child({ name: `cache` }), registry);
+        const key = 'key';
+        customClientCache.set(key, 'value', callingMethod, 100); // set ttl to 1 ms
+        await new Promise(r => setTimeout(r, 500)); // wait for ttl to expire
+        const cacheValue = customClientCache.get(key, callingMethod);
+        expect(cacheValue).to.be.null;
+      });
+    });
+});


### PR DESCRIPTION


---------

**Description**:
Cheery Pick #1469 
Fix boolean `false` issue on cache
- Expand metrics to manage set scenarios also
- Ensure all metrics have calling method
- Update cacheClient to manage where the cached value is false and not treat it as undefined

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
