### PR TITLE
Bumping up hashgraph sdk version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19802,7 +19802,7 @@
             },
             "devDependencies": {
                 "@hashgraph/hedera-local": "^2.4.5",
-                "@hashgraph/sdk": "^2.29.0",
+                "@hashgraph/sdk": "^2.30.0",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
                 "@types/cors": "^2.8.12",
@@ -21492,7 +21492,7 @@
                 "@hashgraph/hedera-local": "^2.4.5",
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "@hashgraph/json-rpc-server": "file:../server",
-                "@hashgraph/sdk": "^2.29.0",
+                "@hashgraph/sdk": "^2.30.0",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
                 "@types/cors": "^2.8.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -317,6 +317,7 @@
             "version": "7.22.7",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
             "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+            "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
             },
@@ -2182,15 +2183,19 @@
             }
         },
         "node_modules/@hashgraph/cryptography": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.6.tgz",
-            "integrity": "sha512-3HmnT1Lek71l6nHxc4GOyT/hSx/LmgusyWfE7hQda2dnE5vL2umydDw5TK2wq8gqmD9S3uRSMhz/BO55wtzxRA==",
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.7.tgz",
+            "integrity": "sha512-DrwZxIw3AM01JINaINTBmFEJVn9lzTHHf343zYXzpu+MrUJbZzuGyzd5bW6DmGGvFqTF/xDo0S/XiO2StdhVgg==",
             "dependencies": {
+                "asn1js": "^3.0.5",
                 "bignumber.js": "^9.1.1",
                 "bn.js": "^5.1.1",
+                "buffer": "^6.0.3",
                 "crypto-js": "^4.1.1",
                 "elliptic": "^6.5.4",
                 "js-base64": "^3.7.4",
+                "node-forge": "^1.3.1",
+                "spark-md5": "^3.0.2",
                 "tweetnacl": "^1.0.3",
                 "utf8": "^3.0.0"
             },
@@ -2271,32 +2276,32 @@
             "link": true
         },
         "node_modules/@hashgraph/proto": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.12.0.tgz",
-            "integrity": "sha512-IIN6K3b2X8ih7V14IDH8rsVJ1DE9ud25FfKUpr+lDNnQdBfdZdG2AGlHRhc9iDAz4vCHoHc6F3Ao6yYKMceeTg==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.13.0.tgz",
+            "integrity": "sha512-Wan4TyiGExymUQOD+WVE/Q/RDjr+eBv5JBVO5+RGa2FDyASFhUWA/E1G0ZyiynXf2clqlewXIHyuNxpR42S80A==",
             "dependencies": {
                 "long": "^4.0.0",
-                "protobufjs": "^7.1.2",
-                "protobufjs-cli": "^1.0.2"
+                "protobufjs": "^7.1.2"
             },
             "engines": {
                 "node": ">=10.0.0"
             }
         },
         "node_modules/@hashgraph/sdk": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.29.0.tgz",
-            "integrity": "sha512-dMv2q7OCa2Xyi0ooGjo4JJRFxHKzKBvMd8G/n30j4jHx1JiSfI2ckPTAOwfCbYZ/o+EMDZzevyD5+Juf9iph+A==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.30.0.tgz",
+            "integrity": "sha512-wezW8W5JGA6dtaVGfHPgjYQp//QlKF3PtfkPUPQ22iVlgxzkXXkDEG+bKO9C+OCAvhGsC2sT0NR+xYhDYk5QGQ==",
             "dependencies": {
                 "@ethersproject/abi": "^5.7.0",
                 "@ethersproject/bignumber": "^5.7.0",
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/rlp": "^5.7.0",
                 "@grpc/grpc-js": "1.8.2",
-                "@hashgraph/cryptography": "1.4.6",
-                "@hashgraph/proto": "2.12.0",
+                "@hashgraph/cryptography": "1.4.7",
+                "@hashgraph/proto": "2.13.0",
                 "axios": "^1.3.1",
                 "bignumber.js": "^9.1.1",
+                "bn.js": "^5.1.1",
                 "crypto-js": "^4.1.1",
                 "js-base64": "^3.7.4",
                 "long": "^4.0.0",
@@ -3900,17 +3905,6 @@
             "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
             "dev": true
         },
-        "node_modules/@jsdoc/salty": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
-            "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
-            "dependencies": {
-                "lodash": "^4.17.21"
-            },
-            "engines": {
-                "node": ">=v12.0.0"
-            }
-        },
         "node_modules/@json-schema-spec/json-pointer": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/@json-schema-spec/json-pointer/-/json-pointer-0.1.2.tgz",
