### PR TITLE
subscriptions_enabled=true is necessary to enable the websockets func…

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
   MIRROR_NODE_RETRIES: {{ .Values.config.MIRROR_NODE_RETRIES | quote }}
   MIRROR_NODE_RETRY_DELAY: {{ .Values.config.MIRROR_NODE_RETRY_DELAY | quote }}
   MIRROR_NODE_URL: {{ .Values.config.MIRROR_NODE_URL | quote }}
-  SUBSCRIPTIONS_ENABLED: {{ .Values.config.SUBSCRIPTIONS_ENABLED | quote }}
+  SUBSCRIPTIONS_ENABLED: "true"
   WEB_SOCKET_HTTP_PORT: {{ .Values.config.WEB_SOCKET_HTTP_PORT | quote }}
   WEB_SOCKET_PORT: {{ .Values.config.WEB_SOCKET_PORT | quote }}
   WS_CONNECTION_LIMIT_PER_IP: {{ .Values.config.WS_CONNECTION_LIMIT_PER_IP | quote }}


### PR DESCRIPTION
This should always be true when deploying the websockets

**Description**:
This PR modifies the `SUBSCRIPTIONS_ENABLED` key/value in the websockets configmap.   This value needs to be true to enable the websocket functionality.

