### PR TITLE
Add Remix IDE in tools Readme.md

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -13,20 +13,23 @@
 | Support for dynamic dataSource templates                         | ✅     |
 | Block Handlers WITHOUT filters                                   | ✅     |
 | Can index anonymous events                                       | ✅     |
-| Block Handlers WITH filters                                      | ❌     | Requires Parity's [trace_filter](https://openethereum.github.io/JSONRPC-trace-module#trace_filter)                                                  |
-| Call Handlers                                                    | ❌     | Requires Parity's [trace_filter](https://openethereum.github.io/JSONRPC-trace-module#trace_filter)                                                  |
+| Block Handlers WITH filters                                      | ❌     | Requires ОpenЕthereum's [trace_filter](https://openethereum.github.io/JSONRPC-trace-module#trace_filter)                                            |
+| Call Handlers                                                    | ❌     | Requires ОpenЕthereum's [trace_filter](https://openethereum.github.io/JSONRPC-trace-module#trace_filter)                                            |
 | Capture HTS transfers through HTS precompile                     | ❌     | Depends on [4127](https://github.com/hashgraph/hedera-services/issues/4127)                                                                         |
 | Capture HTS token transfers through HAPI                         | ❌     | Depends on [4337](https://github.com/hashgraph/hedera-mirror-node/issues/4337), [4738](https://github.com/hashgraph/hedera-mirror-node/issues/4738) |
 
 ### Supported tools
 
-|                                                                      | web3js | Truffle | ethers | Hardhat |
-| -------------------------------------------------------------------- | ------ | ------- | ------ | ------- |
-| Transfer HBARS                                                       | ✅     | ✅      | ✅     | ✅      |
-| Contract Deployment                                                  | ✅     | ✅      | ✅     | ✅      |
-| Can use the contract instance after deploy without re-initialization | ✅     | ✅      | ✅     | ✅      |
-| Contract View Function Call                                          | ✅     | ✅      | ✅     | ✅      |
-| Contract Function Call                                               | ✅     | ✅      | ✅     | ✅      |
+|                                                                      | web3js | Truffle | ethers | Hardhat | Remix IDE |
+| -------------------------------------------------------------------- | ------ | ------- | ------ | ------- | --------- |
+| Transfer HBARS                                                       | ✅     | ✅      | ✅     | ✅      | ✅        |
+| Contract Deployment                                                  | ✅     | ✅      | ✅     | ✅      | ✅        |
+| Can use the contract instance after deploy without re-initialization | ✅     | ✅      | ✅     | ✅      | ✅        |
+| Contract View Function Call                                          | ✅     | ✅      | ✅     | ✅      | ✅        |
+| Contract Function Call                                               | ✅     | ✅      | ✅     | ✅      | ✅        |
+| Debug Operations\*                                                   | ❌     | ❌      | ❌     | ❌      | ❌        |
+
+\*1: Debug operation are not supported yet.
 
 Note:
 Development tools are usually making a lot of requests to certain endpoints, especially during contract deployment. Be aware about rate limiting, when deploying multiple large contracts.


### PR DESCRIPTION
**Description**:
After some extended testing, it turns out that the relay is supporting almost all scenarios when using Remix IDE.
The only ones that are not supported is debug operations and more specifically `debug_traceTransaction`.
Error thrown from Remix IDE:

`Returned error: {"jsonrpc":"2.0","error":"The method \"debug_traceTransaction\" does not exist / is not available.","id":3852726872457090}`

**Related issue(s)**:

Fixes #1492 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