@@ -5188,29 +5182,10 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/linkify-it": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-            "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
-        },
         "node_modules/@types/long": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
             "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-        },
-        "node_modules/@types/markdown-it": {
-            "version": "12.2.3",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-            "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
-            "dependencies": {
-                "@types/linkify-it": "*",
-                "@types/mdurl": "*"
-            }
-        },
-        "node_modules/@types/mdurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
         },
         "node_modules/@types/mime": {
             "version": "1.3.2",
@@ -5658,6 +5633,7 @@
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
             "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5669,6 +5645,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -6012,6 +5989,24 @@
                 "safer-buffer": "~2.1.0"
             }
         },
+        "node_modules/asn1js": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+            "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+            "dependencies": {
+                "pvtsutils": "^1.3.2",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
+        "node_modules/asn1js/node_modules/tslib": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+        },
         "node_modules/assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -6316,7 +6311,9 @@
         "node_modules/bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/bn.js": {
             "version": "5.2.1",
@@ -6730,17 +6727,6 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
             "dev": true
-        },
-        "node_modules/catharsis": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-            "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
-            "dependencies": {
-                "lodash": "^4.17.15"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
         },
         "node_modules/chai": {
             "version": "4.3.7",
@@ -7576,7 +7562,8 @@
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true
         },
         "node_modules/default-require-extensions": {
             "version": "3.0.1",
@@ -7989,14 +7976,6 @@
                 "node": ">=8.6"
             }
         },
-        "node_modules/entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
         "node_modules/env-paths": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -8154,74 +8133,6 @@
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
             "engines": {
                 "node": ">=0.8.0"
-            }
-        },
-        "node_modules/escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=4.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/escodegen/node_modules/levn": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-            "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-            "dependencies": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/optionator": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-            "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-            "dependencies": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.6",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "word-wrap": "~1.2.3"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/prelude-ls": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-            "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/escodegen/node_modules/type-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-            "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-            "dependencies": {
-                "prelude-ls": "~1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
             }
         },
         "node_modules/eslint": {
@@ -8467,6 +8378,7 @@
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
             "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -8677,6 +8589,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -8685,6 +8598,7 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9194,7 +9108,8 @@
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true
         },
         "node_modules/fast-redact": {
             "version": "3.2.0",
@@ -11984,66 +11899,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/js2xmlparser": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
-            "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
-            "dependencies": {
-                "xmlcreate": "^2.0.4"
-            }
-        },
         "node_modules/jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
             "dev": true
-        },
-        "node_modules/jsdoc": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-            "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
-            "dependencies": {
-                "@babel/parser": "^7.20.15",
-                "@jsdoc/salty": "^0.2.1",
-                "@types/markdown-it": "^12.2.3",
-                "bluebird": "^3.7.2",
-                "catharsis": "^0.9.0",
-                "escape-string-regexp": "^2.0.0",
-                "js2xmlparser": "^4.0.2",
-                "klaw": "^3.0.0",
-                "markdown-it": "^12.3.2",
-                "markdown-it-anchor": "^8.4.1",
-                "marked": "^4.0.10",
-                "mkdirp": "^1.0.4",
-                "requizzle": "^0.2.3",
-                "strip-json-comments": "^3.1.0",
-                "underscore": "~1.13.2"
-            },
-            "bin": {
-                "jsdoc": "jsdoc.js"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/jsdoc/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/jsdoc/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
         },
         "node_modules/jsesc": {
             "version": "2.5.2",
@@ -12249,14 +12109,6 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/klaw": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-            "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-            "dependencies": {
-                "graceful-fs": "^4.1.9"
             }
         },
         "node_modules/koa": {
@@ -12978,14 +12830,6 @@
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
         },
-        "node_modules/linkify-it": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-            "dependencies": {
-                "uc.micro": "^1.0.1"
-            }
-        },
         "node_modules/load-json-file": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -13259,30 +13103,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/markdown-it": {
-            "version": "12.3.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-            "dependencies": {
-                "argparse": "^2.0.1",
-                "entities": "~2.1.0",
-                "linkify-it": "^3.0.1",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
-            },
-            "bin": {
-                "markdown-it": "bin/markdown-it.js"
-            }
-        },
-        "node_modules/markdown-it-anchor": {
-            "version": "8.6.7",
-            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
-            "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
-            "peerDependencies": {
-                "@types/markdown-it": "*",
-                "markdown-it": "*"
-            }
-        },
         "node_modules/marked": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -13368,11 +13188,6 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
             }
