### PR TITLE
1438 update trycatch test logic in ethspects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9629,6 +9629,7 @@
             "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
             "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
             "dev": true,
+            "hasInstallScript": true,
             "optional": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"
@@ -9991,6 +9992,7 @@
             "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
             "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
             "dev": true,
+            "hasInstallScript": true,
             "optional": true,
             "dependencies": {
                 "node-gyp-build": "^4.3.0"

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -377,7 +377,7 @@ export class EthImpl implements Eth {
   private async getFeeWeibars(callerName: string, requestIdPrefix?: string, timestamp?: string) {
     let networkFees;
     try {
-      networkFees = await this.mirrorNodeClient.getNetworkFees(timestamp,undefined, requestIdPrefix);
+      networkFees = await this.mirrorNodeClient.getNetworkFees(timestamp, undefined, requestIdPrefix);
       if (_.isNil(networkFees)) {
         this.logger.debug(`${requestIdPrefix} Mirror Node returned no fees. Fallback to network`);
       }
@@ -1106,7 +1106,7 @@ export class EthImpl implements Eth {
     let interactingEntity = '';
     let originatingAddress = '';
     try {
-      let parsedTx = Precheck.parseTxIfNeeded(transaction);
+      const parsedTx = Precheck.parseTxIfNeeded(transaction);
       interactingEntity = parsedTx.to?.toString() || '';
       originatingAddress = parsedTx.from?.toString() || '';
       this.logger.trace(`${requestIdPrefix} sendRawTransaction(from=${originatingAddress}, to=${interactingEntity}, transaction=${transaction})`);
@@ -1564,7 +1564,7 @@ export class EthImpl implements Eth {
     return input.startsWith(EthImpl.emptyHex) ? input : EthImpl.emptyHex + input;
   }
 
-  static numberTo0x(input: number | BigNumber | BigInt): string {
+  static numberTo0x(input: number | BigNumber | bigint): string {
     return EthImpl.emptyHex + input.toString(16);
   }
 
@@ -1648,7 +1648,7 @@ export class EthImpl implements Eth {
 
     // Gas limit for `eth_call` is 50_000_000, but the current Hedera network limit is 15_000_000
     // With values over the gas limit, the call will fail with BUSY error so we cap it at 15_000_000
-    let gas = Number.parseInt(gasString);
+    const gas = Number.parseInt(gasString);
     if (gas > constants.BLOCK_GAS_LIMIT) {
       this.logger.trace(`${requestIdPrefix} eth_call gas amount (${gas}) exceeds network limit, capping gas to ${constants.BLOCK_GAS_LIMIT}`);
       return constants.BLOCK_GAS_LIMIT;

--- a/packages/relay/tests/assertions.ts
+++ b/packages/relay/tests/assertions.ts
@@ -1,8 +1,10 @@
 
 import { expect } from 'chai';
 import { JsonRpcError } from '../src';
+import { EthImpl } from "../src/lib/eth";
+import { Block, Transaction} from "../src/lib/model";
 
-export default class Assertions {
+export default class RelayAssertions {
     static assertRejection = async (error: JsonRpcError, method, checkMessage: boolean, thisObj, args?: any[]): Promise<any> => {
         return await expect(method.apply(thisObj, args)).to.eventually.be.rejected.and.satisfy((err) => {
             if(!checkMessage) {
@@ -10,6 +12,118 @@ export default class Assertions {
             }
             return err.code === error.code && err.name === error.name && err.message === error.message;
         });
+    };
+
+    static assertTransactionReceipt = (receipt, expectedReceipt) => {
+        expect(receipt).to.exist;
+        if (receipt == null) return;
+    
+        expect(this.validateHash(receipt.transactionHash, 64)).to.eq(true);
+        expect(this.validateHash(receipt.blockHash, 64)).to.eq(true);
+        expect(this.validateHash(receipt.from, 40)).to.eq(true);
+        if (receipt.contractAddress) {
+            expect(this.validateHash(receipt.contractAddress, 40)).to.eq(true);
+        }
+        if (receipt.to) {
+            expect(this.validateHash(receipt.to, 40)).to.eq(true);
+        }
+        expect(this.validateHash(receipt.logsBloom, 512)).to.eq(true);
+        if (receipt.root) {
+            expect(this.validateHash(receipt.root, 64)).to.eq(true);
+        }
+    
+        expect(receipt.transactionHash).to.exist;
+        expect(receipt.transactionHash).to.eq(expectedReceipt.transactionHash);
+        expect(receipt.transactionIndex).to.exist;
+        expect(receipt.blockHash).to.eq(expectedReceipt.blockHash);
+        expect(receipt.blockNumber).to.eq(expectedReceipt.blockNumber);
+        expect(receipt.from).to.eq(expectedReceipt.from);
+        expect(receipt.to).to.eq(expectedReceipt.to);
+        expect(receipt.cumulativeGasUsed).to.eq(expectedReceipt.cumulativeGasUsed);
+        expect(receipt.gasUsed).to.eq(expectedReceipt.gasUsed);
+        expect(receipt.contractAddress).to.eq(expectedReceipt.contractAddress);
+        expect(receipt.logs).to.deep.eq(expectedReceipt.logs);
+        expect(receipt.logsBloom).to.eq(expectedReceipt.logsBloom);
+        expect(receipt.root).to.eq(expectedReceipt.root);
+        expect(receipt.status).to.eq(expectedReceipt.status);
+        expect(receipt.effectiveGasPrice).to.eq(expectedReceipt.effectiveGasPrice);
+    };
+    
+    static assertTransaction = (tx, expectedTx) => {
+    
+        expect(tx).to.exist;
+        if (tx == null) return;
+    
+        expect(tx.accessList).to.eq(expectedTx.accessList);
+        expect(tx.blockHash).to.eq(expectedTx.blockHash);
+        expect(tx.blockNumber).to.eq(expectedTx.blockNumber);
+        expect(tx.chainId).to.eq(expectedTx.chainId);
+        expect(tx.from).to.eq(expectedTx.from);
+        expect(tx.gas).to.eq(expectedTx.gas);
+        expect(tx.gasPrice).to.eq(expectedTx.gasPrice);
+        expect(tx.hash).to.eq(expectedTx.hash);
+        expect(tx.input).to.eq(expectedTx.input);
+        expect(tx.maxFeePerGas).to.eq(expectedTx.maxFeePerGas);
+        expect(tx.maxPriorityFeePerGas).to.eq(expectedTx.maxPriorityFeePerGas);
+        expect(tx.nonce).to.eq(EthImpl.numberTo0x(expectedTx.nonce));
+        expect(tx.r).to.eq(expectedTx.r);
+        expect(tx.s).to.eq(expectedTx.s);
+        expect(tx.to).to.eq(expectedTx.to);
+        expect(tx.transactionIndex).to.eq(expectedTx.transactionIndex);
+        expect(tx.type).to.eq(EthImpl.numberTo0x(expectedTx.type));
+        expect(tx.v).to.eq(EthImpl.numberTo0x(expectedTx.v));
+        expect(tx.value).to.eq(expectedTx.value);
+    };
+    
+    static assertBlock = (block, expectedBlock, txDetails = false) => {
+        expect(block).to.exist;
+        expect(block).to.not.be.null;
+    
+        // verify aggregated info
+        expect(block.hash).equal(expectedBlock.hash);
+        expect(block.gasUsed).equal(expectedBlock.gasUsed);
+        expect(block.number).equal(expectedBlock.number);
+        expect(block.parentHash).equal(expectedBlock.parentHash);
+        expect(block.timestamp).equal(expectedBlock.timestamp);
+        expect(block.transactions.length).equal(expectedBlock.transactions.length);
+        for (let i = 0; i < expectedBlock.transactions.length; i++) {
+            if (!txDetails) {
+                expect(block.transactions[i] as string).equal(expectedBlock.transactions[i]);
+            }
+            else {
+                expect((block.transactions[i] as Transaction).hash).equal(expectedBlock.transactions[i]);
+            }
+        }
+    
+        // verify expected constants
+        this.verifyBlockConstants(block);
+    };
+
+    static validateHash = (hash: string, len?: number) => {
+        let regex;
+        if (len && len > 0) {
+            regex = new RegExp(`^0x[a-f0-9]{${len}}$`);
+        } else {
+            regex = /^0x[a-f0-9]*$/;
+        }
+    
+        return !!regex.exec(hash);
+    };
+
+    
+    static verifyBlockConstants = (block: Block) => {
+        expect(block.gasLimit).equal(EthImpl.numberTo0x(15000000));
+        expect(block.baseFeePerGas).equal('0x84b6a5c400');
+        expect(block.difficulty).equal(EthImpl.zeroHex);
+        expect(block.extraData).equal(EthImpl.emptyHex);
+        expect(block.miner).equal(EthImpl.zeroAddressHex);
+        expect(block.mixHash).equal(EthImpl.zeroHex32Byte);
+        expect(block.nonce).equal(EthImpl.zeroHex8Byte);
+        expect(block.receiptsRoot).equal(EthImpl.zeroHex32Byte);
+        expect(block.sha3Uncles).equal(EthImpl.emptyArrayHex);
+        expect(block.stateRoot).equal(EthImpl.zeroHex32Byte);
+        expect(block.totalDifficulty).equal(EthImpl.zeroHex);
+        expect(block.uncles).to.deep.equal([]);
     };
 }
 

--- a/packages/relay/tests/assertions.ts
+++ b/packages/relay/tests/assertions.ts
@@ -1,0 +1,15 @@
+
+import { expect } from 'chai';
+import { JsonRpcError } from '../src';
+
+export default class Assertions {
+    static assertRejection = async (error: JsonRpcError, method, checkMessage: boolean, thisObj, args?: any[]): Promise<any> => {
+        return await expect(method.apply(thisObj, args)).to.eventually.be.rejected.and.satisfy((err) => {
+            if(!checkMessage) {
+                return err.code === error.code && err.name === error.name;
+            }
+            return err.code === error.code && err.name === error.name && err.message === error.message;
+        });
+    };
+}
+

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -21,8 +21,7 @@
 import { expect } from "chai";
 import { ethers } from 'ethers';
 import crypto from 'crypto';
-import {EthImpl} from "../src/lib/eth";
-import {Block, Transaction} from "../src/lib/model";
+import { EthImpl } from "../src/lib/eth";
 import { formatRequestIdMessage } from '../src/formatters';
 import { v4 as uuid } from 'uuid';
 
@@ -77,118 +76,6 @@ export const ethGetLogsFailing = async (ethImpl, args, assertFunc) => {
     }
     expect(hasError).to.eq(true);
 };
-
-export const validateHash = (hash: string, len?: number) => {
-    let regex;
-    if (len && len > 0) {
-        regex = new RegExp(`^0x[a-f0-9]{${len}}$`);
-    } else {
-        regex = /^0x[a-f0-9]*$/;
-    }
-
-    return !!regex.exec(hash);
-};
-
-export const assertTransactionReceipt = (receipt, expectedReceipt) => {
-    expect(receipt).to.exist;
-    if (receipt == null) return;
-
-    expect(validateHash(receipt.transactionHash, 64)).to.eq(true);
-    expect(validateHash(receipt.blockHash, 64)).to.eq(true);
-    expect(validateHash(receipt.from, 40)).to.eq(true);
-    if (receipt.contractAddress) {
-        expect(validateHash(receipt.contractAddress, 40)).to.eq(true);
-    }
-    if (receipt.to) {
-        expect(validateHash(receipt.to, 40)).to.eq(true);
-    }
-    expect(validateHash(receipt.logsBloom, 512)).to.eq(true);
-    if (receipt.root) {
-        expect(validateHash(receipt.root, 64)).to.eq(true);
-    }
-
-    expect(receipt.transactionHash).to.exist;
-    expect(receipt.transactionHash).to.eq(expectedReceipt.transactionHash);
-    expect(receipt.transactionIndex).to.exist;
-    expect(receipt.blockHash).to.eq(expectedReceipt.blockHash);
-    expect(receipt.blockNumber).to.eq(expectedReceipt.blockNumber);
-    expect(receipt.from).to.eq(expectedReceipt.from);
-    expect(receipt.to).to.eq(expectedReceipt.to);
-    expect(receipt.cumulativeGasUsed).to.eq(expectedReceipt.cumulativeGasUsed);
-    expect(receipt.gasUsed).to.eq(expectedReceipt.gasUsed);
-    expect(receipt.contractAddress).to.eq(expectedReceipt.contractAddress);
-    expect(receipt.logs).to.deep.eq(expectedReceipt.logs);
-    expect(receipt.logsBloom).to.eq(expectedReceipt.logsBloom);
-    expect(receipt.root).to.eq(expectedReceipt.root);
-    expect(receipt.status).to.eq(expectedReceipt.status);
-    expect(receipt.effectiveGasPrice).to.eq(expectedReceipt.effectiveGasPrice);
-};
-
-export const assertTransaction = (tx, expectedTx) => {
-
-    expect(tx).to.exist;
-    if (tx == null) return;
-
-    expect(tx.accessList).to.eq(expectedTx.accessList);
-    expect(tx.blockHash).to.eq(expectedTx.blockHash);
-    expect(tx.blockNumber).to.eq(expectedTx.blockNumber);
-    expect(tx.chainId).to.eq(expectedTx.chainId);
-    expect(tx.from).to.eq(expectedTx.from);
-    expect(tx.gas).to.eq(expectedTx.gas);
-    expect(tx.gasPrice).to.eq(expectedTx.gasPrice);
-    expect(tx.hash).to.eq(expectedTx.hash);
-    expect(tx.input).to.eq(expectedTx.input);
-    expect(tx.maxFeePerGas).to.eq(expectedTx.maxFeePerGas);
-    expect(tx.maxPriorityFeePerGas).to.eq(expectedTx.maxPriorityFeePerGas);
-    expect(tx.nonce).to.eq(EthImpl.numberTo0x(expectedTx.nonce));
-    expect(tx.r).to.eq(expectedTx.r);
-    expect(tx.s).to.eq(expectedTx.s);
-    expect(tx.to).to.eq(expectedTx.to);
-    expect(tx.transactionIndex).to.eq(expectedTx.transactionIndex);
-    expect(tx.type).to.eq(EthImpl.numberTo0x(expectedTx.type));
-    expect(tx.v).to.eq(EthImpl.numberTo0x(expectedTx.v));
-    expect(tx.value).to.eq(expectedTx.value);
-};
-
-export const assertBlock = (block, expectedBlock, txDetails = false) => {
-    expect(block).to.exist;
-    expect(block).to.not.be.null;
-
-    // verify aggregated info
-    expect(block.hash).equal(expectedBlock.hash);
-    expect(block.gasUsed).equal(expectedBlock.gasUsed);
-    expect(block.number).equal(expectedBlock.number);
-    expect(block.parentHash).equal(expectedBlock.parentHash);
-    expect(block.timestamp).equal(expectedBlock.timestamp);
-    expect(block.transactions.length).equal(expectedBlock.transactions.length);
-    for (let i = 0; i < expectedBlock.transactions.length; i++) {
-        if (!txDetails) {
-            expect(block.transactions[i] as string).equal(expectedBlock.transactions[i]);
-        }
-        else {
-            expect((block.transactions[i] as Transaction).hash).equal(expectedBlock.transactions[i]);
-        }
-    }
-
-    // verify expected constants
-    verifyBlockConstants(block);
-};
-
-export const verifyBlockConstants = (block: Block) => {
-    expect(block.gasLimit).equal(EthImpl.numberTo0x(15000000));
-    expect(block.baseFeePerGas).equal('0x84b6a5c400');
-    expect(block.difficulty).equal(EthImpl.zeroHex);
-    expect(block.extraData).equal(EthImpl.emptyHex);
-    expect(block.miner).equal(EthImpl.zeroAddressHex);
-    expect(block.mixHash).equal(EthImpl.zeroHex32Byte);
-    expect(block.nonce).equal(EthImpl.zeroHex8Byte);
-    expect(block.receiptsRoot).equal(EthImpl.zeroHex32Byte);
-    expect(block.sha3Uncles).equal(EthImpl.emptyArrayHex);
-    expect(block.stateRoot).equal(EthImpl.zeroHex32Byte);
-    expect(block.totalDifficulty).equal(EthImpl.zeroHex);
-    expect(block.uncles).to.deep.equal([]);
-};
-
 
 export const expectLogData = (res, log, tx) => {
     expect(res.address).to.eq(log.address);

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -64,7 +64,7 @@ export const ethCallFailing = async (ethImpl, args, block, assertFunc) => {
         assertFunc(error);
     }
     expect(hasError).to.eq(true);
-}
+};
 
 export const ethGetLogsFailing = async (ethImpl, args, assertFunc) => {
     let hasError = false;
@@ -76,7 +76,7 @@ export const ethGetLogsFailing = async (ethImpl, args, assertFunc) => {
         assertFunc(error);
     }
     expect(hasError).to.eq(true);
-}
+};
 
 export const validateHash = (hash: string, len?: number) => {
     let regex;
@@ -122,7 +122,7 @@ export const assertTransactionReceipt = (receipt, expectedReceipt) => {
     expect(receipt.root).to.eq(expectedReceipt.root);
     expect(receipt.status).to.eq(expectedReceipt.status);
     expect(receipt.effectiveGasPrice).to.eq(expectedReceipt.effectiveGasPrice);
-}
+};
 
 export const assertTransaction = (tx, expectedTx) => {
 
@@ -148,7 +148,7 @@ export const assertTransaction = (tx, expectedTx) => {
     expect(tx.type).to.eq(EthImpl.numberTo0x(expectedTx.type));
     expect(tx.v).to.eq(EthImpl.numberTo0x(expectedTx.v));
     expect(tx.value).to.eq(expectedTx.value);
-}
+};
 
 export const assertBlock = (block, expectedBlock, txDetails = false) => {
     expect(block).to.exist;
@@ -172,7 +172,7 @@ export const assertBlock = (block, expectedBlock, txDetails = false) => {
 
     // verify expected constants
     verifyBlockConstants(block);
-}
+};
 
 export const verifyBlockConstants = (block: Block) => {
     expect(block.gasLimit).equal(EthImpl.numberTo0x(15000000));
@@ -447,7 +447,7 @@ export const contractTimestamp2 = '1653077542.701408897';
 export const contractTimestamp3 = '1653088542.123456789';
 export const contractId1 = '0.0.5001';
 export const contractId2 = '0.0.5002';
-export const signedTransactionHash = '0x02f87482012a0485a7a358200085a7a3582000832dc6c09400000000000000000000000000000000000003f78502540be40080c001a006f4cd8e6f84b76a05a5c1542a08682c928108ef7163d9c1bf1f3b636b1cd1fba032097cbf2dda17a2dcc40f62c97964d9d930cdce2e8a9df9a8ba023cda28e4ad'
+export const signedTransactionHash = '0x02f87482012a0485a7a358200085a7a3582000832dc6c09400000000000000000000000000000000000003f78502540be40080c001a006f4cd8e6f84b76a05a5c1542a08682c928108ef7163d9c1bf1f3b636b1cd1fba032097cbf2dda17a2dcc40f62c97964d9d930cdce2e8a9df9a8ba023cda28e4ad';
 
 export const defaultBlock = {
     'count': blockTransactionCount,
@@ -797,7 +797,7 @@ export const buildCryptoTransferTransaction = (from, to, amount, args: any = {})
     ],
         "valid_duration_seconds": "120",
         "valid_start_timestamp": "1669207645.620109637"
-    }
+    };
 };
 
 export const defaultCallData = {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -39,17 +39,12 @@ import {
   mockData,
   signTransaction,
   ethCallFailing,
-  validateHash,
-  assertTransactionReceipt,
-  assertTransaction,
-  assertBlock,
   ethGetLogsFailing,
   defaultDetailedContractResults,
   defaultLogs1,
   defaultLogs2,
   defaultLogs3,
   defaultContractResults,
-  verifyBlockConstants,
   expectLogData,
   expectLogData1,
   expectLogData2,
@@ -68,7 +63,7 @@ import HAPIService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
 import { Hbar, HbarUnit, TransactionId } from '@hashgraph/sdk';
 import chaiAsPromised from 'chai-as-promised';
-import Assertions from '../assertions';
+import RelayAssertions from '../assertions';
 import {v4 as uuid} from 'uuid';
 import { JsonRpcError } from '../../dist';
 
@@ -514,7 +509,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     const error = predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK;
 
-    await Assertions.assertRejection(error, ethImpl.blockNumber, true, ethImpl);
+    await RelayAssertions.assertRejection(error, ethImpl.blockNumber, true, ethImpl);
   });
 
   it('"eth_blockNumber" return the latest block number on second try', async function () {
@@ -569,7 +564,7 @@ describe('Eth calls using MirrorNode', async function () {
       }
     });
 
-    await Assertions.assertRejection(predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK, ethImpl.blockNumber, true, ethImpl);
+    await RelayAssertions.assertRejection(predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK, ethImpl.blockNumber, true, ethImpl);
   });
 
   it('eth_getBlockByNumber with match', async function () {
@@ -583,7 +578,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
     const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
 
-    assertBlock(result, {
+    RelayAssertions.assertBlock(result, {
       hash: blockHashTrimmed,
       gasUsed: totalGasUsed,
       number: blockNumberHex,
@@ -606,7 +601,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
     const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
 
-    assertBlock(result, {
+    RelayAssertions.assertBlock(result, {
       hash: blockHashTrimmed,
       gasUsed: totalGasUsed,
       number: blockNumberHex,
@@ -655,7 +650,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result.transactionsRoot).equal(EthImpl.ethEmptyTrie);
 
     // verify expected constants
-    verifyBlockConstants(result);
+    RelayAssertions.verifyBlockConstants(result);
   });
 
   it('eth_getBlockByNumber with match and details', async function () {
@@ -688,7 +683,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect((result.transactions[1] as Transaction).gas).equal("0x0");
 
     // verify expected constants
-    verifyBlockConstants(result);
+    RelayAssertions.verifyBlockConstants(result);
   });
 
   it('eth_getBlockByNumber with match and details paginated', async function () {
@@ -723,7 +718,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect((result.transactions[1] as Transaction).gas).equal("0x0");
 
     // verify expected constants
-    verifyBlockConstants(result);
+    RelayAssertions.verifyBlockConstants(result);
   });
 
   it('eth_getBlockByNumber with block match and contract revert', async function () {
@@ -748,7 +743,7 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result.transactions.length).equal(0);
 
     // verify expected constants
-    verifyBlockConstants(result);
+    RelayAssertions.verifyBlockConstants(result);
   });
 
   it('eth_getBlockByNumber with no match', async function () {
@@ -872,7 +867,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
     const result = await ethImpl.getBlockByHash(blockHash, false);
-    assertBlock(result, {
+    RelayAssertions.assertBlock(result, {
       hash: blockHashTrimmed,
       gasUsed: totalGasUsed,
       number: blockNumberHex,
@@ -894,7 +889,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
     const result = await ethImpl.getBlockByHash(blockHash, false);
-    assertBlock(result, {
+    RelayAssertions.assertBlock(result, {
       hash: blockHashTrimmed,
       gasUsed: totalGasUsed,
       number: blockNumberHex,
@@ -918,7 +913,7 @@ describe('Eth calls using MirrorNode', async function () {
       expect(result).to.not.be.null;
       expect(result.hash).equal(blockHashTrimmed);
       expect(result.number).equal(blockNumberHex);
-      verifyBlockConstants(result);
+      RelayAssertions.verifyBlockConstants(result);
     }
   });
 
@@ -933,7 +928,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     const result = await ethImpl.getBlockByHash(blockHash, true);
 
-    assertBlock(result, {
+    RelayAssertions.assertBlock(result, {
       hash: blockHashTrimmed,
       gasUsed: totalGasUsed,
       number: blockNumberHex,
@@ -955,7 +950,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
     const result = await ethImpl.getBlockByHash(blockHash, true);
-    assertBlock(result, {
+    RelayAssertions.assertBlock(result, {
       hash: blockHashTrimmed,
       gasUsed: totalGasUsed,
       number: blockNumberHex,
@@ -974,7 +969,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, { logs: [] });
 
     const result = await ethImpl.getBlockByHash(blockHash, true);
-    assertBlock(result, {
+    RelayAssertions.assertBlock(result, {
       hash: blockHashTrimmed,
       gasUsed: EthImpl.numberTo0x(gasUsed1),
       number: blockNumberHex,
@@ -1011,7 +1006,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet('network/fees').reply(200, defaultNetworkFees);
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
-    await Assertions.assertRejection(predefined.INTERNAL_ERROR(), ethImpl.getBlockByHash, false, ethImpl, [blockHash, false]);
+    await RelayAssertions.assertRejection(predefined.INTERNAL_ERROR(), ethImpl.getBlockByHash, false, ethImpl, [blockHash, false]);
   });
 
   it('eth_getBlockTransactionCountByNumber with match', async function () {
@@ -1167,7 +1162,7 @@ describe('Eth calls using MirrorNode', async function () {
     const args = [EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count)];
     const errMessage = "Cannot read properties of null (reading 'substring')";
 
-    await Assertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionByBlockNumberAndIndex, true, ethImpl, args);
+    await RelayAssertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionByBlockNumberAndIndex, true, ethImpl, args);
   });
 
   it('eth_getTransactionByBlockNumberAndIndex with no contract results', async function () {
@@ -1266,18 +1261,10 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results?block.hash=${defaultBlock.hash}&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
     restMock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, {...defaultDetailedContractResults, block_hash: null });
 
-    // try {
-    //   await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count));
-    // } catch (e) {
-    //   console.log("EEERRRROOOR ------>", e);
-    //   expect(e.code).to.equal(-32603);
-    //   expect(e.name).to.equal('Internal error');
-    // }
-
     const args = [defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count)];
     const errMessage = "Cannot read properties of null (reading 'substring')";
 
-    await Assertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionByBlockHashAndIndex, true, ethImpl, args);
+    await RelayAssertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionByBlockHashAndIndex, true, ethImpl, args);
   });
 
   it('eth_getTransactionByBlockHashAndIndex with no contract result match', async function () {
@@ -1343,19 +1330,9 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('network/fees').reply(200, defaultNetworkFees);
       restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
-      // try{
-      //   await ethImplLowTransactionCount.getBlockByHash(blockHash, true);
-      // } catch(e) {
-      //   console.log("ERRROOOR --->", e);
-      //   expect(e).to.be.an.instanceof(JsonRpcError);
-      //   expect(e.code).to.equal(-32000);
-      //   expect(e.message).to.equal(`Exceeded max transactions that can be returned in a block: 77`);
-      //   expect(e.name).to.equal('Block size too large');
-      // }  
-
     const args = [blockHash, true];
 
-    await Assertions.assertRejection(predefined.MAX_BLOCK_SIZE(77), ethImplLowTransactionCount.getBlockByHash, true, ethImplLowTransactionCount, args);
+    await RelayAssertions.assertRejection(predefined.MAX_BLOCK_SIZE(77), ethImplLowTransactionCount.getBlockByHash, true, ethImplLowTransactionCount, args);
     });
 
     it('eth_getBlockByNumber with greater number of transactions than the ETH_GET_TRANSACTION_COUNT_MAX_BLOCK_RANGE', async function () {
@@ -1368,18 +1345,9 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('network/fees').reply(200, defaultNetworkFees);
       restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
-      // try{
-      //   await ethImplLowTransactionCount.getBlockByNumber(EthImpl.numberTo0x(blockNumber), true);
-      // } catch(e) {
-      //   expect(e).to.be.an.instanceof(JsonRpcError);
-      //   expect(e.code).to.equal(-32000);
-      //   expect(e.message).to.equal(`Exceeded max transactions that can be returned in a block: 77`);
-      //   expect(e.name).to.equal('Block size too large');
-      // }
-
     const args = [EthImpl.numberTo0x(blockNumber), true];
 
-    await Assertions.assertRejection(predefined.MAX_BLOCK_SIZE(77), ethImplLowTransactionCount.getBlockByNumber, true, ethImplLowTransactionCount, args);
+    await RelayAssertions.assertRejection(predefined.MAX_BLOCK_SIZE(77), ethImplLowTransactionCount.getBlockByNumber, true, ethImplLowTransactionCount, args);
     });
 
   });
@@ -3202,7 +3170,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       restMock.onGet(`network/fees`).reply(200, partialNetworkFees);
 
-      await Assertions.assertRejection(predefined.COULD_NOT_ESTIMATE_GAS_PRICE, ethImpl.gasPrice, true, ethImpl);
+      await RelayAssertions.assertRejection(predefined.COULD_NOT_ESTIMATE_GAS_PRICE, ethImpl.gasPrice, true, ethImpl);
     });
 
     it('eth_gasPrice with mirror node return network fees found', async function () {
@@ -3235,7 +3203,7 @@ describe('Eth calls using MirrorNode', async function () {
         }
       });
 
-      await Assertions.assertRejection(predefined.COULD_NOT_ESTIMATE_GAS_PRICE, ethImpl.gasPrice, true, ethImpl);
+      await RelayAssertions.assertRejection(predefined.COULD_NOT_ESTIMATE_GAS_PRICE, ethImpl.gasPrice, true, ethImpl);
     });
   });
 
@@ -3648,7 +3616,7 @@ describe('Eth calls using MirrorNode', async function () {
           "gas": 50_000_000
         }, 'latest'];
 
-        await Assertions.assertRejection(predefined.GAS_LIMIT_TOO_HIGH(50000000, constants.BLOCK_GAS_LIMIT), ethImpl.call, false, ethImpl, args);
+        await RelayAssertions.assertRejection(predefined.GAS_LIMIT_TOO_HIGH(50000000, constants.BLOCK_GAS_LIMIT), ethImpl.call, false, ethImpl, args);
       });
     });
 
@@ -3682,7 +3650,7 @@ describe('Eth calls using MirrorNode', async function () {
         "gas": maxGasLimitHex
       }, 'latest'];
 
-      await Assertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(wrongContractAddress), ethImpl.call, false, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(wrongContractAddress), ethImpl.call, false, ethImpl, args);
     });
 
     it('eth_call throws internal error when consensus node times out and submitContractCallQueryWithRetry returns undefined', async function () {
@@ -3945,17 +3913,6 @@ describe('Eth calls using MirrorNode', async function () {
     });
 
     it('eth_call with missing `to` field', async function() {
-      // try {
-      //   await ethImpl.call({
-      //     ...defaultCallData,
-      //     "from": contractAddress1,
-      //     "data": contractCallData,
-      //     "gas": maxGasLimit
-      //   }, 'latest');
-      // } catch (error: any) {
-      //   expect(error.message).to.equal(`Invalid Contract Address: ${undefined}.`);
-      // }
-
       const args = [{
         ...defaultCallData,
           "from": contractAddress1,
@@ -3963,22 +3920,10 @@ describe('Eth calls using MirrorNode', async function () {
           "gas": maxGasLimit
       }, 'latest'];
 
-      await Assertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(undefined), ethImpl.call, false, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(undefined), ethImpl.call, false, ethImpl, args);
     });
 
     it('eth_call with wrong `to` field', async function() {
-      // try {
-      //   await ethImpl.call({
-      //     ...defaultCallData,
-      //     "from": contractAddress1,
-      //     "to": wrongContractAddress,
-      //     "data": contractCallData,
-      //     "gas": maxGasLimit
-      //   }, 'latest');
-      // } catch (error: any) {
-      //   expect(error.message).to.equal(`Invalid Contract Address: ${wrongContractAddress}. Expected length of 42 chars but was ${wrongContractAddress.length}.`);
-      // }
-
       const args = [{
         ...defaultCallData,
           "from": contractAddress1,
@@ -3986,7 +3931,7 @@ describe('Eth calls using MirrorNode', async function () {
           "gas": maxGasLimit
       }, 'latest'];
 
-      await Assertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(wrongContractAddress), ethImpl.call, false, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(wrongContractAddress), ethImpl.call, false, ethImpl, args);
     });
   });
 
@@ -4019,7 +3964,7 @@ describe('Eth calls using MirrorNode', async function () {
       const args = [txHash];
       const errMessage = 'overflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow ] (fault="overflow", operation="toNumber", value="30678687678687676876786786876876876000", code=NUMERIC_FAULT, version=bignumber/5.7.0)';
 
-      await Assertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.sendRawTransaction, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.sendRawTransaction, true, ethImpl, args);
     });
 
     it('should return a computed hash if unable to retrieve EthereumHash from record due to contract revert', async function () {
@@ -4224,7 +4169,7 @@ describe('Eth calls using MirrorNode', async function () {
                     defaultDetailedContractResults.state_changes[0].slot,
                     EthImpl.numberTo0x(blockNumber)];
 
-      await Assertions.assertRejection(predefined.RESOURCE_NOT_FOUND(), ethImpl.getStorageAt, false, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.RESOURCE_NOT_FOUND(), ethImpl.getStorageAt, false, ethImpl, args);
     });
 
     it('eth_getStorageAt should return EthImpl.zeroHex32Byte when slot wrong', async function () {
@@ -4257,7 +4202,7 @@ describe('Eth calls using MirrorNode', async function () {
                     defaultDetailedContractResults.state_changes[0].slot,
                     EthImpl.numberTo0x(blockNumber)];
 
-      await Assertions.assertRejection(predefined.RESOURCE_NOT_FOUND(), ethImpl.getStorageAt, false, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.RESOURCE_NOT_FOUND(), ethImpl.getStorageAt, false, ethImpl, args);
     });
   });
 
@@ -4352,19 +4297,9 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('should throw error for earliest block with invalid block', async() => {
       restMock.onGet(earliestBlockPath).reply(200, { blocks: []});
-      const hasError = false;
-      // try {
-      //   expect(await ethImpl.getTransactionCount(mockData.account.evm_address, EthImpl.blockEarliest)).to.throw();
-      // } catch (error) {
-      //   hasError = true;
-      //   expect(error).to.exist;
-      //   expect(error.message).to.equal(`Error invoking RPC: No network blocks found`);
-      // }
-      // expect(hasError).to.be.true;
-
       const args = [mockData.account.evm_address, EthImpl.blockEarliest];
 
-      await Assertions.assertRejection(predefined.INTERNAL_ERROR('No network blocks found'), ethImpl.getTransactionCount, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.INTERNAL_ERROR('No network blocks found'), ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should throw error for earliest block with non 0 or 1 block', async() => {
@@ -4374,7 +4309,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const errMessage = `Partial mirror node encountered, earliest block number is ${mockData.blocks.blocks[2].number}`;
 
-      await Assertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionCount, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should return zero nonce for contract nonce request on historical numerical block', async() => {
@@ -4390,7 +4325,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const args = [mockData.account.evm_address, blockNumberHex];
 
-      await Assertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should throw error for account historical numerical block tag with error on latest block', async() => {
@@ -4400,7 +4335,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const args = [mockData.account.evm_address, blockNumberHex];
 
-      await Assertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should return valid nonce for historical numerical block close to latest', async() => {
@@ -4452,7 +4387,7 @@ describe('Eth calls using MirrorNode', async function () {
       const args = [mockData.account.evm_address, blockNumberHex];
       const errMessage = `Failed to retrieve contract results for transaction ${transactionId}`;
 
-      await Assertions.assertRejection(predefined.RESOURCE_NOT_FOUND(errMessage), ethImpl.getTransactionCount, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.RESOURCE_NOT_FOUND(errMessage), ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should return valid nonce for historical numerical block when contract result sender is not address', async() => {
@@ -4483,35 +4418,15 @@ describe('Eth calls using MirrorNode', async function () {
     });
 
     it('should throw for -1 invalid block tag', async() => {
-      // let hasError = false;
-      // try {
-      //   expect(await ethImpl.getTransactionCount(mockData.account.evm_address, '-1')).to.throw();
-      // } catch (error) {
-      //   hasError = true;
-      //   expect(error).to.exist;
-      //   expect(error.message).to.equal(`Unknown block`);
-      // }
-      // expect(hasError).to.be.true;
-      
       const args = [mockData.account.evm_address, '-1'];
 
-      await Assertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should throw for invalid block tag', async() => {
-      // let hasError = false;
-      // try {
-      //   expect(await ethImpl.getTransactionCount(mockData.account.evm_address, 'notablock')).to.throw();
-      // } catch (error) {
-      //   hasError = true;
-      //   expect(error).to.exist;
-      //   expect(error.message).to.equal(`Unknown block`);
-      // }
-      // expect(hasError).to.be.true;
-
       const args = [mockData.account.evm_address, 'notablock'];
 
-      await Assertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
     });
   });
 });
@@ -4755,7 +4670,7 @@ describe('Eth', async function () {
       const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
 
       // Assert the data format
-      assertTransactionReceipt(receipt, defaultReceipt);
+      RelayAssertions.assertTransactionReceipt(receipt, defaultReceipt);
     });
 
     it('valid receipt on match should hit cache', async function() {
@@ -4766,7 +4681,7 @@ describe('Eth', async function () {
         const receipt = await ethImpl.getTransactionReceipt(defaultTxHash);
         expect(receipt).to.exist;
         if (receipt == null) return;
-        expect(validateHash(receipt.transactionHash, 64)).to.eq(true);
+        expect(RelayAssertions.validateHash(receipt.transactionHash, 64)).to.eq(true);
         expect(receipt.transactionHash).to.exist;
         expect(receipt.to).to.eq(defaultReceipt.to);
         expect(receipt.contractAddress).to.eq(defaultReceipt.contractAddress);
@@ -4785,9 +4700,9 @@ describe('Eth', async function () {
       expect(receipt).to.exist;
       if (receipt == null) return;
 
-      expect(validateHash(receipt.from, 40)).to.eq(true);
+      expect(RelayAssertions.validateHash(receipt.from, 40)).to.eq(true);
       if (receipt.contractAddress) {
-        expect(validateHash(receipt.contractAddress, 40)).to.eq(true);
+        expect(RelayAssertions.validateHash(receipt.contractAddress, 40)).to.eq(true);
       }
       expect(receipt.contractAddress).to.eq(contractEvmAddress);
     });
@@ -4961,7 +4876,7 @@ describe('Eth', async function () {
       });
 
       const result = await ethImpl.getTransactionByHash(defaultTxHash);
-      assertTransaction(result, defaultTransaction);
+      RelayAssertions.assertTransaction(result, defaultTransaction);
     });
 
     it('returns correct transaction for existing hash w no sigs', async function () {
@@ -4980,7 +4895,7 @@ describe('Eth', async function () {
         evm_address: `${defaultTransaction.from}`
       });
       const result = await ethImpl.getTransactionByHash(uniqueTxHash);
-      assertTransaction(result, {
+      RelayAssertions.assertTransaction(result, {
         ...defaultTransaction,
         r: null,
         s: null
@@ -5119,7 +5034,7 @@ describe('Eth', async function () {
       });
 
       const result = await ethImpl.getTransactionByHash(defaultTxHash);
-      assertTransaction(result, defaultTransaction);
+      RelayAssertions.assertTransaction(result, defaultTransaction);
     });
 
     it('throws error for reverted transactions when DEV_MODE=true', async function () {
@@ -5134,19 +5049,11 @@ describe('Eth', async function () {
         evm_address: `${defaultTransaction.from}`
       });
 
-      // try {
-      //   await ethImpl.getTransactionByHash(uniqueTxHash);
-      //   expect(true).to.eq(false);
-      // }
-      // catch(error) {
-      //   expect(error).to.deep.equal(predefined.CONTRACT_REVERT(defaultDetailedContractResultByHashReverted.error_message, defaultDetailedContractResultByHashReverted.error_message));
-      // }
-
       const args = [uniqueTxHash];
       const errMessage = defaultDetailedContractResultByHashReverted.error_message;
       const data = defaultDetailedContractResultByHashReverted.error_message;
 
-      await Assertions.assertRejection(predefined.CONTRACT_REVERT(errMessage, data), ethImpl.getTransactionByHash, true, ethImpl, args);
+      await RelayAssertions.assertRejection(predefined.CONTRACT_REVERT(errMessage, data), ethImpl.getTransactionByHash, true, ethImpl, args);
       process.env.DEV_MODE = initialDevModeValue;
     });
   });

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  *
  */
-
+import chai from 'chai';
 import path from 'path';
 import dotenv from 'dotenv';
 import MockAdapter from 'axios-mock-adapter';
@@ -26,7 +26,7 @@ import { Registry } from 'prom-client';
 import sinon from 'sinon';
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 import { RelayImpl } from '../../src/lib/relay';
-import { JsonRpcError, predefined } from '../../src/lib/errors/JsonRpcError';
+import { predefined } from '../../src/lib/errors/JsonRpcError';
 import { EthImpl } from '../../src/lib/eth';
 import { MirrorNodeClient } from '../../src/lib/clients/mirrorNodeClient';
 import {
@@ -66,8 +66,11 @@ import { ClientCache, SDKClient } from '../../src/lib/clients';
 import { SDKClientError } from '../../src/lib/errors/SDKClientError';
 import HAPIService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
-import { v4 as uuid } from 'uuid';
 import { Hbar, HbarUnit, TransactionId } from '@hashgraph/sdk';
+import chaiAsPromised from 'chai-as-promised';
+import Assertions from '../assertions';
+
+chai.use(chaiAsPromised);
 
 const LRU = require('lru-cache');
 
@@ -500,11 +503,10 @@ describe('Eth calls using MirrorNode', async function () {
         ]
       }
     });
-    try {
-      await ethImpl.blockNumber();
-    } catch (error: any) {
-      expect(error.message).to.equal('Error encountered retrieving latest block');
-    }
+
+    const error = predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK;
+
+    await Assertions.assertRejection(error, ethImpl.blockNumber, true, ethImpl);
   });
 
   it('"eth_blockNumber" return the latest block number on second try', async function () {
@@ -525,7 +527,7 @@ describe('Eth calls using MirrorNode', async function () {
   });
 
   it('"eth_blockNumber" should throw an error if no blocks are found after third try', async function () {
-    restMock.onGet('blocks?limit=1&order=desc').replyOnce(404, {
+    restMock.onGet('blocks?limit=1&order=desc').reply(404, {
       '_status': {
         'messages': [
           {
@@ -533,7 +535,7 @@ describe('Eth calls using MirrorNode', async function () {
           }
         ]
       }
-    }).onGet('blocks?limit=1&order=desc').replyOnce(404, {
+    }).onGet('blocks?limit=1&order=desc').reply(404, {
       '_status': {
         'messages': [
           {
@@ -541,7 +543,7 @@ describe('Eth calls using MirrorNode', async function () {
           }
         ]
       }
-    }).onGet('blocks?limit=1&order=desc').replyOnce(404, {
+    }).onGet('blocks?limit=1&order=desc').reply(404, {
       '_status': {
         'messages': [
           {
@@ -549,7 +551,7 @@ describe('Eth calls using MirrorNode', async function () {
           }
         ]
       }
-    }).onGet('blocks?limit=1&order=desc').replyOnce(404, {
+    }).onGet('blocks?limit=1&order=desc').reply(404, {
       '_status': {
         'messages': [
           {
@@ -559,11 +561,7 @@ describe('Eth calls using MirrorNode', async function () {
       }
     });
 
-    try {
-      await ethImpl.blockNumber();
-    } catch (error: any) {
-      expect(error.message).to.equal('Error encountered retrieving latest block');
-    }
+    await Assertions.assertRejection(predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK, ethImpl.blockNumber, true, ethImpl);
   });
 
   it('eth_getBlockByNumber with match', async function () {
@@ -584,7 +582,7 @@ describe('Eth calls using MirrorNode', async function () {
       parentHash: blockHashPreviousTrimmed,
       timestamp: blockTimestampHex,
       transactions: [contractHash1, contractHash2]
-    })
+    });
   });
 
   it('eth_getBlockByNumber with match paginated', async function () {
@@ -607,7 +605,7 @@ describe('Eth calls using MirrorNode', async function () {
       parentHash: blockHashPreviousTrimmed,
       timestamp: blockTimestampHex,
       transactions: [contractHash1, contractHash2]
-    })
+    });
   });
 
   it('eth_getBlockByNumber should return cached result', async function() {
@@ -873,7 +871,7 @@ describe('Eth calls using MirrorNode', async function () {
       parentHash: blockHashPreviousTrimmed,
       timestamp: blockTimestampHex,
       transactions: [contractHash1, contractHash2]
-    })
+    });
   });
 
   it('eth_getBlockByHash with match paginated', async function () {
@@ -895,7 +893,7 @@ describe('Eth calls using MirrorNode', async function () {
       parentHash: blockHashPreviousTrimmed,
       timestamp: blockTimestampHex,
       transactions: [contractHash1, contractHash2]
-    })
+    });
   });
 
   it('eth_getBlockByHash should hit cache', async function() {
@@ -934,7 +932,7 @@ describe('Eth calls using MirrorNode', async function () {
       timestamp: blockTimestampHex,
       parentHash: blockHashPreviousTrimmed,
       transactions: [contractHash1, contractHash1]
-    }, true)
+    }, true);
   });
 
   it('eth_getBlockByHash with match and details paginated', async function () {
@@ -956,7 +954,7 @@ describe('Eth calls using MirrorNode', async function () {
       parentHash: blockHashPreviousTrimmed,
       timestamp: blockTimestampHex,
       transactions: [contractHash1, contractHash1]
-    }, true)
+    }, true);
   });
 
   it('eth_getBlockByHash with block match and contract revert', async function () {
@@ -975,7 +973,7 @@ describe('Eth calls using MirrorNode', async function () {
       parentHash: blockHashPreviousTrimmed,
       timestamp: blockTimestampHex,
       transactions: []
-    })
+    });
   });
 
   it('eth_getBlockByHash with no match', async function () {
@@ -1004,13 +1002,15 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet('network/fees').reply(200, defaultNetworkFees);
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
-    try {
-      await ethImpl.getBlockByHash(blockHash, false);
-    } catch (e) {
+    // try {
+    //   await ethImpl.getBlockByHash(blockHash, false);
+    // } catch (e) {
+    //   console.log("Error ------>", e);
+    //   expect(e.code).to.equal(-32603);
+    //   expect(e.name).to.equal('Internal error');
+    // }
 
-      expect(e.code).to.equal(-32603);
-      expect(e.name).to.equal('Internal error');
-    }
+    await Assertions.assertRejection(predefined.INTERNAL_ERROR(), ethImpl.getBlockByHash, false, ethImpl, [blockHash, false]);
   });
 
   it('eth_getBlockTransactionCountByNumber with match', async function () {
@@ -1163,12 +1163,10 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results?block.number=${defaultBlock.number}&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
     restMock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, {...defaultDetailedContractResults, block_hash: null });
 
-    try {
-      await ethImpl.getTransactionByBlockNumberAndIndex(EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count));
-    } catch (e) {
-      expect(e.code).to.equal(-32603);
-      expect(e.name).to.equal('Internal error');
-    }
+    const args = [EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count)];
+    const errMessage = "Cannot read properties of null (reading 'substring')";
+
+    await Assertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionByBlockNumberAndIndex, true, ethImpl, args);
   });
 
   it('eth_getTransactionByBlockNumberAndIndex with no contract results', async function () {
@@ -1267,12 +1265,18 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results?block.hash=${defaultBlock.hash}&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
     restMock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, {...defaultDetailedContractResults, block_hash: null });
 
-    try {
-      await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count));
-    } catch (e) {
-      expect(e.code).to.equal(-32603);
-      expect(e.name).to.equal('Internal error');
-    }
+    // try {
+    //   await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count));
+    // } catch (e) {
+    //   console.log("EEERRRROOOR ------>", e);
+    //   expect(e.code).to.equal(-32603);
+    //   expect(e.name).to.equal('Internal error');
+    // }
+
+    const args = [defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count)];
+    const errMessage = "Cannot read properties of null (reading 'substring')";
+
+    await Assertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionByBlockHashAndIndex, true, ethImpl, args);
   });
 
   it('eth_getTransactionByBlockHashAndIndex with no contract result match', async function () {
@@ -1338,14 +1342,19 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('network/fees').reply(200, defaultNetworkFees);
       restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
-      try{
-        await ethImplLowTransactionCount.getBlockByHash(blockHash, true);
-      } catch(e) {
-        expect(e).to.be.an.instanceof(JsonRpcError);
-        expect(e.code).to.equal(-32000);
-        expect(e.message).to.equal(`Exceeded max transactions that can be returned in a block: 77`);
-        expect(e.name).to.equal('Block size too large');
-      }
+      // try{
+      //   await ethImplLowTransactionCount.getBlockByHash(blockHash, true);
+      // } catch(e) {
+      //   console.log("ERRROOOR --->", e);
+      //   expect(e).to.be.an.instanceof(JsonRpcError);
+      //   expect(e.code).to.equal(-32000);
+      //   expect(e.message).to.equal(`Exceeded max transactions that can be returned in a block: 77`);
+      //   expect(e.name).to.equal('Block size too large');
+      // }  
+
+    const args = [blockHash, true];
+
+    await Assertions.assertRejection(predefined.MAX_BLOCK_SIZE(77), ethImplLowTransactionCount.getBlockByHash, true, ethImplLowTransactionCount, args);
     });
 
     it('eth_getBlockByNumber with greater number of transactions than the ETH_GET_TRANSACTION_COUNT_MAX_BLOCK_RANGE', async function () {
@@ -1358,14 +1367,18 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('network/fees').reply(200, defaultNetworkFees);
       restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
-      try{
-        await ethImplLowTransactionCount.getBlockByNumber(EthImpl.numberTo0x(blockNumber), true);
-      } catch(e) {
-        expect(e).to.be.an.instanceof(JsonRpcError);
-        expect(e.code).to.equal(-32000);
-        expect(e.message).to.equal(`Exceeded max transactions that can be returned in a block: 77`);
-        expect(e.name).to.equal('Block size too large');
-      }
+      // try{
+      //   await ethImplLowTransactionCount.getBlockByNumber(EthImpl.numberTo0x(blockNumber), true);
+      // } catch(e) {
+      //   expect(e).to.be.an.instanceof(JsonRpcError);
+      //   expect(e.code).to.equal(-32000);
+      //   expect(e.message).to.equal(`Exceeded max transactions that can be returned in a block: 77`);
+      //   expect(e.name).to.equal('Block size too large');
+      // }
+
+    const args = [EthImpl.numberTo0x(blockNumber), true];
+
+    await Assertions.assertRejection(predefined.MAX_BLOCK_SIZE(77), ethImplLowTransactionCount.getBlockByNumber, true, ethImplLowTransactionCount, args);
     });
 
   });
@@ -1809,7 +1822,7 @@ describe('Eth calls using MirrorNode', async function () {
         });
 
         const resBalance = await ethImpl.getBalance(contractId1, '2', getRequestId());
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 + 65) * TINYBAR_TO_WEIBAR_COEF_BIGINT)
+        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 + 65) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);
 
       });
