### PR TITLE
Adding axios-cached-dns-resolve to axios mirror node client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6095,6 +6095,144 @@
                 "proxy-from-env": "^1.1.0"
             }
         },
+        "node_modules/axios-cached-dns-resolve": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/axios-cached-dns-resolve/-/axios-cached-dns-resolve-3.3.0.tgz",
+            "integrity": "sha512-kIRXghLPhay85bB3DNBfCJ8l9DmkFlM/QTa+pV+nILakgbZehbB4w+baoapOndFLvjft3yxWKy2IuG7xASaX4Q==",
+            "dependencies": {
+                "json-stringify-safe": "^5.0.1",
+                "lru-cache": "^7.18.3",
+                "pino": "^8.14.1",
+                "pino-pretty": "^10.0.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/dateformat": {
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+            "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/on-exit-leak-free": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+            "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/pino": {
+            "version": "8.14.1",
+            "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.1.tgz",
+            "integrity": "sha512-8LYNv7BKWXSfS+k6oEc6occy5La+q2sPwU3q2ljTX5AZk7v+5kND2o5W794FyRaqha6DJajmkNRsWtPpFyMUdw==",
+            "dependencies": {
+                "atomic-sleep": "^1.0.0",
+                "fast-redact": "^3.1.1",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "v1.0.0",
+                "pino-std-serializers": "^6.0.0",
+                "process-warning": "^2.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^3.1.0",
+                "thread-stream": "^2.0.0"
+            },
+            "bin": {
+                "pino": "bin.js"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/pino-abstract-transport": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+            "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+            "dependencies": {
+                "readable-stream": "^4.0.0",
+                "split2": "^4.0.0"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/pino-pretty": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.0.1.tgz",
+            "integrity": "sha512-yrn00+jNpkvZX/NrPVCPIVHAfTDy3ahF0PND9tKqZk4j9s+loK8dpzrJj4dGb7i+WLuR50ussuTAiWoMWU+qeA==",
+            "dependencies": {
+                "colorette": "^2.0.7",
+                "dateformat": "^4.6.3",
+                "fast-copy": "^3.0.0",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^4.0.1",
+                "joycon": "^3.1.1",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.0.0",
+                "pump": "^3.0.0",
+                "readable-stream": "^4.0.0",
+                "secure-json-parse": "^2.4.0",
+                "sonic-boom": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+            },
+            "bin": {
+                "pino-pretty": "bin.js"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/pino-std-serializers": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+            "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/process-warning": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+            "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/readable-stream": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+            "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+            "dependencies": {
+                "abort-controller": "^3.0.0",
+                "buffer": "^6.0.3",
+                "events": "^3.3.0",
+                "process": "^0.11.10",
+                "string_decoder": "^1.3.0"
+            },
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/real-require": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+            "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+            "engines": {
+                "node": ">= 12.13.0"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/sonic-boom": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+            "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+            "dependencies": {
+                "atomic-sleep": "^1.0.0"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "engines": {
+                "node": ">= 10.x"
+            }
+        },
+        "node_modules/axios-cached-dns-resolve/node_modules/thread-stream": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+            "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+            "dependencies": {
+                "real-require": "^0.2.0"
+            }
+        },
         "node_modules/axios-mock-adapter": {
             "version": "1.21.5",
             "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.5.tgz",
@@ -20005,12 +20143,13 @@
         },
         "packages/relay": {
             "name": "@hashgraph/json-rpc-relay",
-            "version": "0.27.0-SNAPSHOT",
+            "version": "0.28.0-SNAPSHOT",
             "dependencies": {
                 "@ethersproject/asm": "^5.7.0",
                 "@hashgraph/sdk": "^2.29.0",
                 "@keyvhq/core": "^1.6.9",
                 "axios": "^1.4.0",
+                "axios-cached-dns-resolve": "^3.3.0",
                 "axios-retry": "^3.5.1",
                 "buffer": "^6.0.3",
                 "dotenv": "^16.0.0",
@@ -20037,7 +20176,7 @@
         },
         "packages/server": {
             "name": "@hashgraph/json-rpc-server",
-            "version": "0.27.0-SNAPSHOT",
+            "version": "0.28.0-SNAPSHOT",
             "dependencies": {
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "axios": "^1.4.0",
@@ -20075,7 +20214,7 @@
         },
         "packages/ws-server": {
             "name": "@hashgraph/json-rpc-ws-server",
-            "version": "0.27.0-SNAPSHOT",
+            "version": "0.28.0-SNAPSHOT",
             "dependencies": {
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "@hashgraph/json-rpc-server": "file:../server",
@@ -21718,6 +21857,7 @@
                 "@types/mocha": "^9.1.0",
                 "@types/node": "^17.0.14",
                 "axios": "^1.4.0",
+                "axios-cached-dns-resolve": "*",
                 "axios-retry": "^3.5.1",
                 "buffer": "^6.0.3",
                 "chai": "^4.3.6",
@@ -24632,6 +24772,125 @@
                 "follow-redirects": "^1.15.0",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
+            }
+        },
+        "axios-cached-dns-resolve": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/axios-cached-dns-resolve/-/axios-cached-dns-resolve-3.3.0.tgz",
+            "integrity": "sha512-kIRXghLPhay85bB3DNBfCJ8l9DmkFlM/QTa+pV+nILakgbZehbB4w+baoapOndFLvjft3yxWKy2IuG7xASaX4Q==",
+            "requires": {
+                "json-stringify-safe": "^5.0.1",
+                "lru-cache": "^7.18.3",
+                "pino": "^8.14.1",
+                "pino-pretty": "^10.0.1"
+            },
+            "dependencies": {
+                "dateformat": {
+                    "version": "4.6.3",
+                    "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+                    "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+                },
+                "on-exit-leak-free": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
+                    "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
+                },
+                "pino": {
+                    "version": "8.14.1",
+                    "resolved": "https://registry.npmjs.org/pino/-/pino-8.14.1.tgz",
+                    "integrity": "sha512-8LYNv7BKWXSfS+k6oEc6occy5La+q2sPwU3q2ljTX5AZk7v+5kND2o5W794FyRaqha6DJajmkNRsWtPpFyMUdw==",
+                    "requires": {
+                        "atomic-sleep": "^1.0.0",
+                        "fast-redact": "^3.1.1",
+                        "on-exit-leak-free": "^2.1.0",
+                        "pino-abstract-transport": "v1.0.0",
+                        "pino-std-serializers": "^6.0.0",
+                        "process-warning": "^2.0.0",
+                        "quick-format-unescaped": "^4.0.3",
+                        "real-require": "^0.2.0",
+                        "safe-stable-stringify": "^2.3.1",
+                        "sonic-boom": "^3.1.0",
+                        "thread-stream": "^2.0.0"
+                    }
+                },
+                "pino-abstract-transport": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz",
+                    "integrity": "sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==",
+                    "requires": {
+                        "readable-stream": "^4.0.0",
+                        "split2": "^4.0.0"
+                    }
+                },
+                "pino-pretty": {
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.0.1.tgz",
+                    "integrity": "sha512-yrn00+jNpkvZX/NrPVCPIVHAfTDy3ahF0PND9tKqZk4j9s+loK8dpzrJj4dGb7i+WLuR50ussuTAiWoMWU+qeA==",
+                    "requires": {
+                        "colorette": "^2.0.7",
+                        "dateformat": "^4.6.3",
+                        "fast-copy": "^3.0.0",
+                        "fast-safe-stringify": "^2.1.1",
+                        "help-me": "^4.0.1",
+                        "joycon": "^3.1.1",
+                        "minimist": "^1.2.6",
+                        "on-exit-leak-free": "^2.1.0",
+                        "pino-abstract-transport": "^1.0.0",
+                        "pump": "^3.0.0",
+                        "readable-stream": "^4.0.0",
+                        "secure-json-parse": "^2.4.0",
+                        "sonic-boom": "^3.0.0",
+                        "strip-json-comments": "^3.1.1"
+                    }
+                },
+                "pino-std-serializers": {
+                    "version": "6.2.2",
+                    "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+                    "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+                },
+                "process-warning": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-2.2.0.tgz",
+                    "integrity": "sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg=="
+                },
+                "readable-stream": {
+                    "version": "4.4.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+                    "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+                    "requires": {
+                        "abort-controller": "^3.0.0",
+                        "buffer": "^6.0.3",
+                        "events": "^3.3.0",
+                        "process": "^0.11.10",
+                        "string_decoder": "^1.3.0"
+                    }
+                },
+                "real-require": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+                    "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
+                },
+                "sonic-boom": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.3.0.tgz",
+                    "integrity": "sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==",
+                    "requires": {
+                        "atomic-sleep": "^1.0.0"
+                    }
+                },
+                "split2": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+                    "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+                },
+                "thread-stream": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.3.0.tgz",
+                    "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
+                    "requires": {
+                        "real-require": "^0.2.0"
+                    }
+                }
             }
         },
         "axios-mock-adapter": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -31,6 +31,7 @@
         "@hashgraph/sdk": "^2.29.0",
         "@keyvhq/core": "^1.6.9",
         "axios": "^1.4.0",