-        },
-        "node_modules/mdurl": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
@@ -14277,6 +14092,14 @@
                 "encoding": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/node-forge": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+            "engines": {
+                "node": ">= 6.13.0"
             }
         },
         "node_modules/node-gyp": {
@@ -16250,169 +16073,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/protobufjs-cli": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
-            "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "escodegen": "^1.13.0",
-                "espree": "^9.0.0",
-                "estraverse": "^5.1.0",
-                "glob": "^8.0.0",
-                "jsdoc": "^4.0.0",
-                "minimist": "^1.2.0",
-                "semver": "^7.1.2",
-                "tmp": "^0.2.1",
-                "uglify-js": "^3.7.7"
-            },
-            "bin": {
-                "pbjs": "bin/pbjs",
-                "pbts": "bin/pbts"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "protobufjs": "^7.0.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "node_modules/protobufjs-cli/node_modules/espree": {
-            "version": "9.6.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-            "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
-            "dependencies": {
-                "acorn": "^8.9.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/minimatch": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/protobufjs-cli/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/protobufjs/node_modules/long": {
             "version": "5.2.3",
             "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
@@ -16461,6 +16121,27 @@
             "integrity": "sha512-Yxz2kRwT90aPiWEMHVYnEf4+rhwF1tBmmZ4KepCP+Wkium9JxtWnUm1nqGwpiAHr/tnTSeHqr3wb++jgSkXjhA==",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/pvtsutils": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+            "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/pvtsutils/node_modules/tslib": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+            "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+        },
+        "node_modules/pvutils": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+            "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/qs": {
@@ -17287,14 +16968,6 @@
             "dev": true,
             "peer": true
         },
-        "node_modules/requizzle": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
-            "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
-            "dependencies": {
-                "lodash": "^4.17.21"
-            }
-        },
         "node_modules/resolve": {
             "version": "1.22.2",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -17917,6 +17590,11 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
+        },
+        "node_modules/spark-md5": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+            "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
         },
         "node_modules/sparkline": {
             "version": "0.1.2",
@@ -19257,15 +18935,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/uc.micro": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
-        },
         "node_modules/uglify-js": {
             "version": "3.17.4",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
             "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "optional": true,
             "bin": {
                 "uglifyjs": "bin/uglifyjs"
             },
@@ -19293,11 +18967,6 @@
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
             "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
             "dev": true
-        },
-        "node_modules/underscore": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         },
         "node_modules/unique-filename": {
             "version": "3.0.0",
@@ -19626,14 +19295,6 @@
                 "node": ">= 0.10.0"
             }
         },
-        "node_modules/word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -19910,11 +19571,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/xmlcreate": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-            "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
-        },
         "node_modules/xtend": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -20059,7 +19715,7 @@
             "version": "0.28.0-SNAPSHOT",
             "dependencies": {
                 "@ethersproject/asm": "^5.7.0",
-                "@hashgraph/sdk": "^2.29.0",
+                "@hashgraph/sdk": "^2.30.0",
                 "@keyvhq/core": "^1.6.9",
                 "axios": "^1.4.0",
                 "axios-retry": "^3.5.1",
@@ -20381,7 +20037,8 @@
         "@babel/parser": {
             "version": "7.22.7",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-            "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q=="
+            "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+            "dev": true
         },
         "@babel/runtime": {
             "version": "7.22.6",
@@ -21706,15 +21363,19 @@
             }
         },
         "@hashgraph/cryptography": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.6.tgz",
-            "integrity": "sha512-3HmnT1Lek71l6nHxc4GOyT/hSx/LmgusyWfE7hQda2dnE5vL2umydDw5TK2wq8gqmD9S3uRSMhz/BO55wtzxRA==",
+            "version": "1.4.7",
+            "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.7.tgz",
+            "integrity": "sha512-DrwZxIw3AM01JINaINTBmFEJVn9lzTHHf343zYXzpu+MrUJbZzuGyzd5bW6DmGGvFqTF/xDo0S/XiO2StdhVgg==",
             "requires": {
+                "asn1js": "^3.0.5",
                 "bignumber.js": "^9.1.1",
                 "bn.js": "^5.1.1",
+                "buffer": "^6.0.3",
                 "crypto-js": "^4.1.1",
                 "elliptic": "^6.5.4",
                 "js-base64": "^3.7.4",
+                "node-forge": "^1.3.1",
+                "spark-md5": "^3.0.2",
                 "tweetnacl": "^1.0.3",
                 "utf8": "^3.0.0"
             }