@@ -2903,7 +2916,7 @@ describe('Eth calls using MirrorNode', async function () {
       from: "0x81cb089c285e5ee3a7353704fb114955037443af",
       to: "0x5b98Ce3a4D1e1AC55F15Da174D5CeFcc5b8FB994",
       value: "0x1"
-    }
+    };
     web3Mock.onPost('contracts/call', {...callData, estimate: true}).reply(501, {"errorMessage":"","statusCode":501});
 
     const receiverAddress = '0x5b98Ce3a4D1e1AC55F15Da174D5CeFcc5b8FB994';
@@ -2918,7 +2931,7 @@ describe('Eth calls using MirrorNode', async function () {
       data: "0x",
       from: "0x81cb089c285e5ee3a7353704fb114955037443af",
       to: "0x5b98Ce3a4D1e1AC55F15Da174D5CeFcc5b8FB994"
-    }
+    };
     web3Mock.onPost('contracts/call', {...callData, estimate: true}).reply(501, {"errorMessage":"","statusCode":501});
 
     const receiverAddress = '0x5b98Ce3a4D1e1AC55F15Da174D5CeFcc5b8FB994';
@@ -2934,7 +2947,7 @@ describe('Eth calls using MirrorNode', async function () {
     const callData = {
       data: "0x608060405234801561001057600080fd5b506040516107893803806107898339818101604052810190610032919061015a565b806000908051906020019061004892919061004f565b50506102f6565b82805461005b90610224565b90600052602060002090601f01602090048101928261007d57600085556100c4565b82601f1061009657805160ff19168380011785556100c4565b828001600101855582156100c4579182015b828111156100c35782518255916020019190600101906100a8565b5b5090506100d191906100d5565b5090565b5b808211156100ee5760008160009055506001016100d6565b5090565b6000610105610100846101c0565b61019b565b90508281526020810184848401111561011d57600080fd5b6101288482856101f1565b509392505050565b600082601f83011261014157600080fd5b81516101518482602086016100f2565b91505092915050565b60006020828403121561016c57600080fd5b600082015167ffffffffffffffff81111561018657600080fd5b61019284828501610130565b91505092915050565b60006101a56101b6565b90506101b18282610256565b919050565b6000604051905090565b600067ffffffffffffffff8211156101db576101da6102b6565b5b6101e4826102e5565b9050602081019050919050565b60005b8381101561020f5780820151818401526020810190506101f4565b8381111561021e576000848401525b50505050565b6000600282049050600182168061023c57607f821691505b602082108114156102505761024f610287565b5b50919050565b61025f826102e5565b810181811067ffffffffffffffff8211171561027e5761027d6102b6565b5b80604052505050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602260045260246000fd5b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b6000601f19601f8301169050919050565b610484806103056000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c8063a41368621461003b578063cfae321714610057575b600080fd5b6100556004803603810190610050919061022c565b610075565b005b61005f61008f565b60405161006c91906102a6565b60405180910390f35b806000908051906020019061008b929190610121565b5050565b60606000805461009e9061037c565b80601f01602080910402602001604051908101604052809291908181526020018280546100ca9061037c565b80156101175780601f106100ec57610100808354040283529160200191610117565b820191906000526020600020905b8154815290600101906020018083116100fa57829003601f168201915b5050505050905090565b82805461012d9061037c565b90600052602060002090601f01602090048101928261014f5760008555610196565b82601f1061016857805160ff1916838001178555610196565b82800160010185558215610196579182015b8281111561019557825182559160200191906001019061017a565b5b5090506101a391906101a7565b5090565b5b808211156101c05760008160009055506001016101a8565b5090565b60006101d76101d2846102ed565b6102c8565b9050828152602081018484840111156101ef57600080fd5b6101fa84828561033a565b509392505050565b600082601f83011261021357600080fd5b81356102238482602086016101c4565b91505092915050565b60006020828403121561023e57600080fd5b600082013567ffffffffffffffff81111561025857600080fd5b61026484828501610202565b91505092915050565b60006102788261031e565b6102828185610329565b9350610292818560208601610349565b61029b8161043d565b840191505092915050565b600060208201905081810360008301526102c0818461026d565b905092915050565b60006102d26102e3565b90506102de82826103ae565b919050565b6000604051905090565b600067ffffffffffffffff8211156103085761030761040e565b5b6103118261043d565b9050602081019050919050565b600081519050919050565b600082825260208201905092915050565b82818337600083830152505050565b60005b8381101561036757808201518184015260208101905061034c565b83811115610376576000848401525b50505050565b6000600282049050600182168061039457607f821691505b602082108114156103a8576103a76103df565b5b50919050565b6103b78261043d565b810181811067ffffffffffffffff821117156103d6576103d561040e565b5b80604052505050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052602260045260246000fd5b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b6000601f19601f830116905091905056fea264697066735822122070d157c4efbb3fba4a1bde43cbba5b92b69f2fc455a650c0dfb61e9ed3d4bd6364736f6c634300080400330000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b696e697469616c5f6d7367000000000000000000000000000000000000000000",
       from: "0x81cb089c285e5ee3a7353704fb114955037443af",
-    }
+    };
     web3Mock.onPost('contracts/call', {...callData, estimate: true}).reply(200, {result: `0x61A80`});
 
     const gas = await ethImpl.estimateGas(callData, null);
@@ -3188,12 +3201,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       restMock.onGet(`network/fees`).reply(200, partialNetworkFees);
 
-      try {
-        await ethImpl.gasPrice();
-      } catch (error: any) {
-        expect(error.message).to.equal(predefined.COULD_NOT_ESTIMATE_GAS_PRICE.message);
-        expect(error.code).to.equal(predefined.COULD_NOT_ESTIMATE_GAS_PRICE.code);
-      }
+      await Assertions.assertRejection(predefined.COULD_NOT_ESTIMATE_GAS_PRICE, ethImpl.gasPrice, true, ethImpl);
     });
 
     it('eth_gasPrice with mirror node return network fees found', async function () {
@@ -3226,12 +3234,7 @@ describe('Eth calls using MirrorNode', async function () {
         }
       });
 
-      try {
-        await ethImpl.gasPrice();
-      } catch (error: any) {
-        expect(error.message).to.equal(predefined.COULD_NOT_ESTIMATE_GAS_PRICE.message);
-        expect(error.code).to.equal(predefined.COULD_NOT_ESTIMATE_GAS_PRICE.code);
-      }
+      await Assertions.assertRejection(predefined.COULD_NOT_ESTIMATE_GAS_PRICE, ethImpl.gasPrice, true, ethImpl);
     });
   });
 
