### PR TITLE
Increase default number of sockets for mirror node client to 300

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -164,8 +164,8 @@ export class MirrorNodeClient {
         const mirrorNodeMaxRedirects = parseInt(process.env.MIRROR_NODE_MAX_REDIRECTS || '5');
         const mirrorNodeHttpKeepAlive = process.env.MIRROR_NODE_HTTP_KEEP_ALIVE === 'true' ? true : false;
         const mirrorNodeHttpKeepAliveMsecs = parseInt(process.env.MIRROR_NODE_HTTP_KEEP_ALIVE_MSECS || '1000');
-        const mirrorNodeHttpMaxSockets = parseInt(process.env.MIRROR_NODE_HTTP_MAX_SOCKETS || '100');
-        const mirrorNodeHttpMaxTotalSockets = parseInt(process.env.MIRROR_NODE_HTTP_MAX_TOTAL_SOCKETS || '100');
+        const mirrorNodeHttpMaxSockets = parseInt(process.env.MIRROR_NODE_HTTP_MAX_SOCKETS || '300');
+        const mirrorNodeHttpMaxTotalSockets = parseInt(process.env.MIRROR_NODE_HTTP_MAX_TOTAL_SOCKETS || '300');
         const mirrorNodeHttpSocketTimeout = parseInt(process.env.MIRROR_NODE_HTTP_SOCKET_TIMEOUT || '60000');
         const isDevMode = process.env.DEV_MODE && process.env.DEV_MODE === 'true';
         const mirrorNodeRetries = parseInt(process.env.MIRROR_NODE_RETRIES || '3');


### PR DESCRIPTION
**Description**:
This change has already been tested by tuning the value of these properties directly using the config map, however, once in a while (presumably when new changes in infrastructure are roll out) these config maps reset to their defaults and its necessary to tune them manually again, but once we know that a configuration is better than other we should productize these changes into code defaults to simplify properties management.


**Related issue(s)**:  #1120 

Fixes #

**Notes for reviewer**:
These changes were already tested on both `testnet` and `mainnet` and noticeable improvements were observed.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