@@ -21764,7 +21425,7 @@
             "version": "file:packages/relay",
             "requires": {
                 "@ethersproject/asm": "^5.7.0",
-                "@hashgraph/sdk": "^2.29.0",
+                "@hashgraph/sdk": "^2.30.0",
                 "@keyvhq/core": "^1.6.9",
                 "@types/chai": "^4.3.0",
                 "@types/mocha": "^9.1.0",
@@ -21862,29 +21523,29 @@
             }
         },
         "@hashgraph/proto": {
-            "version": "2.12.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.12.0.tgz",
-            "integrity": "sha512-IIN6K3b2X8ih7V14IDH8rsVJ1DE9ud25FfKUpr+lDNnQdBfdZdG2AGlHRhc9iDAz4vCHoHc6F3Ao6yYKMceeTg==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.13.0.tgz",
+            "integrity": "sha512-Wan4TyiGExymUQOD+WVE/Q/RDjr+eBv5JBVO5+RGa2FDyASFhUWA/E1G0ZyiynXf2clqlewXIHyuNxpR42S80A==",
             "requires": {
                 "long": "^4.0.0",
-                "protobufjs": "^7.1.2",
-                "protobufjs-cli": "^1.0.2"
+                "protobufjs": "^7.1.2"
             }
         },
         "@hashgraph/sdk": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.29.0.tgz",
-            "integrity": "sha512-dMv2q7OCa2Xyi0ooGjo4JJRFxHKzKBvMd8G/n30j4jHx1JiSfI2ckPTAOwfCbYZ/o+EMDZzevyD5+Juf9iph+A==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.30.0.tgz",
+            "integrity": "sha512-wezW8W5JGA6dtaVGfHPgjYQp//QlKF3PtfkPUPQ22iVlgxzkXXkDEG+bKO9C+OCAvhGsC2sT0NR+xYhDYk5QGQ==",
             "requires": {
                 "@ethersproject/abi": "^5.7.0",
                 "@ethersproject/bignumber": "^5.7.0",
                 "@ethersproject/bytes": "^5.7.0",
                 "@ethersproject/rlp": "^5.7.0",
                 "@grpc/grpc-js": "1.8.2",
-                "@hashgraph/cryptography": "1.4.6",
-                "@hashgraph/proto": "2.12.0",
+                "@hashgraph/cryptography": "1.4.7",
+                "@hashgraph/proto": "2.13.0",
                 "axios": "^1.3.1",
                 "bignumber.js": "^9.1.1",
+                "bn.js": "^5.1.1",
                 "crypto-js": "^4.1.1",
                 "js-base64": "^3.7.4",
                 "long": "^4.0.0",
@@ -22967,14 +22628,6 @@
                 }
             }
         },
-        "@jsdoc/salty": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
-            "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
-            "requires": {
-                "lodash": "^4.17.21"
-            }
-        },
         "@json-schema-spec/json-pointer": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/@json-schema-spec/json-pointer/-/json-pointer-0.1.2.tgz",
@@ -24014,29 +23667,10 @@
                 "@types/node": "*"
             }
         },
-        "@types/linkify-it": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-            "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA=="
-        },
         "@types/long": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
             "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-        },
-        "@types/markdown-it": {
-            "version": "12.2.3",
-            "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-            "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
-            "requires": {
-                "@types/linkify-it": "*",
-                "@types/mdurl": "*"
-            }
-        },
-        "@types/mdurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
         },
         "@types/mime": {
             "version": "1.3.2",
@@ -24365,12 +23999,14 @@
         "acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true
         },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true,
             "requires": {}
         },
         "acorn-walk": {
@@ -24627,6 +24263,23 @@
                 "safer-buffer": "~2.1.0"
             }
         },
+        "asn1js": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+            "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+            "requires": {
+                "pvtsutils": "^1.3.2",
+                "pvutils": "^1.1.3",
+                "tslib": "^2.4.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+                    "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+                }
+            }
+        },
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -24867,7 +24520,9 @@
         "bluebird": {
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+            "dev": true,
+            "peer": true
         },
         "bn.js": {
             "version": "5.2.1",
@@ -25167,14 +24822,6 @@
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
             "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
             "dev": true
-        },
-        "catharsis": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
-            "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
-            "requires": {
-                "lodash": "^4.17.15"
-            }
         },
         "chai": {
             "version": "4.3.7",
@@ -25808,7 +25455,8 @@
         "deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true
         },
         "default-require-extensions": {
             "version": "3.0.1",
@@ -26125,11 +25773,6 @@
                 "ansi-colors": "^4.1.1"
             }
         },
