### PR TITLE
Productize mirror node configuration to keep alive by default

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -162,7 +162,7 @@ export class MirrorNodeClient {
         // defualt values for axios clients to mirror node
         const mirrorNodeTimeout = parseInt(process.env.MIRROR_NODE_TIMEOUT || '10000');
         const mirrorNodeMaxRedirects = parseInt(process.env.MIRROR_NODE_MAX_REDIRECTS || '5');
-        const mirrorNodeHttpKeepAlive = process.env.MIRROR_NODE_HTTP_KEEP_ALIVE === 'true' ? true : false;
+        const mirrorNodeHttpKeepAlive = process.env.MIRROR_NODE_HTTP_KEEP_ALIVE === 'false' ? false : true;
         const mirrorNodeHttpKeepAliveMsecs = parseInt(process.env.MIRROR_NODE_HTTP_KEEP_ALIVE_MSECS || '1000');
         const mirrorNodeHttpMaxSockets = parseInt(process.env.MIRROR_NODE_HTTP_MAX_SOCKETS || '300');
         const mirrorNodeHttpMaxTotalSockets = parseInt(process.env.MIRROR_NODE_HTTP_MAX_TOTAL_SOCKETS || '300');


### PR DESCRIPTION
**Description**:
Productize mirror node configuration to keep alive by default

**Related issue(s)**:

Fixes #1565 

**Notes for reviewer**:
This has already been tested on `testnet`  and helped a lot with `latency` issues that were being experienced at the moment of the change.


<img width="1496" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/289e8e5a-30bf-4785-8158-bb3f07f322df">


**Also:** literature usually recommends setting to keepAlive when calling many times the same downstream service.

> keepAlive [<boolean>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type) Keep sockets around even when there are no outstanding requests, so they can be used for future requests without having to reestablish a TCP connection. Not to be confused with the keep-alive value of the Connection header. The Connection: keep-alive header is always sent when using an agent except when the Connection header is explicitly specified or when the keepAlive and maxSockets options are respectively set to false and Infinity, in which case Connection: close will be used. Default: false.

https://connectreport.com/blog/tuning-http-keep-alive-in-node-js/


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
