### PR TITLE
Returned bytecode is incorrect after selfdestruct and recreation via create2

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -897,7 +897,6 @@ export class EthImpl implements Eth {
         // handle INVALID_CONTRACT_ID or CONTRACT_DELETED
         if (e.isInvalidContractId() || e.isContractDeleted()) {
           this.logger.debug(`${requestIdPrefix} Unable to find code for contract ${address} in block "${blockNumber}", returning 0x0, err code: ${e.statusCode}`);
-          this.cache.set(cachedLabel, EthImpl.emptyHex, EthImpl.ethGetCode, undefined, requestIdPrefix);
           return EthImpl.emptyHex;
         }
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2007,7 +2007,7 @@ describe('Eth calls using MirrorNode', async function () {
   });
 
   describe('eth_getCode', async function() {
-    it('should return cached value', async () => {
+    it('should return non cached value for not found contract', async () => {
       restMock.onGet(`contracts/${contractAddress1}`).reply(404, defaultContract);
       restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(404, null);
       restMock.onGet(`tokens/0.0.${parseInt(contractAddress1, 16)}`).reply(404, null);
@@ -2017,7 +2017,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const resNoCache = await ethImpl.getCode(contractAddress1, null);
       const resCached = await ethImpl.getCode(contractAddress1, null);
-      sinon.assert.calledOnce(sdkClientStub.getContractByteCode);
+      // sinon.assert.calledOnce(sdkClientStub.getContractByteCode);
       expect(resNoCache).to.equal(EthImpl.emptyHex);
       expect(resCached).to.equal(EthImpl.emptyHex);
     });

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2017,7 +2017,6 @@ describe('Eth calls using MirrorNode', async function () {
 
       const resNoCache = await ethImpl.getCode(contractAddress1, null);
       const resCached = await ethImpl.getCode(contractAddress1, null);
-      // sinon.assert.calledOnce(sdkClientStub.getContractByteCode);
       expect(resNoCache).to.equal(EthImpl.emptyHex);
       expect(resCached).to.equal(EthImpl.emptyHex);
     });


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

The relay caches non-existing contracts or deleted ones, which is a problem when we redeploy contracts via create2.

**Related issue(s)**:

Fixes #1533 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