-        "entities": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
-        },
         "env-paths": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -26255,55 +25898,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
-        },
-        "escodegen": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-            "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-            "requires": {
-                "esprima": "^4.0.1",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
-            },
-            "dependencies": {
-                "levn": {
-                    "version": "0.3.0",
-                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                    "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
-                    "requires": {
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2"
-                    }
-                },
-                "optionator": {
-                    "version": "0.8.3",
-                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-                    "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-                    "requires": {
-                        "deep-is": "~0.1.3",
-                        "fast-levenshtein": "~2.0.6",
-                        "levn": "~0.3.0",
-                        "prelude-ls": "~1.1.2",
-                        "type-check": "~0.3.2",
-                        "word-wrap": "~1.2.3"
-                    }
-                },
-                "prelude-ls": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                    "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
-                },
-                "type-check": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                    "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
-                    "requires": {
-                        "prelude-ls": "~1.1.2"
-                    }
-                }
-            }
         },
         "eslint": {
             "version": "7.32.0",
@@ -26589,7 +26183,8 @@
         "eslint-visitor-keys": {
             "version": "3.4.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA=="
+            "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+            "dev": true
         },
         "espree": {
             "version": "7.3.1",
@@ -26652,12 +26247,14 @@
         "estraverse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+            "dev": true
         },
         "esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
         },
         "eth-ens-namehash": {
             "version": "2.0.8",
@@ -27061,7 +26658,8 @@
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+            "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+            "dev": true
         },
         "fast-redact": {
             "version": "3.2.0",
@@ -29045,53 +28643,11 @@
                 "argparse": "^2.0.1"
             }
         },
-        "js2xmlparser": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
-            "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
-            "requires": {
-                "xmlcreate": "^2.0.4"
-            }
-        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
             "dev": true
-        },
-        "jsdoc": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-            "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
-            "requires": {
-                "@babel/parser": "^7.20.15",
-                "@jsdoc/salty": "^0.2.1",
-                "@types/markdown-it": "^12.2.3",
-                "bluebird": "^3.7.2",
-                "catharsis": "^0.9.0",
-                "escape-string-regexp": "^2.0.0",
-                "js2xmlparser": "^4.0.2",
-                "klaw": "^3.0.0",
-                "markdown-it": "^12.3.2",
-                "markdown-it-anchor": "^8.4.1",
-                "marked": "^4.0.10",
-                "mkdirp": "^1.0.4",
-                "requizzle": "^0.2.3",
-                "strip-json-comments": "^3.1.0",
-                "underscore": "~1.13.2"
-            },
-            "dependencies": {
-                "escape-string-regexp": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
-                },
-                "mkdirp": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-                }
-            }
         },
         "jsesc": {
             "version": "2.5.2",
@@ -29261,14 +28817,6 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
-        },
-        "klaw": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-            "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
-            "requires": {
-                "graceful-fs": "^4.1.9"
-            }
         },
         "koa": {
             "version": "2.14.2",
@@ -29817,14 +29365,6 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
             "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w=="
         },
-        "linkify-it": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
-            "requires": {
-                "uc.micro": "^1.0.1"
-            }
-        },
         "load-json-file": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-6.2.0.tgz",
@@ -30043,24 +29583,6 @@
             "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
             "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
         },
-        "markdown-it": {
-            "version": "12.3.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
-            "requires": {
-                "argparse": "^2.0.1",
-                "entities": "~2.1.0",
-                "linkify-it": "^3.0.1",
-                "mdurl": "^1.0.1",
-                "uc.micro": "^1.0.5"
-            }
-        },
-        "markdown-it-anchor": {
-            "version": "8.6.7",
-            "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
-            "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
-            "requires": {}
-        },
         "marked": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
@@ -30115,11 +29637,6 @@
                 "inherits": "^2.0.1",
                 "safe-buffer": "^5.1.2"
             }
-        },
-        "mdurl": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
         },
         "media-typer": {
             "version": "0.3.0",
@@ -30826,6 +30343,11 @@
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
+        },
+        "node-forge": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
         },
         "node-gyp": {
             "version": "9.4.0",
@@ -32313,116 +31835,6 @@
                 }
             }
         },