+        "axios-cached-dns-resolve": "^3.3.0",
         "axios-retry": "^3.5.1",
         "buffer": "^6.0.3",
         "dotenv": "^16.0.0",

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -30,6 +30,7 @@ import { SDKClientError } from '../errors/SDKClientError';
 import { ClientCache } from './clientCache';
 const http = require('http');
 const https = require('https');
+import { registerInterceptor } from 'axios-cached-dns-resolve';
 
 type REQUEST_METHODS = 'GET' | 'POST';
 
@@ -207,6 +208,8 @@ export class MirrorNodeClient {
             },
             shouldResetTimeout: true
         });
+
+        registerInterceptor(axiosClient);
 
         return axiosClient;
     }


### PR DESCRIPTION
**Description**:
Adding axios-cached-dns-resolve to axios mirror node client

**Related issue(s)**: #1323, #1139

Fixes #1507

**Notes for reviewer**:


```
const config = {
  disabled: process.env.AXIOS_DNS_DISABLE === 'true',
  dnsTtlMs: process.env.AXIOS_DNS_CACHE_TTL_MS || 5000, // when to refresh actively used dns entries (5 sec)
  cacheGraceExpireMultiplier: process.env.AXIOS_DNS_CACHE_EXPIRE_MULTIPLIER || 2, // maximum grace to use entry beyond TTL
  dnsIdleTtlMs: process.env.AXIOS_DNS_CACHE_IDLE_TTL_MS || 1000 * 60 * 60, // when to remove entry entirely if not being used (1 hour)
  backgroundScanMs: process.env.AXIOS_DNS_BACKGROUND_SCAN_MS || 2400, // how frequently to scan for expired TTL and refresh (2.4 sec)
  dnsCacheSize: process.env.AXIOS_DNS_CACHE_SIZE || 100, // maximum number of entries to keep in cache
  // pino logging options
  logging: {
    name: 'axios-cache-dns-resolve',
    // enabled: true,
    level: process.env.AXIOS_DNS_LOG_LEVEL || 'info', // default 'info' others trace, debug, info, warn, error, and fatal
    // timestamp: true,
    prettyPrint: process.env.NODE_ENV === 'DEBUG' || false,
    useLevelLabels: true,
  },
}
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