@@ -3257,7 +3260,7 @@ describe('Eth calls using MirrorNode', async function () {
         "gas": maxGasLimitHex
       }, 'latest', (error) => {
         expect(error.message).to.equal(`Invalid Contract Address: ${undefined}.`);
-      })
+      });
     });
 
     it('eth_call with incorrect `to` field length', async function() {
@@ -3268,7 +3271,7 @@ describe('Eth calls using MirrorNode', async function () {
         "gas": maxGasLimitHex
       }, 'latest', (error) => {
         expect(error.message).to.equal(`Invalid Contract Address: ${EthImpl.zeroHex}. Expected length of 42 chars but was 3.`);
-      })
+      });
     });
 
     it('should execute "eth_call" against mirror node with a false ETH_CALL_DEFAULT_TO_CONSENSUS_NODE', async function () {
@@ -3337,7 +3340,7 @@ describe('Eth calls using MirrorNode', async function () {
       }, 'latest', (error) => {
         expect(error).to.be.not.null;
         expect(error.code).to.equal(predefined.GAS_LIMIT_TOO_HIGH(excessiveGasLimit, constants.BLOCK_GAS_LIMIT).code);
-      })
+      });
     });
 
     it('block 0', async function () {
@@ -3359,7 +3362,7 @@ describe('Eth calls using MirrorNode', async function () {
         expect(error.code).to.equal(predefineError.code);
         expect(error.name).to.equal(predefineError.name);
         expect(error.message).to.equal(predefineError.message);
-      })
+      });
     });
 
     it('block 1', async function () {
@@ -3381,7 +3384,7 @@ describe('Eth calls using MirrorNode', async function () {
         expect(error.code).to.equal(predefineError.code);
         expect(error.name).to.equal(predefineError.name);
         expect(error.message).to.equal(predefineError.message);
-      })
+      });
     });
 
     it('block earliest', async function () {
@@ -3403,7 +3406,7 @@ describe('Eth calls using MirrorNode', async function () {
         expect(error.code).to.equal(predefineError.code);
         expect(error.name).to.equal(predefineError.name);
         expect(error.message).to.equal(predefineError.message);
-      })
+      });
     });
 
     it('block hash not supported', async function () {
@@ -3425,7 +3428,7 @@ describe('Eth calls using MirrorNode', async function () {
         expect(error.code).to.equal(predefineError.code);
         expect(error.name).to.equal(predefineError.name);
         expect(error.message).to.equal(predefineError.message);
-      })
+      });
     });
 
     it('latest block but not found for comparison', async function () {
@@ -3448,7 +3451,7 @@ describe('Eth calls using MirrorNode', async function () {
         expect(error.code).to.equal(predefineError.code);
         expect(error.name).to.equal(predefineError.name);
         expect(error.message).to.equal(predefineError.message);
-      })
+      });
     });
 
     it('to field is not a contract or token', async function () {
@@ -3459,20 +3462,14 @@ describe('Eth calls using MirrorNode', async function () {
       });
       restMock.onGet(`contracts/${contractAddress2}`).reply(404);
       restMock.onGet(`tokens/${contractId2}`).reply(404);
+      web3Mock.onPost(`contracts/call`).reply(200, {result: '0x1'});
 
-      try {
-        await ethImpl.call({
-          "from": accountAddress1,
-          "to": contractAddress2,
-          "data": contractCallData,
-          "gas": maxGasLimitHex
-        }, 'latest');
-      } catch (error: any) {
-        const predefineError = predefined.NON_EXISTING_CONTRACT(contractAddress2);
-        expect(error.code).to.equal(predefineError.code);
-        expect(error.name).to.equal(predefineError.name);
-        expect(error.message).to.equal(predefineError.message);
-      }
+      await expect(ethImpl.call({
+            "from": accountAddress1,
+            "to": contractAddress2,
+            "data": contractCallData,
+            "gas": maxGasLimitHex
+          }, 'latest')).to.eventually.be.fulfilled.and.equal("0x1");
     });
   });
 