-        "protobufjs-cli": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/protobufjs-cli/-/protobufjs-cli-1.1.1.tgz",
-            "integrity": "sha512-VPWMgIcRNyQwWUv8OLPyGQ/0lQY/QTQAVN5fh+XzfDwsVw1FZ2L3DM/bcBf8WPiRz2tNpaov9lPZfNcmNo6LXA==",
-            "requires": {
-                "chalk": "^4.0.0",
-                "escodegen": "^1.13.0",
-                "espree": "^9.0.0",
-                "estraverse": "^5.1.0",
-                "glob": "^8.0.0",
-                "jsdoc": "^4.0.0",
-                "minimist": "^1.2.0",
-                "semver": "^7.1.2",
-                "tmp": "^0.2.1",
-                "uglify-js": "^3.7.7"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "8.10.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-                    "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
-                },
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-                    "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-                    "requires": {
-                        "balanced-match": "^1.0.0"
-                    }
-                },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-                    "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-                    "requires": {
-                        "color-name": "~1.1.4"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-                },
-                "espree": {
-                    "version": "9.6.0",
-                    "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-                    "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
-                    "requires": {
-                        "acorn": "^8.9.0",
-                        "acorn-jsx": "^5.3.2",
-                        "eslint-visitor-keys": "^3.4.1"
-                    }
-                },
-                "estraverse": {
-                    "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
-                },
-                "glob": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-                    "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^5.0.1",
-                        "once": "^1.3.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-                },
-                "minimatch": {
-                    "version": "5.1.6",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-                    "requires": {
-                        "brace-expansion": "^2.0.1"
-                    }
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
-                }
-            }
-        },
         "protocols": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
@@ -32464,6 +31876,26 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
             "integrity": "sha512-Yxz2kRwT90aPiWEMHVYnEf4+rhwF1tBmmZ4KepCP+Wkium9JxtWnUm1nqGwpiAHr/tnTSeHqr3wb++jgSkXjhA=="
+        },
+        "pvtsutils": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.2.tgz",
+            "integrity": "sha512-+Ipe2iNUyrZz+8K/2IOo+kKikdtfhRKzNpQbruF2URmqPtoqAs8g3xS7TJvFF2GcPXjh7DkqMnpVveRFq4PgEQ==",
+            "requires": {
+                "tslib": "^2.4.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.6.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+                    "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+                }
+            }
+        },
+        "pvutils": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+            "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
         },
         "qs": {
             "version": "6.11.2",
@@ -33079,14 +32511,6 @@
             "dev": true,
             "peer": true
         },
-        "requizzle": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
-            "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
-            "requires": {
-                "lodash": "^4.17.21"
-            }
-        },
         "resolve": {
             "version": "1.22.2",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -33546,6 +32970,11 @@
                 "buffer-from": "^1.0.0",
                 "source-map": "^0.6.0"
             }
+        },
+        "spark-md5": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+            "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
         },
         "sparkline": {
             "version": "0.1.2",
@@ -34571,15 +34000,11 @@
             "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
             "dev": true
         },
-        "uc.micro": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
-        },
         "uglify-js": {
             "version": "3.17.4",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g=="
+            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "optional": true
         },
         "unbox-primitive": {
             "version": "1.0.2",
@@ -34598,11 +34023,6 @@
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
             "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
             "dev": true
-        },
-        "underscore": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         },
         "unique-filename": {
             "version": "3.0.0",
@@ -34857,11 +34277,6 @@
             "dev": true,
             "peer": true
         },
-        "word-wrap": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
-        },
         "wordwrap": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -35062,11 +34477,6 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-        },
-        "xmlcreate": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
-            "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
         },
         "xtend": {
             "version": "4.0.2",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "@ethersproject/asm": "^5.7.0",
-        "@hashgraph/sdk": "^2.29.0",
+        "@hashgraph/sdk": "^2.30.0",
         "@keyvhq/core": "^1.6.9",
         "better-lookup": "^1.3.0",
         "axios": "^1.4.0",

--- a/packages/ws-server/package.json
+++ b/packages/ws-server/package.json
@@ -23,7 +23,7 @@
     },
     "devDependencies": {
         "@hashgraph/hedera-local": "^2.4.5",
-        "@hashgraph/sdk": "^2.29.0",
+        "@hashgraph/sdk": "^2.30.0",
         "@koa/cors": "^3.1.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",


### PR DESCRIPTION
**Description**:
Bumping up hashgraph sdk version to **v2.30.0**

**Related issue(s)**:

Fixes #1525 

**Notes for reviewer**:
[Release version](https://github.com/hashgraph/hedera-sdk-js/releases/tag/v2.30.0)


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
