### PR TITLE
Bumping up hedera-local version to latest v2.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "name": "root",
             "dependencies": {
-                "@hashgraph/hedera-local": "^2.10.0",
+                "@hashgraph/hedera-local": "^2.11.0",
                 "@open-rpc/schema-utils-js": "^1.16.1",
                 "@types/find-config": "^1.0.1",
                 "keyv-file": "^0.2.0",
@@ -2220,22 +2220,22 @@
             }
         },
         "node_modules/@hashgraph/hedera-local": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.10.0.tgz",
-            "integrity": "sha512-+92OkJpA55FJJFW1TyvXcduPSBVE45RJXhjQJNwSTOT6AOZl8sPvwFfPa8PV7KpMxS4TrOkWk/DTCuEQLgqs2Q==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.11.0.tgz",
+            "integrity": "sha512-uVy2L+7Ugfld/FaTe6hgX772sajZO3R4TEazLfohSxp/S95ewVnSk9xTKw8oj3S7lQA8kBLTyjus1AVyIXvJ9A==",
             "dependencies": {
                 "@hashgraph/hethers": "^1.2.6",
-                "@hashgraph/sdk": "^2.24.1",
+                "@hashgraph/sdk": "^2.29.0",
                 "blessed": "^0.1.81",
                 "blessed-terminal": "^0.1.22",
                 "dockerode": "^3.3.5",
-                "dotenv": "^16.0.3",
+                "dotenv": "^16.3.1",
                 "ethers": "^5.7.2",
                 "js-yaml": "^4.1.0",
                 "mustache": "^4.2.0",
                 "rimraf": "^3.0.2",
                 "shelljs": "^0.8.5",
-                "yargs": "^17.6.2"
+                "yargs": "^17.7.2"
             },
             "bin": {
                 "hedera": "cli.js"
@@ -19762,7 +19762,7 @@
                 "uuid": "^3.3.2"
             },
             "devDependencies": {
-                "@hashgraph/hedera-local": "^2.7.0",
+                "@hashgraph/hedera-local": "^2.11.0",
                 "@hashgraph/sdk": "^2.29.0",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
@@ -19801,7 +19801,7 @@
                 "pino-pretty": "^7.6.1"
             },
             "devDependencies": {
-                "@hashgraph/hedera-local": "^2.4.5",
+                "@hashgraph/hedera-local": "^2.11.0",
                 "@hashgraph/sdk": "^2.30.0",
                 "@koa/cors": "^3.1.0",
                 "@types/chai": "^4.3.0",
@@ -21381,22 +21381,22 @@
             }
         },
         "@hashgraph/hedera-local": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.10.0.tgz",
-            "integrity": "sha512-+92OkJpA55FJJFW1TyvXcduPSBVE45RJXhjQJNwSTOT6AOZl8sPvwFfPa8PV7KpMxS4TrOkWk/DTCuEQLgqs2Q==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.11.0.tgz",
+            "integrity": "sha512-uVy2L+7Ugfld/FaTe6hgX772sajZO3R4TEazLfohSxp/S95ewVnSk9xTKw8oj3S7lQA8kBLTyjus1AVyIXvJ9A==",
             "requires": {
                 "@hashgraph/hethers": "^1.2.6",
-                "@hashgraph/sdk": "^2.24.1",
+                "@hashgraph/sdk": "^2.29.0",
                 "blessed": "^0.1.81",
                 "blessed-terminal": "^0.1.22",
                 "dockerode": "^3.3.5",
-                "dotenv": "^16.0.3",
+                "dotenv": "^16.3.1",
                 "ethers": "^5.7.2",
                 "js-yaml": "^4.1.0",
                 "mustache": "^4.2.0",
                 "rimraf": "^3.0.2",
                 "shelljs": "^0.8.5",
-                "yargs": "^17.6.2"
+                "yargs": "^17.7.2"
             }
         },
         "@hashgraph/hethers": {
@@ -21454,7 +21454,7 @@
         "@hashgraph/json-rpc-server": {
             "version": "file:packages/server",
             "requires": {
-                "@hashgraph/hedera-local": "^2.7.0",
+                "@hashgraph/hedera-local": "^2.11.0",
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "@hashgraph/sdk": "^2.29.0",
                 "@koa/cors": "^3.1.0",
@@ -21489,7 +21489,7 @@
         "@hashgraph/json-rpc-ws-server": {
             "version": "file:packages/ws-server",
             "requires": {
-                "@hashgraph/hedera-local": "^2.4.5",
+                "@hashgraph/hedera-local": "^2.11.0",
                 "@hashgraph/json-rpc-relay": "file:../relay",
                 "@hashgraph/json-rpc-server": "file:../server",
                 "@hashgraph/sdk": "^2.30.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "bump-version": "SEM_VER=${npm_config_semver} SNAPSHOT=${npm_config_snapshot} node scripts/.bump-version.js"
     },
     "dependencies": {
-        "@hashgraph/hedera-local": "^2.10.0",
+        "@hashgraph/hedera-local": "^2.11.0",
         "@open-rpc/schema-utils-js": "^1.16.1",
         "@types/find-config": "^1.0.1",
         "keyv-file": "^0.2.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
         "uuid": "^3.3.2"
     },
     "devDependencies": {
-        "@hashgraph/hedera-local": "^2.7.0",
+        "@hashgraph/hedera-local": "^2.11.0",
         "@hashgraph/sdk": "^2.29.0",
         "@koa/cors": "^3.1.0",
         "@types/chai": "^4.3.0",

--- a/packages/ws-server/package.json
+++ b/packages/ws-server/package.json
@@ -22,7 +22,7 @@
         "pino-pretty": "^7.6.1"
     },
     "devDependencies": {
-        "@hashgraph/hedera-local": "^2.4.5",
+        "@hashgraph/hedera-local": "^2.11.0",
         "@hashgraph/sdk": "^2.30.0",
         "@koa/cors": "^3.1.0",
         "@types/chai": "^4.3.0",


### PR DESCRIPTION
**Description**:
Bumping up @hashgraph/hedera-local version across packages to latest 2.11.0

**Related issue(s)**:

Fixes #1528 

**Notes for reviewer**:
[Release version v2.11.0](https://github.com/hashgraph/hedera-local-node/releases/tag/v.2.11.0)


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