@@ -3617,18 +3614,15 @@ describe('Eth calls using MirrorNode', async function () {
       }
 
       await new Promise(r => setTimeout(r, 200));
-      try {
-        await ethImpl.call({
-          "from": accountAddress1,
-          "to": contractAddress2,
-          "data": contractCallData,
-          "gas": maxGasLimitHex
-        }, 'latest');
-      } catch (error) {
-        expect(error.code).to.equal(predefined.INTERNAL_ERROR().code);
-        expect(error.name).to.equal(predefined.INTERNAL_ERROR().name);
-      }
 
+      const args = [{
+        "from": accountAddress1,
+        "to": contractAddress2,
+        "data": contractCallData,
+        "gas": maxGasLimitHex
+      }, 'latest'];
+
+      await Assertions.assertRejection(predefined.INTERNAL_ERROR(), ethImpl.call, false, ethImpl, args);
     });
 
     describe('with gas > 15_000_000', async function() {      
@@ -3637,17 +3631,13 @@ describe('Eth calls using MirrorNode', async function () {
 
         sdkClientStub.submitContractCallQueryWithRetry.returns(undefined);
 
-        try {
-          await ethImpl.call({
-            "to": contractAddress2,
-            "data": contractCallData,
-            "gas": 50_000_000
-          }, 'latest');
-        } catch (error: any) {
-          expect(error.code).to.equal(-32005);
-          expect(error.name).to.equal('gasLimit too high');
-          expect(error.message).to.equal(`Transaction gas limit '50000000' exceeds block gas limit '${constants.BLOCK_GAS_LIMIT}'`);
-        }
+        const args = [{
+          "to": contractAddress2,
+          "data": contractCallData,
+          "gas": 50_000_000
+        }, 'latest'];
+  
+        await Assertions.assertRejection(predefined.GAS_LIMIT_TOO_HIGH(50000000, constants.BLOCK_GAS_LIMIT), ethImpl.call, false, ethImpl, args);
       });
     });
 
