### PR TITLE
refactor getContractByteCode to set cost based on the sdk assessment

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -136,8 +136,12 @@ export class SDKClient {
     }
 
     async getContractByteCode(shard: number | Long, realm: number | Long, address: string, callerName: string, requestId?: string): Promise<Uint8Array> {
+        const contractByteCodeQuery = new ContractByteCodeQuery().setContractId(ContractId.fromEvmAddress(shard, realm, address));
+        const cost = await contractByteCodeQuery
+            .getCost(this.clientMain);
+
         return this.executeQuery(new ContractByteCodeQuery()
-            .setContractId(ContractId.fromEvmAddress(shard, realm, address)), this.clientMain, callerName, address, requestId);
+            .setQueryPayment(cost), this.clientMain, callerName, address, requestId);
     }
 
     async getContractBalance(contract: string, callerName: string, requestId?: string): Promise<AccountBalance> {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -135,13 +135,18 @@ export class SDKClient {
             .setAccountId(AccountId.fromString(address)), this.clientMain, callerName, address, requestId);
     }
 
-    async getContractByteCode(shard: number | Long, realm: number | Long, address: string, callerName: string, requestId?: string): Promise<Uint8Array> {
-        const contractByteCodeQuery = new ContractByteCodeQuery().setContractId(ContractId.fromEvmAddress(shard, realm, address));
-        const cost = await contractByteCodeQuery
-            .getCost(this.clientMain);
+    async getContractByteCode(shard: number | Long, realm: number | Long, address: string, callerName: string, hasProhibitedOpCodes: boolean, requestId?: string): Promise<Uint8Array> {
+        if(hasProhibitedOpCodes) {
+            return this.executeQuery(new ContractByteCodeQuery()
+                .setContractId(ContractId.fromEvmAddress(shard, realm, address)), this.clientMain, callerName, address, requestId);
+        } else {
+            const contractByteCodeQuery = new ContractByteCodeQuery().setContractId(ContractId.fromEvmAddress(shard, realm, address));
+            const cost = await contractByteCodeQuery
+                .getCost(this.clientMain);
 
-        return this.executeQuery(new ContractByteCodeQuery()
-            .setQueryPayment(cost), this.clientMain, callerName, address, requestId);
+            return this.executeQuery(new ContractByteCodeQuery()
+                .setQueryPayment(cost), this.clientMain, callerName, address, requestId);
+        }
     }
 
     async getContractBalance(contract: string, callerName: string, requestId?: string): Promise<AccountBalance> {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -135,18 +135,13 @@ export class SDKClient {
             .setAccountId(AccountId.fromString(address)), this.clientMain, callerName, address, requestId);
     }
 
-    async getContractByteCode(shard: number | Long, realm: number | Long, address: string, callerName: string, hasProhibitedOpCodes: boolean, requestId?: string): Promise<Uint8Array> {
-        if(hasProhibitedOpCodes) {
-            return this.executeQuery(new ContractByteCodeQuery()
-                .setContractId(ContractId.fromEvmAddress(shard, realm, address)), this.clientMain, callerName, address, requestId);
-        } else {
-            const contractByteCodeQuery = new ContractByteCodeQuery().setContractId(ContractId.fromEvmAddress(shard, realm, address));
-            const cost = await contractByteCodeQuery
-                .getCost(this.clientMain);
+    async getContractByteCode(shard: number | Long, realm: number | Long, address: string, callerName: string, requestId?: string): Promise<Uint8Array> {
+        const contractByteCodeQuery = new ContractByteCodeQuery().setContractId(ContractId.fromEvmAddress(shard, realm, address));
+        const cost = await contractByteCodeQuery
+            .getCost(this.clientMain);
 
-            return this.executeQuery(new ContractByteCodeQuery()
-                .setQueryPayment(cost), this.clientMain, callerName, address, requestId);
-        }
+        return this.executeQuery(contractByteCodeQuery
+            .setQueryPayment(cost), this.clientMain, callerName, address, requestId);
     }
 
     async getContractBalance(contract: string, callerName: string, requestId?: string): Promise<AccountBalance> {

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -18,8 +18,6 @@
   *
   */
 
-import {PrecheckStatusError} from "@hashgraph/sdk";
-
 enum CACHE_KEY {
     ACCOUNT = 'account',
     ETH_BLOCK_NUMBER = 'eth_block_number',

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -18,6 +18,8 @@
   *
   */
 
+import {PrecheckStatusError} from "@hashgraph/sdk";
+
 enum CACHE_KEY {
     ACCOUNT = 'account',
     ETH_BLOCK_NUMBER = 'eth_block_number',
@@ -124,6 +126,12 @@ export default {
 
     TRANSACTION_RESULT_STATUS: {
         WRONG_NONCE: 'WRONG_NONCE'
+    },
+
+    PRECHECK_STATUS_ERROR_STATUS_CODES: {
+        INVALID_CONTRACT_ID: 16,
+        CONTRACT_DELETED: 66
     }
+
 };
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -902,7 +902,7 @@ export class EthImpl implements Eth {
 
         this.hapiService.decrementErrorCounter(e.statusCode);
         this.logger.error(e, `${requestIdPrefix} Error raised during getCode for address ${address}, err code: ${e.statusCode}`);
-      } if(e instanceof PrecheckStatusError) {
+      } else if(e instanceof PrecheckStatusError) {
         if(e.status._code === constants.PRECHECK_STATUS_ERROR_STATUS_CODES.INVALID_CONTRACT_ID ||
             e.status._code === constants.PRECHECK_STATUS_ERROR_STATUS_CODES.CONTRACT_DELETED ) {
           this.logger.debug(`${requestIdPrefix} Unable to find code for contract ${address} in block "${blockNumber}", returning 0x0, err code: ${e.message}`);

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -873,7 +873,6 @@ export class EthImpl implements Eth {
 
     try {
       const result = await this.mirrorNodeClient.resolveEntityType(address, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN], EthImpl.ethGetCode, requestIdPrefix);
-      let hasProhibitedOpcode = false;
       if (result) {
         if (result?.type === constants.TYPE_TOKEN) {
           this.logger.trace(`${requestIdPrefix} Token redirect case, return redirectBytecode`);
@@ -882,7 +881,7 @@ export class EthImpl implements Eth {
           if (result?.entity.runtime_bytecode !== EthImpl.emptyHex) {
             const prohibitedOpcodes = ['CALLCODE', 'DELEGATECALL', 'SELFDESTRUCT', 'SUICIDE'];
             const opcodes = asm.disassemble(result?.entity.runtime_bytecode);
-            hasProhibitedOpcode = opcodes.filter(opcode => prohibitedOpcodes.indexOf(opcode.opcode.mnemonic) > -1).length > 0;
+            const hasProhibitedOpcode = opcodes.filter(opcode => prohibitedOpcodes.indexOf(opcode.opcode.mnemonic) > -1).length > 0;
             if (!hasProhibitedOpcode) {
               this.cache.set(cachedLabel, result?.entity.runtime_bytecode, EthImpl.ethGetCode, undefined, requestIdPrefix);
               return result?.entity.runtime_bytecode;
@@ -891,7 +890,7 @@ export class EthImpl implements Eth {
         }
       }
 
-      const bytecode = await this.hapiService.getSDKClient().getContractByteCode(0, 0, address, EthImpl.ethGetCode, hasProhibitedOpcode, requestIdPrefix);
+      const bytecode = await this.hapiService.getSDKClient().getContractByteCode(0, 0, address, EthImpl.ethGetCode, requestIdPrefix);
       return EthImpl.prepend0x(Buffer.from(bytecode).toString('hex'));
     } catch (e: any) {
       if (e instanceof SDKClientError) {


### PR DESCRIPTION

**Description**:
refactor getContractByteCode to set cost based on the sdk assessment using getCost method

**Related issue(s)**:

Fixes #1523 

**Notes for reviewer**:
Did not include a test case, since if every tests we already have continues to work as expected, there should not be an issue, also, testing this overlaps with testing the sdk itself, which is outside the relay and is already tested by the sdk test suites

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