@@ -3674,16 +3664,14 @@ describe('Eth calls using MirrorNode', async function () {
     });
 
     it('eth_call with wrong `to` field', async function() {
-      try {
-        await ethImpl.call({
-          "from": contractAddress1,
-          "to": wrongContractAddress,
-          "data": contractCallData,
-          "gas": maxGasLimitHex
-        }, 'latest');
-      } catch (error: any) {
-        expect(error.message).to.equal(`Invalid Contract Address: ${wrongContractAddress}. Expected length of 42 chars but was ${wrongContractAddress.length}.`);
-      }
+      const args = [{
+        "from": contractAddress1,
+        "to": wrongContractAddress,
+        "data": contractCallData,
+        "gas": maxGasLimitHex
+      }, 'latest'];
+
+      await Assertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(wrongContractAddress), ethImpl.call, false, ethImpl, args);
     });
 
     it('eth_call throws internal error when consensus node times out and submitContractCallQueryWithRetry returns undefined', async function () {
@@ -3723,6 +3711,7 @@ describe('Eth calls using MirrorNode', async function () {
     //temporary workaround until precompiles are implemented in Mirror node evm module
     beforeEach(() => {
       restMock.onGet(`tokens/${defaultContractResults.results[1].contract_id}`).reply(404, null);
+      web3Mock.reset();
     });
 
     it('eth_call with all fields, but mirror-node returns empty response', async function () {
@@ -3954,30 +3943,48 @@ describe('Eth calls using MirrorNode', async function () {
     });
 
     it('eth_call with missing `to` field', async function() {
-      try {
-        await ethImpl.call({
-          ...defaultCallData,
+      // try {
+      //   await ethImpl.call({
+      //     ...defaultCallData,
+      //     "from": contractAddress1,
+      //     "data": contractCallData,
+      //     "gas": maxGasLimit
+      //   }, 'latest');
+      // } catch (error: any) {
+      //   expect(error.message).to.equal(`Invalid Contract Address: ${undefined}.`);
+      // }
+
+      const args = [{
+        ...defaultCallData,
           "from": contractAddress1,
           "data": contractCallData,
           "gas": maxGasLimit
-        }, 'latest');
-      } catch (error: any) {
-        expect(error.message).to.equal(`Invalid Contract Address: ${undefined}.`);
-      }
+      }, 'latest'];
+
+      await Assertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(undefined), ethImpl.call, false, ethImpl, args);
     });
 
     it('eth_call with wrong `to` field', async function() {
-      try {
-        await ethImpl.call({
-          ...defaultCallData,
+      // try {
+      //   await ethImpl.call({
+      //     ...defaultCallData,
+      //     "from": contractAddress1,
+      //     "to": wrongContractAddress,
+      //     "data": contractCallData,
+      //     "gas": maxGasLimit
+      //   }, 'latest');
+      // } catch (error: any) {
+      //   expect(error.message).to.equal(`Invalid Contract Address: ${wrongContractAddress}. Expected length of 42 chars but was ${wrongContractAddress.length}.`);
+      // }
+
+      const args = [{
+        ...defaultCallData,
           "from": contractAddress1,
-          "to": wrongContractAddress,
           "data": contractCallData,
           "gas": maxGasLimit
-        }, 'latest');
-      } catch (error: any) {
-        expect(error.message).to.equal(`Invalid Contract Address: ${wrongContractAddress}. Expected length of 42 chars but was ${wrongContractAddress.length}.`);
-      }
+      }, 'latest'];
+
+      await Assertions.assertRejection(predefined.INVALID_CONTRACT_ADDRESS(wrongContractAddress), ethImpl.call, false, ethImpl, args);
     });
   });
 
@@ -4005,16 +4012,12 @@ describe('Eth calls using MirrorNode', async function () {
       // tx with 'gasLimit: BigNumber { value: "30678687678687676876786786876876876000" }'
       const txHash = '0x02f881820128048459682f0086014fa0186f00901714801554cbe52dd95512bedddf68e09405fba803be258049a27b820088bab1cad205887185174876e80080c080a0cab3f53602000c9989be5787d0db637512acdd2ad187ce15ba83d10d9eae2571a07802515717a5a1c7d6fa7616183eb78307b4657d7462dbb9e9deca820dd28f62';
 
-      let hasError = false;
       restMock.onGet('network/fees').reply(200, defaultNetworkFees);
-      try {
-        await ethImpl.sendRawTransaction(txHash);
-      } catch (e) {
-        hasError = true;
-        expect(e.code).to.equal(predefined.INTERNAL_ERROR(e.message).code);
-        expect(`Error invoking RPC: ${e.message}`).to.equal(predefined.INTERNAL_ERROR(e.message).message);
-      }
-      expect(hasError).to.be.true;
+
+      const args = [txHash];
+      const errMessage = 'overflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-overflow ] (fault="overflow", operation="toNumber", value="30678687678687676876786786876876876000", code=NUMERIC_FAULT, version=bignumber/5.7.0)';
+
+      await Assertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.sendRawTransaction, true, ethImpl, args);
     });
 
     it('should return a computed hash if unable to retrieve EthereumHash from record due to contract revert', async function () {
@@ -4212,17 +4215,14 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('eth_getStorageAt should throw a predefined RESOURCE_NOT_FOUND when block not found', async function () {
       mirrorNodeCache.clear();
-      let hasError = false;
-      try {
-        restMock.onGet(`blocks/${blockNumber}`).reply(200, null);
-        restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
-        await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
-      } catch (e: any) {
-        hasError = true;
-        expect(e.code).to.equal(predefined.RESOURCE_NOT_FOUND().code);
-        expect(e.name).to.equal(predefined.RESOURCE_NOT_FOUND().name);
-      }
-      expect(hasError).to.be.true;
+      restMock.onGet(`blocks/${blockNumber}`).reply(200, null);
+      restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
+
+      const args = [contractAddress1,
+                    defaultDetailedContractResults.state_changes[0].slot,
+                    EthImpl.numberTo0x(blockNumber)];
+
+      await Assertions.assertRejection(predefined.RESOURCE_NOT_FOUND(), ethImpl.getStorageAt, false, ethImpl, args);
     });
 
     it('eth_getStorageAt should return EthImpl.zeroHex32Byte when slot wrong', async function () {
@@ -4251,15 +4251,11 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
       restMock.onGet(`contracts/${contractAddress1}/state?timestamp=${defaultBlock.timestamp.to}&slot=${defaultOlderContractState.state[0].slot}&limit=100&order=desc`).reply(404, detailedContractResultNotFound);
 
-      let hasError = false;
-      try {
-        await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
-      } catch (e: any) {
-        hasError = true;
-        expect(e.code).to.equal(predefined.RESOURCE_NOT_FOUND().code);
-        expect(e.name).to.equal(predefined.RESOURCE_NOT_FOUND().name);
-      }
-      expect(hasError).to.be.true;
+      const args = [contractAddress1,
+                    defaultDetailedContractResults.state_changes[0].slot,
+                    EthImpl.numberTo0x(blockNumber)];
+
+      await Assertions.assertRejection(predefined.RESOURCE_NOT_FOUND(), ethImpl.getStorageAt, false, ethImpl, args);
     });
   });
 
@@ -4354,28 +4350,29 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('should throw error for earliest block with invalid block', async() => {
       restMock.onGet(earliestBlockPath).reply(200, { blocks: []});
-      let hasError = false;
-      try {
-        expect(await ethImpl.getTransactionCount(mockData.account.evm_address, EthImpl.blockEarliest)).to.throw();
-      } catch (error) {
-        hasError = true;
-        expect(error).to.exist;
-        expect(error.message).to.equal(`Error invoking RPC: No network blocks found`);
-      }
-      expect(hasError).to.be.true;
+      const hasError = false;
+      // try {
+      //   expect(await ethImpl.getTransactionCount(mockData.account.evm_address, EthImpl.blockEarliest)).to.throw();
+      // } catch (error) {
+      //   hasError = true;
+      //   expect(error).to.exist;
+      //   expect(error.message).to.equal(`Error invoking RPC: No network blocks found`);
+      // }
+      // expect(hasError).to.be.true;
+
+      const args = [mockData.account.evm_address, EthImpl.blockEarliest];
+
+      await Assertions.assertRejection(predefined.INTERNAL_ERROR('No network blocks found'), ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should throw error for earliest block with non 0 or 1 block', async() => {
       restMock.onGet(earliestBlockPath).reply(200, { blocks: [mockData.blocks.blocks[2]]});
-      let hasError = false;
-      try {
-        expect(await ethImpl.getTransactionCount(mockData.account.evm_address, EthImpl.blockEarliest)).to.throw();
-      } catch (error) {
-        hasError = true;
-        expect(error).to.exist;
-        expect(error.message).to.equal(`Error invoking RPC: Partial mirror node encountered, earliest block number is ${mockData.blocks.blocks[2].number}`);
-      }
-      expect(hasError).to.be.true;
+
+      const args = [mockData.account.evm_address, EthImpl.blockEarliest];
+
+      const errMessage = `Partial mirror node encountered, earliest block number is ${mockData.blocks.blocks[2].number}`;
+
+      await Assertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should return zero nonce for contract nonce request on historical numerical block', async() => {
@@ -4388,30 +4385,20 @@ describe('Eth calls using MirrorNode', async function () {
     it('should throw error for account historical numerical block tag with missing block', async() => {
       restMock.onGet(contractPath).reply(404, mockData.notFound);
       restMock.onGet(blockPath).reply(404, mockData.notFound);
-      let hasError = false;
-      try {
-        expect(await ethImpl.getTransactionCount(mockData.account.evm_address, blockNumberHex)).to.throw();
-      } catch (error) {
-        hasError = true;
-        expect(error).to.exist;
-        expect(error.message).to.equal(`Unknown block`);
-      }
-      expect(hasError).to.be.true;
+
+      const args = [mockData.account.evm_address, blockNumberHex];
+
+      await Assertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should throw error for account historical numerical block tag with error on latest block', async() => {
       restMock.onGet(contractPath).reply(404, mockData.notFound);
       restMock.onGet(blockPath).reply(404, mockData.notFound);
       restMock.onGet(latestBlockPath).reply(404, mockData.notFound);
-      let hasError = false;
-      try {
-        expect(await ethImpl.getTransactionCount(mockData.account.evm_address, blockNumberHex)).to.throw();
-      } catch (error) {
-        hasError = true;
-        expect(error).to.exist;
-        expect(error.message).to.equal(`Unknown block`);
-      }
-      expect(hasError).to.be.true;
+
+      const args = [mockData.account.evm_address, blockNumberHex];
+
+      await Assertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should return valid nonce for historical numerical block close to latest', async() => {
@@ -4460,15 +4447,10 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet(transactionPath(mockData.account.evm_address, 2)).reply(200, { transactions: [{transaction_id: transactionId}, {}] });
       restMock.onGet(contractResultsPath).reply(404, mockData.notFound);
 
-      let hasError = false;
-      try {
-        expect(await ethImpl.getTransactionCount(mockData.account.evm_address, blockNumberHex)).to.throw();
-      } catch (error) {
-        hasError = true;
-        expect(error).to.exist;
-        expect(error.message).to.equal(`Requested resource not found. Failed to retrieve contract results for transaction ${transactionId}`);
-      }
-      expect(hasError).to.be.true;
+      const args = [mockData.account.evm_address, blockNumberHex];
+      const errMessage = `Failed to retrieve contract results for transaction ${transactionId}`;
+
+      await Assertions.assertRejection(predefined.RESOURCE_NOT_FOUND(errMessage), ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should return valid nonce for historical numerical block when contract result sender is not address', async() => {
@@ -4499,27 +4481,35 @@ describe('Eth calls using MirrorNode', async function () {
     });
 
     it('should throw for -1 invalid block tag', async() => {
-      let hasError = false;
-      try {
-        expect(await ethImpl.getTransactionCount(mockData.account.evm_address, '-1')).to.throw();
-      } catch (error) {
-        hasError = true;
-        expect(error).to.exist;
-        expect(error.message).to.equal(`Unknown block`);
-      }
-      expect(hasError).to.be.true;
+      // let hasError = false;
+      // try {
+      //   expect(await ethImpl.getTransactionCount(mockData.account.evm_address, '-1')).to.throw();
+      // } catch (error) {
+      //   hasError = true;
+      //   expect(error).to.exist;
+      //   expect(error.message).to.equal(`Unknown block`);
+      // }
+      // expect(hasError).to.be.true;
+      
+      const args = [mockData.account.evm_address, '-1'];
+
+      await Assertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
     });
 
     it('should throw for invalid block tag', async() => {
-      let hasError = false;
-      try {
-        expect(await ethImpl.getTransactionCount(mockData.account.evm_address, 'notablock')).to.throw();
-      } catch (error) {
-        hasError = true;
-        expect(error).to.exist;
-        expect(error.message).to.equal(`Unknown block`);
-      }
-      expect(hasError).to.be.true;
+      // let hasError = false;
+      // try {
+      //   expect(await ethImpl.getTransactionCount(mockData.account.evm_address, 'notablock')).to.throw();
+      // } catch (error) {
+      //   hasError = true;
+      //   expect(error).to.exist;
+      //   expect(error.message).to.equal(`Unknown block`);
+      // }
+      // expect(hasError).to.be.true;
+
+      const args = [mockData.account.evm_address, 'notablock'];
+
+      await Assertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
     });
   });
 });
@@ -4992,7 +4982,7 @@ describe('Eth', async function () {
         ...defaultTransaction,
         r: null,
         s: null
-      })
+      });
     });
 
     it('handles transactions with null gas_used', async function () {
@@ -5142,14 +5132,19 @@ describe('Eth', async function () {
         evm_address: `${defaultTransaction.from}`
       });
 
-      try {
-        await ethImpl.getTransactionByHash(uniqueTxHash);
-        expect(true).to.eq(false);
-      }
-      catch(error) {
-        expect(error).to.deep.equal(predefined.CONTRACT_REVERT(defaultDetailedContractResultByHashReverted.error_message, defaultDetailedContractResultByHashReverted.error_message));
-      }
+      // try {
+      //   await ethImpl.getTransactionByHash(uniqueTxHash);
+      //   expect(true).to.eq(false);
+      // }
+      // catch(error) {
+      //   expect(error).to.deep.equal(predefined.CONTRACT_REVERT(defaultDetailedContractResultByHashReverted.error_message, defaultDetailedContractResultByHashReverted.error_message));
+      // }
 
+      const args = [uniqueTxHash];
+      const errMessage = defaultDetailedContractResultByHashReverted.error_message;
+      const data = defaultDetailedContractResultByHashReverted.error_message;
+
+      await Assertions.assertRejection(predefined.CONTRACT_REVERT(errMessage, data), ethImpl.getTransactionByHash, true, ethImpl, args);
       process.env.DEV_MODE = initialDevModeValue;
     });
   });

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -503,7 +503,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INTERNAL_ERROR();
 
-                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx + "11", requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx + "11", requestId]);
             });
 
             it('should execute "eth_getTransactionReceipt" for non-existing hash', async function () {
@@ -521,7 +521,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.UNSUPPORTED_CHAIN_ID(ethers.utils.hexValue(INCORRECT_CHAIN_ID), CHAIN_ID);
 
-                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('@release should execute "eth_sendRawTransaction" for legacy EIP 155 transactions', async function () {
@@ -556,7 +556,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INSUFFICIENT_ACCOUNT_BALANCE;
 
-                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy transactions (with no chainId)', async function () {
@@ -569,7 +569,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.UNSUPPORTED_CHAIN_ID('0x0', CHAIN_ID);
 
-                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy transactions (with gas price too low)', async function () {
@@ -583,7 +583,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.GAS_PRICE_TOO_LOW(GAS_PRICE_TOO_LOW, GAS_PRICE_REF);
 
-                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransactxion" for Legacy 2930 transactions', async function () {
@@ -596,7 +596,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INTERNAL_ERROR();
 
-                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions (with gas price too low)', async function () {
@@ -609,7 +609,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.GAS_PRICE_TOO_LOW(GAS_PRICE_TOO_LOW, GAS_PRICE_REF);
 
-                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions (with insufficient balance)', async function () {
@@ -624,7 +624,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INSUFFICIENT_ACCOUNT_BALANCE;
 
-                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for London transactions (with gas price too low)', async function () {
@@ -638,7 +638,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.GAS_PRICE_TOO_LOW(GAS_PRICE_TOO_LOW, GAS_PRICE_REF);
 
-                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for London transactions (with insufficient balance)', async function () {
@@ -656,7 +656,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INSUFFICIENT_ACCOUNT_BALANCE;
 
-                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('should execute "eth_sendRawTransaction" for London transactions', async function () {
@@ -743,7 +743,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INTERNAL_ERROR();
 
-                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             describe('Prechecks', async function () {
@@ -757,7 +757,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.UNSUPPORTED_CHAIN_ID('0x3e7', CHAIN_ID);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
+                    await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for EIP155 transaction with not enough gas', async function () {
@@ -773,7 +773,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.GAS_LIMIT_TOO_LOW(gasLimit, Constants.BLOCK_GAS_LIMIT);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                    await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for EIP155 transaction with a too high gasLimit', async function () {
@@ -789,7 +789,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                    await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for London transaction with not enough gas', async function () {
@@ -803,7 +803,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.GAS_LIMIT_TOO_LOW(gasLimit, Constants.BLOCK_GAS_LIMIT);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                    await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for London transaction with a too high gasLimit', async function () {
@@ -817,7 +817,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
+                    await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for legacy EIP 155 transactions (with gas price too low)', async function () {
@@ -852,7 +852,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     Assertions.transactionReceipt(res, mirrorResult);
                     const error = predefined.NONCE_TOO_LOW(nonce, nonce + 1);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
+                    await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestId]);
                 });
 
                 it('@release fail "eth_getTransactionReceipt" on precheck with wrong nonce error when sending a tx with a higher nonce', async function () {
@@ -868,7 +868,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.NONCE_TOO_HIGH(nonce + 100, nonce);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
+                    await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestId]);
                 });
 
                 it('@release fail "eth_getTransactionReceipt" on submitting with wrong nonce error when sending a tx with the same nonce twice', async function () {

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -503,7 +503,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INTERNAL_ERROR();
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx + "11", requestId], false);
+                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx + "11", requestId]);
             });
 
             it('should execute "eth_getTransactionReceipt" for non-existing hash', async function () {
@@ -521,7 +521,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.UNSUPPORTED_CHAIN_ID(ethers.utils.hexValue(INCORRECT_CHAIN_ID), CHAIN_ID);
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], true);
+                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('@release should execute "eth_sendRawTransaction" for legacy EIP 155 transactions', async function () {
@@ -556,7 +556,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INSUFFICIENT_ACCOUNT_BALANCE;
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], true);
+                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy transactions (with no chainId)', async function () {
@@ -569,7 +569,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.UNSUPPORTED_CHAIN_ID('0x0', CHAIN_ID);
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], true);
+                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy transactions (with gas price too low)', async function () {
@@ -583,10 +583,10 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.GAS_PRICE_TOO_LOW(GAS_PRICE_TOO_LOW, GAS_PRICE_REF);
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
-            it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions', async function () {
+            it('should fail "eth_sendRawTransactxion" for Legacy 2930 transactions', async function () {
                 const transaction = {
                     ...defaultLegacy2930TransactionData,
                     to: mirrorContract.evm_address,
@@ -596,7 +596,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INTERNAL_ERROR();
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions (with gas price too low)', async function () {
@@ -609,7 +609,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.GAS_PRICE_TOO_LOW(GAS_PRICE_TOO_LOW, GAS_PRICE_REF);
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for Legacy 2930 transactions (with insufficient balance)', async function () {
@@ -624,7 +624,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INSUFFICIENT_ACCOUNT_BALANCE;
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], true);
+                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for London transactions (with gas price too low)', async function () {
@@ -638,7 +638,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.GAS_PRICE_TOO_LOW(GAS_PRICE_TOO_LOW, GAS_PRICE_REF);
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             it('should fail "eth_sendRawTransaction" for London transactions (with insufficient balance)', async function () {
@@ -656,7 +656,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INSUFFICIENT_ACCOUNT_BALANCE;
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], true);
+                await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
             });
 
             it('should execute "eth_sendRawTransaction" for London transactions', async function () {
@@ -743,7 +743,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const signedTx = await accounts[2].wallet.signTransaction(transaction);
                 const error = predefined.INTERNAL_ERROR();
 
-                await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
             });
 
             describe('Prechecks', async function () {
@@ -757,7 +757,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.UNSUPPORTED_CHAIN_ID('0x3e7', CHAIN_ID);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], true);
+                    await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for EIP155 transaction with not enough gas', async function () {
@@ -773,7 +773,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.GAS_LIMIT_TOO_LOW(gasLimit, Constants.BLOCK_GAS_LIMIT);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                    await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for EIP155 transaction with a too high gasLimit', async function () {
@@ -789,7 +789,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                    await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for London transaction with not enough gas', async function () {
@@ -803,7 +803,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.GAS_LIMIT_TOO_LOW(gasLimit, Constants.BLOCK_GAS_LIMIT);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                    await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for London transaction with a too high gasLimit', async function () {
@@ -817,7 +817,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.GAS_LIMIT_TOO_HIGH(gasLimit, Constants.BLOCK_GAS_LIMIT);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], false);
+                    await Assertions.assertRejection(error, sendRawTransaction, false, relay, [signedTx, requestId]);
                 });
 
                 it('should fail "eth_sendRawTransaction" for legacy EIP 155 transactions (with gas price too low)', async function () {
@@ -852,7 +852,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     Assertions.transactionReceipt(res, mirrorResult);
                     const error = predefined.NONCE_TOO_LOW(nonce, nonce + 1);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], true);
+                    await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
                 });
 
                 it('@release fail "eth_getTransactionReceipt" on precheck with wrong nonce error when sending a tx with a higher nonce', async function () {
@@ -868,7 +868,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     const signedTx = await accounts[2].wallet.signTransaction(transaction);
                     const error = predefined.NONCE_TOO_HIGH(nonce + 100, nonce);
 
-                    await Assertions.assertRejection(error, sendRawTransaction, [signedTx, requestId], true);
+                    await Assertions.assertRejection(error, sendRawTransaction, true, relay, [signedTx, requestId]);
                 });
 
                 it('@release fail "eth_getTransactionReceipt" on submitting with wrong nonce error when sending a tx with the same nonce twice', async function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -751,7 +751,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
                 expect(res.baseFeePerGas[res.baseFeePerGas.length - 1]).to.equal(defaultGasPriceHex);
             });
 
-            itß('should call eth_feeHistory with newest block > latest', async function () {
+            it('should call eth_feeHistory with newest block > latest', async function () {
                 const blocksAhead = 10;
 
                 const latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
@@ -759,8 +759,8 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
                 const newestBlockNumberHex = ethers.utils.hexValue(latestBlock.number + blocksAhead);
                 const args = [RelayCalls.ETH_ENDPOINTS.ETH_FEE_HISTORY, ['0x1', newestBlockNumberHex, null], requestId];
 
-                await Assertions.assertRejection(errorType, relay.call, args, true);
-                //await Assertions.assertRejection(errorType, relay.call, true, relay, args);
+                await Assertions.assertPredefinedRpcError(errorType, relay.call, args, true);
+                //await Assertions.assertPredefinedRpcError(errorType, relay.call, true, relay, args);
             });
 
             it('should call eth_feeHistory with zero block count', async function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -751,7 +751,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
                 expect(res.baseFeePerGas[res.baseFeePerGas.length - 1]).to.equal(defaultGasPriceHex);
             });
 
-            it('should call eth_feeHistory with newest block > latest', async function () {
+            itß('should call eth_feeHistory with newest block > latest', async function () {
                 const blocksAhead = 10;
 
                 const latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
@@ -760,6 +760,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
                 const args = [RelayCalls.ETH_ENDPOINTS.ETH_FEE_HISTORY, ['0x1', newestBlockNumberHex, null], requestId];
 
                 await Assertions.assertRejection(errorType, relay.call, args, true);
+                //await Assertions.assertRejection(errorType, relay.call, true, relay, args);
             });
 
             it('should call eth_feeHistory with zero block count', async function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -759,8 +759,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
                 const newestBlockNumberHex = ethers.utils.hexValue(latestBlock.number + blocksAhead);
                 const args = [RelayCalls.ETH_ENDPOINTS.ETH_FEE_HISTORY, ['0x1', newestBlockNumberHex, null], requestId];
 
-                await Assertions.assertPredefinedRpcError(errorType, relay.call, args, true);
-                //await Assertions.assertPredefinedRpcError(errorType, relay.call, true, relay, args);
+                await Assertions.assertPredefinedRpcError(errorType, relay.call, true, relay, args);
             });
 
             it('should call eth_feeHistory with zero block count', async function () {

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -193,7 +193,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const errorType = predefined.INVALID_PARAMETER(1, `${errorMessagePrefixedStr}, value: newest`);
             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'newest'], requestId];
 
-            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, false);
+            await Assertions.assertPredefinedRpcError(errorType, relay.call, false, relay, args);
         });
 
         it('should fail to execute "eth_call" with wrong block number', async function () {
@@ -205,7 +205,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const errorType = predefined.INVALID_PARAMETER(1, `${errorMessagePrefixedStr}, value: 123`);
             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, '123'], requestId];
 
-            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, false);
+            await Assertions.assertPredefinedRpcError(errorType, relay.call, false, relay, args);
         });
 
         it('should fail to execute "eth_call" with wrong block hash object', async function () {
@@ -217,7 +217,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const errorType = predefined.INVALID_PARAMETER(`'blockHash' for BlockHashObject`, 'Expected 0x prefixed string representing the hash (32 bytes) of a block, value: 0x123');
             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId];
             
-            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, false);
+            await Assertions.assertPredefinedRpcError(errorType, relay.call, false, relay, args);
         });
 
         it('should fail to execute "eth_call" with wrong block number object', async function () {
@@ -229,7 +229,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const errorType = predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, `${errorMessagePrefixedStr}, value: 123`);
             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId];
             
-            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, false);
+            await Assertions.assertPredefinedRpcError(errorType, relay.call, false, relay, args);
         });
 
         describe('Caller contract', () => {
@@ -383,7 +383,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                             const errorType = predefined.CONTRACT_REVERT();
                             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId];
 
-                            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, true);
+                            await Assertions.assertPredefinedRpcError(errorType, relay.call, true, relay, args);
                         });
 
                         it("012 should work for wrong 'from' field", async function () {

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -193,7 +193,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const errorType = predefined.INVALID_PARAMETER(1, `${errorMessagePrefixedStr}, value: newest`);
             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'newest'], requestId];
 
-            await Assertions.assertRejection(errorType, relay.call, args, false);
+            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, false);
         });
 
         it('should fail to execute "eth_call" with wrong block number', async function () {
@@ -205,7 +205,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const errorType = predefined.INVALID_PARAMETER(1, `${errorMessagePrefixedStr}, value: 123`);
             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, '123'], requestId];
 
-            await Assertions.assertRejection(errorType, relay.call, args, false);
+            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, false);
         });
 
         it('should fail to execute "eth_call" with wrong block hash object', async function () {
@@ -217,7 +217,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const errorType = predefined.INVALID_PARAMETER(`'blockHash' for BlockHashObject`, 'Expected 0x prefixed string representing the hash (32 bytes) of a block, value: 0x123');
             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId];
             
-            await Assertions.assertRejection(errorType, relay.call, args, false);
+            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, false);
         });
 
         it('should fail to execute "eth_call" with wrong block number object', async function () {
@@ -229,7 +229,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const errorType = predefined.INVALID_PARAMETER(`'blockNumber' for BlockNumberObject`, `${errorMessagePrefixedStr}, value: 123`);
             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, { 'blockHash': '0x123' }], requestId];
             
-            await Assertions.assertRejection(errorType, relay.call, args, false);
+            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, false);
         });
 
         describe('Caller contract', () => {
@@ -383,7 +383,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                             const errorType = predefined.CONTRACT_REVERT();
                             const args = [RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId];
 
-                            await Assertions.assertRejection(errorType, relay.call, args, true);
+                            await Assertions.assertPredefinedRpcError(errorType, relay.call, args, true);
                         });
 
                         it("012 should work for wrong 'from' field", async function () {

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -208,7 +208,7 @@ export default class Assertions {
         }
     }
 
-    static assertRejection = async (error: JsonRpcError, method: () => Promise<any>, checkMessage: boolean, thisObj, args?: any[]): Promise<any> => {
+    static assertPredefinedRpcError = async (error: JsonRpcError, method: () => Promise<any>, checkMessage: boolean, thisObj, args?: any[]): Promise<any> => {
         return await expect(method.apply(thisObj, args)).to.eventually.be.rejected.and.satisfy((err) => {
             if(!checkMessage) {
                 return [error.code, error.name].every(substring => err.body.includes(substring));

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -208,6 +208,15 @@ export default class Assertions {
         }
     }
 
+    static assertRejection = async (error: JsonRpcError, method: () => Promise<any>, checkMessage: boolean, thisObj, args?: any[]): Promise<any> => {
+        return await expect(method.apply(thisObj, args)).to.eventually.be.rejected.and.satisfy((err) => {
+            if(!checkMessage) {
+                return [error.code, error.name].every(substring => err.body.includes(substring));
+            }
+            return [error.code, error.name, error.message].every(substring => err.body.includes(substring));
+        });
+    };
+
     static expectRevert = async (promise, code) => {
         const tx = await promise;
         try {
@@ -233,15 +242,6 @@ export default class Assertions {
     static expectAnonymousLog = (log, contract, data) => {
         expect(log.data).to.equal(data);
         expect(log.address.toLowerCase()).to.equal(contract.address.toLowerCase());
-    };
-
-    static assertRejection = async (error: JsonRpcError, method: () => Promise<any>, args: any[], checkMessage: boolean): Promise<any> => {
-        return await expect(method.apply(relay, args)).to.eventually.be.rejected.and.satisfy((err) => {
-            if(!checkMessage) {
-                return [error.code, error.name].every(substring => err.body.includes(substring));
-            }
-            return [error.code, error.name, error.message].every(substring => err.body.includes(substring));
-        });
     };
 
 }


### PR DESCRIPTION
**Description**:

This PR modifies the eth.spec.ts file where it removes try catch logic which does not work properly in some cases

**Related issue(s)**:

Fixes #1438

### Proposed Changes

- Remove try catch logic from eth.spec.ts
- Fix some tests in eth.spec that were not working properly
- Add assertions class in relay folder
- Rename assertRejection file in the server so it is more descriptive and clear

**Checklist**
- [x] Tested (unit, integration, etc.)
