### PR TITLE
Refactor `EthImpl.formatContractResult()`

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -20,7 +20,8 @@
 
 import constants from "./lib/constants";
 import { Transaction } from './lib/model';
-import { BigNumber as BN } from 'bignumber.js';
+import { BigNumber } from '@hashgraph/sdk/lib/Transfer';
+import { BigNumber as BN } from "bignumber.js";
 
 const EMPTY_HEX = '0x';
 
@@ -144,15 +145,15 @@ const prepend0x = (input: string): string => {
     return input.startsWith(EMPTY_HEX) ? input : EMPTY_HEX + input;
 };
 
-const numberTo0x = (input: number | BN | bigint): string => {
+const numberTo0x = (input: number | BigNumber | bigint): string => {
     return EMPTY_HEX + input.toString(16);
 };
 
-const nullableNumberTo0x = (input: number | BN): string | null => {
+const nullableNumberTo0x = (input: number | BigNumber): string | null => {
     return input == null ? null : numberTo0x(input);
 };
 
-const nanOrNumberTo0x = (input: number | BN): string => {
+const nanOrNumberTo0x = (input: number | BigNumber): string => {
     return input == null || input !== input ? numberTo0x(0) : numberTo0x(input);
 };
 

--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -19,6 +19,8 @@
  */
 
 import constants from "./lib/constants";
+import { Transaction } from './lib/model';
+import { EthImpl } from './lib/eth';
 
 const hashNumber = (num) => {
   return '0x' + num.toString(16);
@@ -108,4 +110,32 @@ const parseNumericEnvVar = (envVarName: string, fallbackConstantKey: string): nu
     return value;
 }
 
-export { hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId, formatTransactionIdWithoutQueryParams, parseNumericEnvVar };
+const formatContractResult = (cr: any) => {
+    if (cr === null) {
+        return null;
+    }
+
+    return new Transaction({
+        accessList: undefined,
+        blockHash: EthImpl.toHash32(cr.block_hash),
+        blockNumber: EthImpl.nullableNumberTo0x(cr.block_number),
+        chainId: cr.chain_id,
+        from: cr.from.substring(0, 42),
+        gas: EthImpl.nanOrNumberTo0x(cr.gas_used),
+        gasPrice: EthImpl.toNullIfEmptyHex(cr.gas_price),
+        hash: cr.hash.substring(0, 66),
+        input: cr.function_parameters,
+        maxPriorityFeePerGas: EthImpl.toNullIfEmptyHex(cr.max_priority_fee_per_gas),
+        maxFeePerGas: EthImpl.toNullIfEmptyHex(cr.max_fee_per_gas),
+        nonce: EthImpl.nanOrNumberTo0x(cr.nonce),
+        r: cr.r === null ? null : cr.r.substring(0, 66),
+        s: cr.s === null ? null : cr.s.substring(0, 66),
+        to: cr.to?.substring(0, 42),
+        transactionIndex: EthImpl.nullableNumberTo0x(cr.transaction_index),
+        type: EthImpl.nullableNumberTo0x(cr.type),
+        v: EthImpl.nanOrNumberTo0x(cr.v),
+        value: EthImpl.nanOrNumberTo0x(cr.amount)
+    });
+}
+
+export { hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId, formatTransactionIdWithoutQueryParams, parseNumericEnvVar, formatContractResult };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -30,7 +30,17 @@ import { SDKClientError } from './errors/SDKClientError';
 import { MirrorNodeClientError } from './errors/MirrorNodeClientError';
 import constants from './constants';
 import { Precheck } from './precheck';
-import { formatTransactionIdWithoutQueryParams, parseNumericEnvVar } from '../formatters';
+import {
+  formatTransactionIdWithoutQueryParams,
+  parseNumericEnvVar,
+  formatContractResult,
+  prepend0x,
+  numberTo0x,
+  nullableNumberTo0x,
+  nanOrNumberTo0x,
+  toHash32,
+  toNullableBigNumber
+} from '../formatters';
 import crypto from 'crypto';
 import HAPIService from './services/hapiService/hapiService';
 import { Counter, Registry } from "prom-client";
@@ -40,7 +50,6 @@ const _ = require('lodash');
 const createHash = require('keccak');
 const asm = require('@ethersproject/asm');
 import { Transaction as EthersTransaction } from 'ethers';
-import { formatContractResult } from '../formatters';
 
 interface LatestBlockNumberTimestamp {
   blockNumber: string;
@@ -67,9 +76,9 @@ export class EthImpl implements Eth {
   static emptyArrayHex = '0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347';
   static zeroAddressHex = '0x0000000000000000000000000000000000000000';
   static emptyBloom = "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
-  static defaultTxGas = EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT);
-  static gasTxBaseCost = EthImpl.numberTo0x(constants.TX_BASE_COST);
-  static gasTxHollowAccountCreation = EthImpl.numberTo0x(constants.TX_HOLLOW_ACCOUNT_CREATION_GAS);
+  static defaultTxGas = numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT);
+  static gasTxBaseCost = numberTo0x(constants.TX_BASE_COST);
+  static gasTxHollowAccountCreation = numberTo0x(constants.TX_HOLLOW_ACCOUNT_CREATION_GAS);
   static ethTxType = 'EthereumTransaction';
   static ethEmptyTrie = '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421';
   static defaultGasUsedRatio = 0.5;
@@ -113,7 +122,7 @@ export class EthImpl implements Eth {
    *
    * @private
    */
-  private readonly defaultGas = EthImpl.numberTo0x(
+  private readonly defaultGas = numberTo0x(
     parseNumericEnvVar('TX_DEFAULT_GAS', 'TX_DEFAULT_GAS_DEFAULT'));
   private readonly ethCallCacheTtl =
     parseNumericEnvVar('ETH_CALL_CACHE_TTL', 'ETH_CALL_CACHE_TTL_DEFAULT');
@@ -313,7 +322,7 @@ export class EthImpl implements Eth {
       this.logger.warn(error, `${requestIdPrefix} Fee history cannot retrieve block or fee. Returning ${fee} fee for block ${blockNumber}`);
     }
 
-    return EthImpl.numberTo0x(fee);
+    return numberTo0x(fee);
   }
 
   private getRepeatedFeeHistory(blockCount: number, oldestBlockNumber: number, rewardPercentiles: Array<number> | null, fee: string) {
@@ -322,7 +331,7 @@ export class EthImpl implements Eth {
     const feeHistory = {
       baseFeePerGas: Array(blockCount).fill(fee),
       gasUsedRatio: Array(blockCount).fill(EthImpl.defaultGasUsedRatio),
-      oldestBlock: EthImpl.numberTo0x(oldestBlockNumber),
+      oldestBlock: numberTo0x(oldestBlockNumber),
     };
 
     // next fee. Due to high block production rate and low fee change rate we add the next fee
@@ -343,7 +352,7 @@ export class EthImpl implements Eth {
     const feeHistory = {
       baseFeePerGas: [] as string[],
       gasUsedRatio: [] as number[],
-      oldestBlock: EthImpl.numberTo0x(oldestBlockNumber),
+      oldestBlock: numberTo0x(oldestBlockNumber),
     };
 
     // get fees from oldest to newest blocks
@@ -429,7 +438,7 @@ export class EthImpl implements Eth {
     const blocksResponse = await this.mirrorNodeClient.getLatestBlock(requestIdPrefix);
     const blocks = blocksResponse !== null ? blocksResponse.blocks : null;
     if (Array.isArray(blocks) && blocks.length > 0) {
-      const currentBlock = EthImpl.numberTo0x(blocks[0].number);
+      const currentBlock = numberTo0x(blocks[0].number);
       // save the latest block number in cache
       this.cache.set(cacheKey, currentBlock, EthImpl.ethBlockByNumber, this.ethBlockNumberCacheTtlMs, requestIdPrefix);
 
@@ -450,7 +459,7 @@ export class EthImpl implements Eth {
     const blocksResponse = await this.mirrorNodeClient.getLatestBlock(requestIdPrefix);
     const blocks = blocksResponse !== null ? blocksResponse.blocks : null;
     if (Array.isArray(blocks) && blocks.length > 0) {
-      const currentBlock = EthImpl.numberTo0x(blocks[0].number);
+      const currentBlock = numberTo0x(blocks[0].number);
       const timestamp = blocks[0].timestamp.to;
       const blockTimeStamp: LatestBlockNumberTimestamp = { blockNumber: currentBlock, timeStampTo: timestamp };
       // save the latest block number in cache
@@ -494,7 +503,7 @@ export class EthImpl implements Eth {
         if (!transaction.to && transaction.data !== '0x') {
           gas = this.defaultGas;
         } else {
-          gas = EthImpl.prepend0x(contractCallResponse.result);
+          gas = prepend0x(contractCallResponse.result);
         }
       }
     } catch (e: any) {
@@ -551,7 +560,7 @@ export class EthImpl implements Eth {
         this.cache.set(constants.CACHE_KEY.GAS_PRICE, gasPrice, EthImpl.ethGasPrice, constants.CACHE_TTL.ONE_DAY, requestIdPrefix);
       }
 
-      return EthImpl.numberTo0x(gasPrice);
+      return numberTo0x(gasPrice);
     } catch (error) {
       throw this.genericErrorHandler(error, `${requestIdPrefix} Failed to retrieve gasPrice`);
     }
@@ -842,7 +851,7 @@ export class EthImpl implements Eth {
       }
 
       // save in cache the current balance for the account and blockNumberOrTag
-      cachedBalance = EthImpl.numberTo0x(weibars);
+      cachedBalance = numberTo0x(weibars);
       this.cache.set(cacheKey, cachedBalance, EthImpl.ethGetBalance, this.ethGetBalanceCacheTtlMs, requestIdPrefix);
 
       return cachedBalance;
@@ -893,7 +902,7 @@ export class EthImpl implements Eth {
       }
 
       const bytecode = await this.hapiService.getSDKClient().getContractByteCode(0, 0, address, EthImpl.ethGetCode, requestIdPrefix);
-      return EthImpl.prepend0x(Buffer.from(bytecode).toString('hex'));
+      return prepend0x(Buffer.from(bytecode).toString('hex'));
     } catch (e: any) {
       if (e instanceof SDKClientError) {
         // handle INVALID_CONTRACT_ID or CONTRACT_DELETED
@@ -1139,7 +1148,7 @@ export class EthImpl implements Eth {
     this.logger.error(e,
         `${requestIdPrefix} Failed sendRawTransaction during record retrieval for transaction ${transaction}, returning computed hash`);
     //Return computed hash if unable to retrieve EthereumHash from record due to error
-    return EthImpl.prepend0x(createHash('keccak256').update(transactionBuffer).digest('hex'));
+    return prepend0x(createHash('keccak256').update(transactionBuffer).digest('hex'));
   }
 
   /**
@@ -1215,7 +1224,7 @@ export class EthImpl implements Eth {
 
     // Get a reasonable value for "gas" if it is not specified.
     const gas = this.getCappedBlockGasLimit(call.gas, requestIdPrefix);
-    const value: string | null = EthImpl.toNullableBigNumber(call.value);
+    const value: string | null = toNullableBigNumber(call.value);
     
     try {
       // ETH_CALL_DEFAULT_TO_CONSENSUS_NODE = false enables the use of Mirror node
@@ -1246,7 +1255,7 @@ export class EthImpl implements Eth {
       };
 
       const contractCallResponse = await this.mirrorNodeClient.postContractCall(callData, requestIdPrefix);
-      return contractCallResponse?.result ? EthImpl.prepend0x(contractCallResponse.result) : EthImpl.emptyHex;
+      return contractCallResponse?.result ? prepend0x(contractCallResponse.result) : EthImpl.emptyHex;
     } catch (e: any) {
       if (e instanceof JsonRpcError) {
         return e;
@@ -1323,7 +1332,7 @@ export class EthImpl implements Eth {
 
       const contractCallResponse = await this.hapiService.getSDKClient().submitContractCallQueryWithRetry(call.to, call.data, gas, call.from, EthImpl.ethCall, requestIdPrefix);
       if (contractCallResponse) {
-        const formattedCallReponse = EthImpl.prepend0x(Buffer.from(contractCallResponse.asBytes()).toString('hex'));
+        const formattedCallReponse = prepend0x(Buffer.from(contractCallResponse.asBytes()).toString('hex'));
 
         this.cache.set(cacheKey, formattedCallReponse, EthImpl.ethCall, this.ethCallCacheTtl, requestIdPrefix);
         return formattedCallReponse;
@@ -1498,30 +1507,30 @@ export class EthImpl implements Eth {
       const logs = receiptResponse.logs.map(log => {
         return new Log({
           address: log.address,
-          blockHash: EthImpl.toHash32(receiptResponse.block_hash),
-          blockNumber: EthImpl.numberTo0x(receiptResponse.block_number),
+          blockHash: toHash32(receiptResponse.block_hash),
+          blockNumber: numberTo0x(receiptResponse.block_number),
           data: log.data,
-          logIndex: EthImpl.numberTo0x(log.index),
+          logIndex: numberTo0x(log.index),
           removed: false,
           topics: log.topics,
-          transactionHash: EthImpl.toHash32(receiptResponse.hash),
-          transactionIndex: EthImpl.nullableNumberTo0x(receiptResponse.transaction_index)
+          transactionHash: toHash32(receiptResponse.hash),
+          transactionIndex: nullableNumberTo0x(receiptResponse.transaction_index)
         });
       });
 
       const receipt: any = {
-        blockHash: EthImpl.toHash32(receiptResponse.block_hash),
-        blockNumber: EthImpl.numberTo0x(receiptResponse.block_number),
+        blockHash: toHash32(receiptResponse.block_hash),
+        blockNumber: numberTo0x(receiptResponse.block_number),
         from: receiptResponse.from,
         to: receiptResponse.to,
-        cumulativeGasUsed: EthImpl.numberTo0x(receiptResponse.block_gas_used),
-        gasUsed: EthImpl.nanOrNumberTo0x(receiptResponse.gas_used),
+        cumulativeGasUsed: numberTo0x(receiptResponse.block_gas_used),
+        gasUsed: nanOrNumberTo0x(receiptResponse.gas_used),
         contractAddress: receiptResponse.address,
         logs: logs,
         logsBloom: receiptResponse.bloom === EthImpl.emptyHex ? EthImpl.emptyBloom : receiptResponse.bloom,
-        transactionHash: EthImpl.toHash32(receiptResponse.hash),
-        transactionIndex: EthImpl.nullableNumberTo0x(receiptResponse.transaction_index),
-        effectiveGasPrice: EthImpl.nanOrNumberTo0x(Number.parseInt(effectiveGas) * 10_000_000_000),
+        transactionHash: toHash32(receiptResponse.hash),
+        transactionIndex: nullableNumberTo0x(receiptResponse.transaction_index),
+        effectiveGasPrice: nanOrNumberTo0x(Number.parseInt(effectiveGas) * 10_000_000_000),
         root: receiptResponse.root,
         status: receiptResponse.status,
       };
@@ -1537,55 +1546,10 @@ export class EthImpl implements Eth {
     }
   }
 
-  /**
-   * Internal helper method that prepends a leading 0x if there isn't one.
-   * @param input
-   * @private
-   */
-  static prepend0x(input: string): string {
-    return input.startsWith(EthImpl.emptyHex) ? input : EthImpl.emptyHex + input;
-  }
-
-  static numberTo0x(input: number | BigNumber | bigint): string {
-    return EthImpl.emptyHex + input.toString(16);
-  }
-
-  static nullableNumberTo0x(input: number | BigNumber): string | null {
-    return input == null ? null : EthImpl.numberTo0x(input);
-  }
-
-  static nanOrNumberTo0x(input: number | BigNumber): string {
-    // input == null assures to check against both null and undefined.
-    // A reliable way for ECMAScript code to test if a value X is a NaN is an expression of the form X !== X.
-    // The result will be true if and only if X is a NaN.
-    return input == null || input !== input ? EthImpl.numberTo0x(0) : EthImpl.numberTo0x(input);
-  }
-
-  static toHash32(value: string): string {
-    return value.substring(0, 66);
-  }
-
-  static toNullableBigNumber(value: string): string | null {
-    if (typeof value === 'string') {
-      return (new BN(value)).toString();
-    }
-
-    return null;
-  }
-
-  static toNullIfEmptyHex(value: string): string | null {
-    return value === EthImpl.emptyHex ? null : value;
-  }
-
   private static redirectBytecodeAddressReplace(address: string): string {
     return `${this.redirectBytecodePrefix}${address.slice(2)}${this.redirectBytecodePostfix}`;
   }
 
-  /**
-   * Internal helper method that removes the leading 0x if there is one.
-   * @param input
-   * @private
-   */
   private static prune0x(input: string): string {
     return input.startsWith(EthImpl.emptyHex) ? input.substring(2) : input;
   }
@@ -1673,7 +1637,7 @@ export class EthImpl implements Eth {
       throw predefined.MAX_BLOCK_SIZE(blockResponse.count);
     }
 
-    const blockHash = EthImpl.toHash32(blockResponse.hash);
+    const blockHash = toHash32(blockResponse.hash);
     const transactionArray = contractResults.map(cr => showDetails ? formatContractResult(cr) : cr.hash);
     // Gating feature in case of unexpected behavior with other apps.
     if (this.shouldPopulateSyntheticContractResults) {
@@ -1683,19 +1647,19 @@ export class EthImpl implements Eth {
       baseFeePerGas: await this.gasPrice(requestIdPrefix),
       difficulty: EthImpl.zeroHex,
       extraData: EthImpl.emptyHex,
-      gasLimit: EthImpl.numberTo0x(maxGasLimit),
-      gasUsed: EthImpl.numberTo0x(gasUsed),
+      gasLimit: numberTo0x(maxGasLimit),
+      gasUsed: numberTo0x(gasUsed),
       hash: blockHash,
       logsBloom: EthImpl.emptyBloom, //TODO calculate full block boom in mirror node
       miner: EthImpl.zeroAddressHex,
       mixHash: EthImpl.zeroHex32Byte,
       nonce: EthImpl.zeroHex8Byte,
-      number: EthImpl.numberTo0x(blockResponse.number),
+      number: numberTo0x(blockResponse.number),
       parentHash: blockResponse.previous_hash.substring(0, 66),
       receiptsRoot: EthImpl.zeroHex32Byte,
-      timestamp: EthImpl.numberTo0x(Number(timestamp)),
+      timestamp: numberTo0x(Number(timestamp)),
       sha3Uncles: EthImpl.emptyArrayHex,
-      size: EthImpl.numberTo0x(blockResponse.size | 0),
+      size: numberTo0x(blockResponse.size | 0),
       stateRoot: EthImpl.zeroHex32Byte,
       totalDifficulty: EthImpl.zeroHex,
       transactions: transactionArray,
@@ -1756,7 +1720,7 @@ export class EthImpl implements Eth {
       input: EthImpl.zeroHex8Byte,
       maxPriorityFeePerGas: EthImpl.zeroHex,
       maxFeePerGas: EthImpl.zeroHex,
-      nonce: EthImpl.nanOrNumberTo0x(0),
+      nonce: nanOrNumberTo0x(0),
       r: EthImpl.zeroHex,
       s: EthImpl.zeroHex,
       to: log.address,
@@ -1811,7 +1775,7 @@ export class EthImpl implements Eth {
       return null;
     }
 
-    return EthImpl.numberTo0x(block.count);
+    return numberTo0x(block.count);
   }
 
 
@@ -1914,7 +1878,7 @@ export class EthImpl implements Eth {
     const accountData = await this.mirrorNodeClient.getAccount(address, requestId);
     if (accountData) {
       // with HIP 729 ethereum_nonce should always be 0+ and null. Historical contracts may have a null value as the nonce was not tracked, return default EVM compliant 0x1 in this case
-      return accountData.ethereum_nonce !== null ? EthImpl.numberTo0x(accountData.ethereum_nonce) : EthImpl.oneHex;
+      return accountData.ethereum_nonce !== null ? numberTo0x(accountData.ethereum_nonce) : EthImpl.oneHex;
     }
 
     return EthImpl.zeroHex;
@@ -1959,7 +1923,7 @@ export class EthImpl implements Eth {
       return await this.getAccountLatestEthereumNonce(address, requestIdPrefix);
     }
 
-    return EthImpl.numberTo0x(transactionResult.nonce + 1); // nonce is 0 indexed
+    return numberTo0x(transactionResult.nonce + 1); // nonce is 0 indexed
   }
 
   private async getAccountNonceForEarliestBlock(requestIdPrefix?: string): Promise<string> {
@@ -2033,14 +1997,14 @@ export class EthImpl implements Eth {
       logs.push(
         new Log({
           address: log.address,
-          blockHash: EthImpl.toHash32(log.block_hash),
-          blockNumber: EthImpl.numberTo0x(log.block_number),
+          blockHash: toHash32(log.block_hash),
+          blockNumber: numberTo0x(log.block_number),
           data: log.data,
-          logIndex: EthImpl.nullableNumberTo0x(log.index),
+          logIndex: nullableNumberTo0x(log.index),
           removed: false,
           topics: log.topics,
-          transactionHash: EthImpl.toHash32(log.transaction_hash),
-          transactionIndex: EthImpl.nullableNumberTo0x(log.transaction_index)
+          transactionHash: toHash32(log.transaction_hash),
+          transactionIndex: nullableNumberTo0x(log.transaction_index)
         })
       );
     }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -20,8 +20,6 @@
 
 import { Eth } from '../index';
 import {Hbar, PrecheckStatusError} from '@hashgraph/sdk';
-import { BigNumber } from '@hashgraph/sdk/lib/Transfer';
-import { BigNumber as BN } from "bignumber.js";
 import { Logger } from 'pino';
 import { Block, Transaction, Log } from './model';
 import { ClientCache, MirrorNodeClient } from './clients';

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -24,7 +24,7 @@ import { EthImpl } from './eth';
 import { Logger } from 'pino';
 import constants from './constants';
 import { BigNumber, ethers, Transaction } from 'ethers';
-import { formatRequestIdMessage } from '../formatters';
+import { formatRequestIdMessage, prepend0x } from '../formatters';
 
 export class Precheck {
   private mirrorNodeClient: MirrorNodeClient;
@@ -94,7 +94,7 @@ export class Precheck {
    */
   chainId(tx: Transaction, requestId?: string) {
     const requestIdPrefix = formatRequestIdMessage(requestId);
-    const txChainId = EthImpl.prepend0x(Number(tx.chainId).toString(16));
+    const txChainId = prepend0x(Number(tx.chainId).toString(16));
     const passes = txChainId === this.chain;
     if (!passes) {
       this.logger.trace(`${requestIdPrefix} Failed chainId precheck for sendRawTransaction(transaction=%s, chainId=%s)`, JSON.stringify(tx), txChainId);

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -34,6 +34,7 @@ import { Gauge, Registry } from 'prom-client';
 import HAPIService from './services/hapiService/hapiService';
 import constants from './constants';
 import HbarLimit from './hbarlimiter';
+import { prepend0x } from '../formatters';
 
 export class RelayImpl implements Relay {
   private readonly clientMain: Client;
@@ -51,7 +52,7 @@ export class RelayImpl implements Relay {
 
     const configuredChainId =
       process.env.CHAIN_ID || constants.CHAIN_IDS[hederaNetwork] || '298';
-    const chainId = EthImpl.prepend0x(Number(configuredChainId).toString(16));
+    const chainId = prepend0x(Number(configuredChainId).toString(16));
 
     const duration = constants.HBAR_RATE_LIMIT_DURATION;
     const total = constants.HBAR_RATE_LIMIT_TINYBAR;

--- a/packages/relay/tests/assertions.ts
+++ b/packages/relay/tests/assertions.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { JsonRpcError } from '../src';
 import { EthImpl } from "../src/lib/eth";
 import { Block, Transaction} from "../src/lib/model";
+import { numberTo0x } from '../src/formatters';
 
 export default class RelayAssertions {
     static assertRejection = async (error: JsonRpcError, method, checkMessage: boolean, thisObj, args?: any[]): Promise<any> => {
@@ -65,13 +66,13 @@ export default class RelayAssertions {
         expect(tx.input).to.eq(expectedTx.input);
         expect(tx.maxFeePerGas).to.eq(expectedTx.maxFeePerGas);
         expect(tx.maxPriorityFeePerGas).to.eq(expectedTx.maxPriorityFeePerGas);
-        expect(tx.nonce).to.eq(EthImpl.numberTo0x(expectedTx.nonce));
+        expect(tx.nonce).to.eq(numberTo0x(expectedTx.nonce));
         expect(tx.r).to.eq(expectedTx.r);
         expect(tx.s).to.eq(expectedTx.s);
         expect(tx.to).to.eq(expectedTx.to);
         expect(tx.transactionIndex).to.eq(expectedTx.transactionIndex);
-        expect(tx.type).to.eq(EthImpl.numberTo0x(expectedTx.type));
-        expect(tx.v).to.eq(EthImpl.numberTo0x(expectedTx.v));
+        expect(tx.type).to.eq(numberTo0x(expectedTx.type));
+        expect(tx.v).to.eq(numberTo0x(expectedTx.v));
         expect(tx.value).to.eq(expectedTx.value);
     };
     
@@ -112,7 +113,7 @@ export default class RelayAssertions {
 
     
     static verifyBlockConstants = (block: Block) => {
-        expect(block.gasLimit).equal(EthImpl.numberTo0x(15000000));
+        expect(block.gasLimit).equal(numberTo0x(15000000));
         expect(block.baseFeePerGas).equal('0x84b6a5c400');
         expect(block.difficulty).equal(EthImpl.zeroHex);
         expect(block.extraData).equal(EthImpl.emptyHex);

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -21,8 +21,7 @@
 import { expect } from "chai";
 import { ethers } from 'ethers';
 import crypto from 'crypto';
-import { EthImpl } from "../src/lib/eth";
-import { formatRequestIdMessage } from '../src/formatters';
+import { formatRequestIdMessage, numberTo0x, toHash32 } from '../src/formatters';
 import { v4 as uuid } from 'uuid';
 
 // Randomly generated key
@@ -79,17 +78,17 @@ export const ethGetLogsFailing = async (ethImpl, args, assertFunc) => {
 
 export const expectLogData = (res, log, tx) => {
     expect(res.address).to.eq(log.address);
-    expect(res.blockHash).to.eq(EthImpl.toHash32(tx.block_hash));
+    expect(res.blockHash).to.eq(toHash32(tx.block_hash));
     expect(res.blockHash.length).to.eq(66);
-    expect(res.blockNumber).to.eq(EthImpl.numberTo0x(tx.block_number));
+    expect(res.blockNumber).to.eq(numberTo0x(tx.block_number));
     expect(res.data).to.eq(log.data);
-    expect(res.logIndex).to.eq(EthImpl.numberTo0x(log.index));
+    expect(res.logIndex).to.eq(numberTo0x(log.index));
     expect(res.removed).to.eq(false);
     expect(res.topics).to.exist;
     expect(res.topics).to.deep.eq(log.topics);
     expect(res.transactionHash).to.eq(tx.hash);
     expect(res.transactionHash.length).to.eq(66);
-    expect(res.transactionIndex).to.eq(EthImpl.numberTo0x(tx.transaction_index));
+    expect(res.transactionIndex).to.eq(numberTo0x(tx.transaction_index));
 };
 
 export const expectLogData1 = (res) => {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -67,7 +67,7 @@ import chaiAsPromised from 'chai-as-promised';
 import RelayAssertions from '../assertions';
 import {v4 as uuid} from 'uuid';
 import { JsonRpcError } from '../../dist';
-import { hashNumber } from '../../dist/formatters';
+import { hashNumber, numberTo0x, nullableNumberTo0x, toHash32 } from '../../dist/formatters';
 import * as _ from 'lodash';
 
 chai.use(chaiAsPromised);
@@ -155,10 +155,10 @@ describe('Eth calls using MirrorNode', async function () {
   const gasUsed1 = 200000;
   const gasUsed2 = 800000;
   const maxGasLimit = 250000;
-  const maxGasLimitHex = EthImpl.numberTo0x(maxGasLimit);
+  const maxGasLimitHex = numberTo0x(maxGasLimit);
   const contractCallData = "0xef641f44";
   const blockTimestamp = '1651560386';
-  const blockTimestampHex = EthImpl.numberTo0x(Number(blockTimestamp));
+  const blockTimestampHex = numberTo0x(Number(blockTimestamp));
   const firstTransactionTimestampSeconds = '1653077541';
   const contractAddress1 = '0x000000000000000000000000000000000000055f';
   const htsTokenAddress = '0x0000000000000000000000000000000002dca431';
@@ -386,7 +386,7 @@ describe('Eth calls using MirrorNode', async function () {
   const detailedContractResultNotFound = { "_status": { "messages": [{ "message": "No correlating transaction" }] } };
 
   const results = defaultContractResults.results;
-  const totalGasUsed = EthImpl.numberTo0x(results[0].gas_used + results[1].gas_used);
+  const totalGasUsed = numberTo0x(results[0].gas_used + results[1].gas_used);
 
   const defaultNetworkFees = {
     'fees': [
@@ -405,7 +405,7 @@ describe('Eth calls using MirrorNode', async function () {
     ],
     'timestamp': '1653644164.591111113'
   };
-  const baseFeePerGasHex = EthImpl.numberTo0x(BigInt(defaultNetworkFees.fees[2].gas) * TINYBAR_TO_WEIBAR_COEF_BIGINT); // '0x84b6a5c400' -> 570_000_000_000 tb
+  const baseFeePerGasHex = numberTo0x(BigInt(defaultNetworkFees.fees[2].gas) * TINYBAR_TO_WEIBAR_COEF_BIGINT); // '0x84b6a5c400' -> 570_000_000_000 tb
 
   const defaultContract = {
     "admin_key": null,
@@ -488,7 +488,7 @@ describe('Eth calls using MirrorNode', async function () {
       blocks: [defaultBlock]
     });
     const blockNumber = await ethImpl.blockNumber();
-    expect(EthImpl.numberTo0x(defaultBlock.number)).to.be.eq(blockNumber);
+    expect(numberTo0x(defaultBlock.number)).to.be.eq(blockNumber);
 
     // Second call should return the same block number using cache
     restMock.onGet('blocks?limit=1&order=desc').reply(400, {
@@ -506,7 +506,7 @@ describe('Eth calls using MirrorNode', async function () {
       blocks: [{...defaultBlock, number : newBlockNumber}]
     });
     const blockNumber3 = await ethImpl.blockNumber();
-    expect(EthImpl.numberTo0x(newBlockNumber)).to.be.eq(blockNumber3);
+    expect(numberTo0x(newBlockNumber)).to.be.eq(blockNumber3);
 
   });
 
@@ -595,7 +595,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       restMock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultContractResults);
 
-      const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
+      const result = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), false);
 
       RelayAssertions.assertBlock(result, {
         hash: blockHashTrimmed,
@@ -611,7 +611,7 @@ describe('Eth calls using MirrorNode', async function () {
       const next = `contracts/results?timestamp=lte:${defaultBlock.timestamp.to}&timestamp=gte:${defaultBlock.timestamp.from}&limit=100&order=asc`; // just flip the timestamp parameters for simplicity
       restMock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, { 'results': [], 'links': { 'next': next } });
       restMock.onGet(next).reply(200, defaultContractResults);
-      const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
+      const result = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), false);
 
       RelayAssertions.assertBlock(result, {
         hash: blockHashTrimmed,
@@ -625,10 +625,10 @@ describe('Eth calls using MirrorNode', async function () {
 
     it('eth_getBlockByNumber should return cached result', async function() {
       restMock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultContractResults);
-      const resBeforeCache = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
+      const resBeforeCache = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), false);
 
       restMock.onGet(`blocks/${blockNumber}`).reply(404);
-      const resAfterCache = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
+      const resAfterCache = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), false);
 
       expect(resBeforeCache).to.eq(resAfterCache);
     });
@@ -671,7 +671,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
     restMock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, { 'results': [] });
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, { logs: [] });
-    const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
+    const result = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), false);
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -695,7 +695,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
     restMock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultContractResults);
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
-    const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), true);
+    const result = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), true);
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -723,7 +723,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, { 'results': [], 'links': { 'next': next } });
     restMock.onGet(next).reply(200, defaultContractResults);
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
-    const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), true);
+    const result = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), true);
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -750,13 +750,13 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultContractResultsRevert);
     restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, { logs: [] });
 
-    const result = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), true);
+    const result = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), true);
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
     // verify aggregated info
     expect(result.hash).equal(blockHashTrimmed);
-    expect(result.gasUsed).equal(EthImpl.numberTo0x(gasUsed1));
+    expect(result.gasUsed).equal(numberTo0x(gasUsed1));
     expect(result.number).equal(blockNumberHex);
     expect(result.parentHash).equal(blockHashPreviousTrimmed);
     expect(result.timestamp).equal(blockTimestampHex);
@@ -975,7 +975,7 @@ describe('Eth calls using MirrorNode', async function () {
     const result = await ethImpl.getBlockByHash(blockHash, true);
     RelayAssertions.assertBlock(result, {
       hash: blockHashTrimmed,
-      gasUsed: EthImpl.numberTo0x(randomBlock.gas_used),
+      gasUsed: numberTo0x(randomBlock.gas_used),
       number: blockNumberHex,
       parentHash: blockHashPreviousTrimmed,
       timestamp: blockTimestampHex,
@@ -1018,7 +1018,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
 
     const result = await ethImpl.getBlockTransactionCountByNumber(blockNumber.toString());
-    expect(result).equal(EthImpl.numberTo0x(blockTransactionCount));
+    expect(result).equal(numberTo0x(blockTransactionCount));
   });
 
   it('eth_getBlockTransactionCountByNumber with match should hit cache', async function() {
@@ -1026,7 +1026,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     for (let i = 0; i < 3; i++) {
       const result = await ethImpl.getBlockTransactionCountByNumber(blockNumber.toString());
-      expect(result).equal(EthImpl.numberTo0x(blockTransactionCount));
+      expect(result).equal(numberTo0x(blockTransactionCount));
     }
   });
 
@@ -1052,7 +1052,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
 
     const result = await ethImpl.getBlockTransactionCountByNumber('latest');
-    expect(result).equal(EthImpl.numberTo0x(blockTransactionCount));
+    expect(result).equal(numberTo0x(blockTransactionCount));
   });
 
   it('eth_getBlockTransactionCountByNumber with pending tag', async function () {
@@ -1061,7 +1061,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`blocks/${blockNumber}`).reply(200, defaultBlock);
 
     const result = await ethImpl.getBlockTransactionCountByNumber('pending');
-    expect(result).equal(EthImpl.numberTo0x(blockTransactionCount));
+    expect(result).equal(numberTo0x(blockTransactionCount));
   });
 
   it('eth_getBlockTransactionCountByNumber with earliest tag', async function () {
@@ -1069,7 +1069,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`blocks/0`).reply(200, defaultBlock);
 
     const result = await ethImpl.getBlockTransactionCountByNumber('earliest');
-    expect(result).equal(EthImpl.numberTo0x(blockTransactionCount));
+    expect(result).equal(numberTo0x(blockTransactionCount));
   });
 
   it('eth_getBlockTransactionCountByNumber with hex number', async function () {
@@ -1077,7 +1077,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`blocks/3735929054`).reply(200, defaultBlock);
 
     const result = await ethImpl.getBlockTransactionCountByNumber('0xdeadc0de');
-    expect(result).equal(EthImpl.numberTo0x(blockTransactionCount));
+    expect(result).equal(numberTo0x(blockTransactionCount));
   });
 
   it('eth_getBlockTransactionCountByHash with match', async function () {
@@ -1085,7 +1085,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`blocks/${blockHash}`).reply(200, defaultBlock);
 
     const result = await ethImpl.getBlockTransactionCountByHash(blockHash);
-    expect(result).equal(EthImpl.numberTo0x(blockTransactionCount));
+    expect(result).equal(numberTo0x(blockTransactionCount));
   });
 
   it('eth_getBlockTransactionCountByHash with match should hit cache', async function() {
@@ -1093,7 +1093,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     for (let i = 0; i < 3; i++) {
       const result = await ethImpl.getBlockTransactionCountByHash(blockHash);
-      expect(result).equal(EthImpl.numberTo0x(blockTransactionCount));
+      expect(result).equal(numberTo0x(blockTransactionCount));
     }
   });
 
@@ -1119,7 +1119,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results?block.number=${defaultBlock.number}&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
     restMock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResults);
 
-    const result = await ethImpl.getTransactionByBlockNumberAndIndex(EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockNumberAndIndex(numberTo0x(defaultBlock.number), numberTo0x(defaultBlock.count));
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -1140,7 +1140,7 @@ describe('Eth calls using MirrorNode', async function () {
     nullableDefaultContractResults.results[0].amount = null;
     restMock.onGet(`contracts/results?block.number=${randomBlock.number}&transaction.index=${randomBlock.count}&limit=100&order=asc`).reply(200, nullableDefaultContractResults);
 
-    const result = await ethImpl.getTransactionByBlockNumberAndIndex(EthImpl.numberTo0x(randomBlock.number), EthImpl.numberTo0x(randomBlock.count));
+    const result = await ethImpl.getTransactionByBlockNumberAndIndex(numberTo0x(randomBlock.number), numberTo0x(randomBlock.count));
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -1159,7 +1159,7 @@ describe('Eth calls using MirrorNode', async function () {
       }
     });
 
-    const result = await ethImpl.getTransactionByBlockNumberAndIndex(EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockNumberAndIndex(numberTo0x(defaultBlock.number), numberTo0x(defaultBlock.count));
     expect(result).to.equal(null);
   });
 
@@ -1170,7 +1170,7 @@ describe('Eth calls using MirrorNode', async function () {
     };
     restMock.onGet(`contracts/results?block.number=${randomBlock.number}&transaction.index=${randomBlock.count}&limit=100&order=asc`).reply(200, defaultContractResultsWithNullableFrom);
 
-    const args = [EthImpl.numberTo0x(randomBlock.number), EthImpl.numberTo0x(randomBlock.count)];
+    const args = [numberTo0x(randomBlock.number), numberTo0x(randomBlock.count)];
     const errMessage = "Cannot read properties of null (reading 'substring')";
 
     await RelayAssertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionByBlockNumberAndIndex, true, ethImpl, args);
@@ -1181,7 +1181,7 @@ describe('Eth calls using MirrorNode', async function () {
       'results': []
     });
 
-    const result = await ethImpl.getTransactionByBlockNumberAndIndex(EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockNumberAndIndex(numberTo0x(defaultBlock.number), numberTo0x(defaultBlock.count));
     expect(result).to.equal(null);
   });
 
@@ -1190,7 +1190,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet('blocks?limit=1&order=desc').reply(200, { blocks: [defaultBlock] });
     restMock.onGet(`contracts/results?block.number=${defaultBlock.number}&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
 
-    const result = await ethImpl.getTransactionByBlockNumberAndIndex('latest', EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockNumberAndIndex('latest', numberTo0x(defaultBlock.count));
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -1206,7 +1206,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet('blocks?limit=1&order=desc').reply(200, { blocks: [defaultBlock] });
     restMock.onGet(`contracts/results?block.number=${defaultBlock.number}&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
 
-    const result = await ethImpl.getTransactionByBlockNumberAndIndex('pending', EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockNumberAndIndex('pending', numberTo0x(defaultBlock.count));
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -1221,7 +1221,7 @@ describe('Eth calls using MirrorNode', async function () {
     // mirror node request mocks
     restMock.onGet(`contracts/results?block.number=0&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
 
-    const result = await ethImpl.getTransactionByBlockNumberAndIndex('earliest', EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockNumberAndIndex('earliest', numberTo0x(defaultBlock.count));
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -1236,7 +1236,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`contracts/results?block.number=3735929054&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
 
     const result = await ethImpl.getTransactionByBlockNumberAndIndex('0xdeadc0de' +
-      '', EthImpl.numberTo0x(defaultBlock.count));
+      '', numberTo0x(defaultBlock.count));
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -1251,7 +1251,7 @@ describe('Eth calls using MirrorNode', async function () {
     // mirror node request mocks
     restMock.onGet(`contracts/results?block.hash=${defaultBlock.hash}&transaction.index=${defaultBlock.count}&limit=100&order=asc`).reply(200, defaultContractResults);
     restMock.onGet(`contracts/${contractAddress1}/results/${contractTimestamp1}`).reply(200, defaultDetailedContractResults);
-    const result = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, numberTo0x(defaultBlock.count));
     expect(result).to.exist;
     expect(result).to.not.be.null;
 
@@ -1269,7 +1269,7 @@ describe('Eth calls using MirrorNode', async function () {
     };
     restMock.onGet(`contracts/results?block.hash=${randomBlock.hash}&transaction.index=${randomBlock.count}&limit=100&order=asc`).reply(200, defaultContractResultsWithNullableFrom);
 
-    const args = [randomBlock.hash, EthImpl.numberTo0x(randomBlock.count)];
+    const args = [randomBlock.hash, numberTo0x(randomBlock.count)];
     const errMessage = "Cannot read properties of null (reading 'substring')";
 
     await RelayAssertions.assertRejection(predefined.INTERNAL_ERROR(errMessage), ethImpl.getTransactionByBlockHashAndIndex, true, ethImpl, args);
@@ -1287,7 +1287,7 @@ describe('Eth calls using MirrorNode', async function () {
       }
     });
 
-    const result = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash.toString(), EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash.toString(), numberTo0x(defaultBlock.count));
     expect(result).to.equal(null);
   });
 
@@ -1296,7 +1296,7 @@ describe('Eth calls using MirrorNode', async function () {
       'results': []
     });
 
-    const result = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash.toString(), EthImpl.numberTo0x(defaultBlock.count));
+    const result = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash.toString(), numberTo0x(defaultBlock.count));
     expect(result).to.equal(null);
   });
 
@@ -1335,7 +1335,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`).reply(200, defaultDetailedContractResults);
       restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
 
-    const args = [EthImpl.numberTo0x(blockNumber), true];
+    const args = [numberTo0x(blockNumber), true];
 
     await RelayAssertions.assertRejection(predefined.MAX_BLOCK_SIZE(77), ethImplLowTransactionCount.getBlockByNumber, true, ethImplLowTransactionCount, args);
     });
@@ -1344,7 +1344,7 @@ describe('Eth calls using MirrorNode', async function () {
 
   describe('eth_getBalance', async function() {
     const defBalance = 99960581137;
-    const defHexBalance = EthImpl.numberTo0x(BigInt(defBalance) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+    const defHexBalance = numberTo0x(BigInt(defBalance) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
     it('should return balance from mirror node', async () => {
       restMock.onGet(`blocks?limit=1&order=desc`).reply(200, {
         blocks: [{
@@ -1386,7 +1386,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       // Third call should return new number using mirror node
       const newBalance = 55555;
-      const newBalanceHex = EthImpl.numberTo0x(BigInt(newBalance) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+      const newBalanceHex = numberTo0x(BigInt(newBalance) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
       restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {
@@ -1538,8 +1538,8 @@ describe('Eth calls using MirrorNode', async function () {
       const timestamp3 = 1651560386;
       const timestamp4 = 1651561386;
 
-      const hexBalance1 = EthImpl.numberTo0x(BigInt(balance1) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
-      const hexBalance3 = EthImpl.numberTo0x(BigInt(balance3) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+      const hexBalance1 = numberTo0x(BigInt(balance1) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+      const hexBalance3 = numberTo0x(BigInt(balance3) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
 
       const latestBlock = Object.assign({}, defaultBlock, {
         number: 4,
@@ -1675,7 +1675,7 @@ describe('Eth calls using MirrorNode', async function () {
         });
  
         const resBalance = await ethImpl.getBalance(contractId1, '2', getRequestId());
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+        const historicalBalance = numberTo0x(BigInt(balance3) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);
       });
 
@@ -1720,7 +1720,7 @@ describe('Eth calls using MirrorNode', async function () {
         });
 
         const resBalance = await ethImpl.getBalance(contractId1, '2', getRequestId());
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 - 175) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+        const historicalBalance = numberTo0x(BigInt(balance3 - 175) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);
       });
 
@@ -1750,7 +1750,7 @@ describe('Eth calls using MirrorNode', async function () {
         });
  
         const resBalance = await ethImpl.getBalance(contractId1, '2', getRequestId());
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 + 175) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+        const historicalBalance = numberTo0x(BigInt(balance3 + 175) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);
       });
 
@@ -1781,7 +1781,7 @@ describe('Eth calls using MirrorNode', async function () {
         });
 
         const resBalance = await ethImpl.getBalance(contractId1, '2', getRequestId());
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 + 65) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+        const historicalBalance = numberTo0x(BigInt(balance3 + 65) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);
 
       });
@@ -1824,7 +1824,7 @@ describe('Eth calls using MirrorNode', async function () {
         });
       
         const resBalance = await ethImpl.getBalance(contractId1, '1', getRequestId());
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 - 230) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+        const historicalBalance = numberTo0x(BigInt(balance3 - 230) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);
       });
 
@@ -1882,7 +1882,7 @@ describe('Eth calls using MirrorNode', async function () {
         });
       
         const resBalance = await ethImpl.getBalance(contractId1, '1', getRequestId());
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 - 480) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+        const historicalBalance = numberTo0x(BigInt(balance3 - 480) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);        
       });
 
@@ -1940,7 +1940,7 @@ describe('Eth calls using MirrorNode', async function () {
         });
       
         const resBalance = await ethImpl.getBalance(contractId1, '1', getRequestId());
-        const historicalBalance = EthImpl.numberTo0x(BigInt(balance3 - 80) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+        const historicalBalance = numberTo0x(BigInt(balance3 - 80) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
         expect(resBalance).to.equal(historicalBalance);        
       });      
 
@@ -2737,7 +2737,7 @@ describe('Eth calls using MirrorNode', async function () {
       const feeHistory = await ethImpl.feeHistory(countBlocks, 'latest', [25, 75]);
 
       expect(feeHistory).to.exist;
-      expect(feeHistory['oldestBlock']).to.eq(EthImpl.numberTo0x(latestBlockNumber - countBlocks + 1));
+      expect(feeHistory['oldestBlock']).to.eq(numberTo0x(latestBlockNumber - countBlocks + 1));
       expect(feeHistory['baseFeePerGas'].length).to.eq(countBlocks + 1);
       expect(feeHistory['baseFeePerGas'][0]).to.eq(baseFeePerGasHex);
       expect(feeHistory['baseFeePerGas'][1]).to.eq(baseFeePerGasHex);
@@ -2755,7 +2755,7 @@ describe('Eth calls using MirrorNode', async function () {
       const feeHistory = await ethImpl.feeHistory(countBlocks, 'latest', []);
 
       expect(feeHistory).to.exist;
-      expect(feeHistory['oldestBlock']).to.eq(EthImpl.numberTo0x(latestBlockNumber - countBlocks + 1));
+      expect(feeHistory['oldestBlock']).to.eq(numberTo0x(latestBlockNumber - countBlocks + 1));
       expect(feeHistory['baseFeePerGas'].length).to.eq(countBlocks + 1);
       expect(feeHistory['baseFeePerGas'][0]).to.eq(baseFeePerGasHex);
       expect(feeHistory['baseFeePerGas'][1]).to.eq(baseFeePerGasHex);
@@ -2774,7 +2774,7 @@ describe('Eth calls using MirrorNode', async function () {
       const feeHistory = await ethImpl.feeHistory(countBlocks, 'latest', []);
 
       expect(feeHistory).to.exist;
-      expect(feeHistory['oldestBlock']).to.eq(EthImpl.numberTo0x(latestBlockNumber - countBlocks + 1));
+      expect(feeHistory['oldestBlock']).to.eq(numberTo0x(latestBlockNumber - countBlocks + 1));
       expect(feeHistory['baseFeePerGas'].length).to.eq(countBlocks + 1);
       expect(feeHistory['baseFeePerGas'][0]).to.eq(baseFeePerGasHex);
       expect(feeHistory['baseFeePerGas'][1]).to.eq(baseFeePerGasHex);
@@ -2792,7 +2792,7 @@ describe('Eth calls using MirrorNode', async function () {
       const feeHistory = await ethImpl.feeHistory(countBlocks, 'pending', []);
 
       expect(feeHistory).to.exist;
-      expect(feeHistory['oldestBlock']).to.eq(EthImpl.numberTo0x(latestBlockNumber - countBlocks + 1));
+      expect(feeHistory['oldestBlock']).to.eq(numberTo0x(latestBlockNumber - countBlocks + 1));
       expect(feeHistory['baseFeePerGas'].length).to.eq(countBlocks + 1);
       expect(feeHistory['baseFeePerGas'][0]).to.eq(baseFeePerGasHex);
     });
@@ -2807,7 +2807,7 @@ describe('Eth calls using MirrorNode', async function () {
       const feeHistory = await ethImpl.feeHistory(countBlocks, 'earliest', []);
 
       expect(feeHistory).to.exist;
-      expect(feeHistory['oldestBlock']).to.eq(EthImpl.numberTo0x(1));
+      expect(feeHistory['oldestBlock']).to.eq(numberTo0x(1));
       expect(feeHistory['baseFeePerGas'].length).to.eq(2);
       expect(feeHistory['baseFeePerGas'][0]).to.eq(baseFeePerGasHex);
     });
@@ -2824,7 +2824,7 @@ describe('Eth calls using MirrorNode', async function () {
       const feeHistory = await ethImpl.feeHistory(countBlocks, 'latest', []);
 
       expect(feeHistory).to.exist;
-      expect(feeHistory['oldestBlock']).to.eq(EthImpl.numberTo0x(latestBlockNumber - countBlocks + 1));
+      expect(feeHistory['oldestBlock']).to.eq(numberTo0x(latestBlockNumber - countBlocks + 1));
       expect(feeHistory['baseFeePerGas'].length).to.eq(countBlocks + 1);
       expect(feeHistory['baseFeePerGas'][0]).to.eq(baseFeePerGasHex);
       expect(feeHistory['baseFeePerGas'][1]).to.eq(baseFeePerGasHex);
@@ -2835,7 +2835,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const feeHistoryUsingCache = await ethImpl.feeHistory(countBlocks, 'latest', []);
       expect(feeHistoryUsingCache).to.exist;
-      expect(feeHistoryUsingCache['oldestBlock']).to.eq(EthImpl.numberTo0x(latestBlockNumber - countBlocks + 1));
+      expect(feeHistoryUsingCache['oldestBlock']).to.eq(numberTo0x(latestBlockNumber - countBlocks + 1));
       expect(feeHistoryUsingCache['baseFeePerGas'].length).to.eq(countBlocks + 1);
       expect(feeHistoryUsingCache['baseFeePerGas'][0]).to.eq(baseFeePerGasHex);
       expect(feeHistoryUsingCache['baseFeePerGas'][1]).to.eq(baseFeePerGasHex);
@@ -2855,7 +2855,7 @@ describe('Eth calls using MirrorNode', async function () {
     web3Mock.onPost('contracts/call', {...callData, estimate: true}).reply(501, {"errorMessage":"","statusCode":501});
 
     const gas = await ethImpl.estimateGas(callData, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(gas).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
   it('eth_estimateGas to mirror node for contract call returns 501', async function () {
@@ -2866,7 +2866,7 @@ describe('Eth calls using MirrorNode', async function () {
     web3Mock.onPost('contracts/call', {...callData, estimate: true}).reply(501, {"errorMessage":"","statusCode":501});
 
     const gas = await ethImpl.estimateGas(callData, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(gas).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
   it('eth_estimateGas contract call returns workaround response from mirror-node', async function () {
@@ -2877,12 +2877,12 @@ describe('Eth calls using MirrorNode', async function () {
     web3Mock.onPost('contracts/call', {...callData, estimate: true}).reply(200, {result: `0x61A80`});
 
     const gas = await ethImpl.estimateGas(callData, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(gas).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
   it('eth_estimateGas contract call returns default', async function () {
     const gas = await ethImpl.estimateGas({ data: "0x01" }, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(gas).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
   it('eth_estimateGas to mirror node for transfer returns 501', async function () {
@@ -2897,7 +2897,7 @@ describe('Eth calls using MirrorNode', async function () {
     restMock.onGet(`accounts/${receiverAddress}${noTransactions}`).reply(200, { address: receiverAddress });
 
     const gas = await ethImpl.estimateGas(callData, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(constants.TX_BASE_COST));
+    expect(gas).to.equal(numberTo0x(constants.TX_BASE_COST));
   });
 
   it('eth_estimateGas to mirror node for transfer without value returns 501', async function () {
@@ -2981,7 +2981,7 @@ describe('Eth calls using MirrorNode', async function () {
   it('eth_estimateGas empty call returns transfer cost', async function () {
     restMock.onGet(`accounts/undefined${noTransactions}`).reply(404);
     const gas = await ethImpl.estimateGas({}, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(gas).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
   it('eth_estimateGas empty call returns transfer cost with overridden default gas', async function () {
@@ -2990,13 +2990,13 @@ describe('Eth calls using MirrorNode', async function () {
     const ethImplOverridden = new EthImpl(sdkClientStub, mirrorNodeInstance, logger, '0x12a', registry, clientCache);
     restMock.onGet(`accounts/undefined${noTransactions}`).reply(404);
     const gas = await ethImplOverridden.estimateGas({}, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(defaultGasOverride));
+    expect(gas).to.equal(numberTo0x(defaultGasOverride));
   });
 
   it('eth_estimateGas empty input transfer cost', async function () {
     restMock.onGet(`accounts/undefined${noTransactions}`).reply(404);
     const gas = await ethImpl.estimateGas({ data: "" }, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(gas).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
   it('eth_estimateGas empty input transfer cost with overridden default gas', async function () {
@@ -3005,13 +3005,13 @@ describe('Eth calls using MirrorNode', async function () {
     const ethImplOverridden = new EthImpl(sdkClientStub, mirrorNodeInstance, logger, '0x12a', registry, clientCache);
     restMock.onGet(`accounts/undefined${noTransactions}`).reply(404);
     const gas = await ethImplOverridden.estimateGas({ data: "" }, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(defaultGasOverride));
+    expect(gas).to.equal(numberTo0x(defaultGasOverride));
   });
 
   it('eth_estimateGas zero input returns transfer cost', async function () {
     restMock.onGet(`accounts/undefined${noTransactions}`).reply(404);
     const gas = await ethImpl.estimateGas({ data: "0x" }, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(gas).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
   it('eth_estimateGas zero input returns transfer cost with overridden default gas', async function () {
@@ -3020,7 +3020,7 @@ describe('Eth calls using MirrorNode', async function () {
     const ethImplOverridden = new EthImpl(sdkClientStub, mirrorNodeInstance, logger, '0x12a', registry, clientCache);
     restMock.onGet(`accounts/undefined${noTransactions}`).reply(404);
     const gas = await ethImplOverridden.estimateGas({ data: "0x" }, null);
-    expect(gas).to.equal(EthImpl.numberTo0x(defaultGasOverride));
+    expect(gas).to.equal(numberTo0x(defaultGasOverride));
   });
 
   it('eth_estimateGas with contract revert and message does not equal executionReverted', async function () {
@@ -3043,7 +3043,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     const result: any = await ethImpl.estimateGas(transaction, id);
 
-    expect(result).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(result).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
 
   });
 
@@ -3069,7 +3069,7 @@ describe('Eth calls using MirrorNode', async function () {
 
     const result: any = await ethImpl.estimateGas(transaction, id);
 
-    expect(result).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(result).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
     process.env.ESTIMATE_GAS_THROWS = estimateGasThrows;
 
   });
@@ -3118,7 +3118,7 @@ describe('Eth calls using MirrorNode', async function () {
     });
   
     const result: any = await ethImpl.estimateGas(transaction, id);
-    expect(result).to.equal(EthImpl.numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
+    expect(result).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
   describe('eth_gasPrice', async function () {
@@ -3127,7 +3127,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const weiBars = await ethImpl.gasPrice();
       const expectedWeiBars = defaultNetworkFees.fees[2].gas * constants.TINYBAR_TO_WEIBAR_COEF;
-      expect(weiBars).to.equal(EthImpl.numberTo0x(expectedWeiBars));
+      expect(weiBars).to.equal(numberTo0x(expectedWeiBars));
     });
 
     it('eth_gasPrice with cached value', async function () {
@@ -4072,7 +4072,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
       restMock.onGet(`contracts/${contractAddress1}/state?timestamp=${defaultBlock.timestamp.to}&slot=0x101&limit=100&order=desc`).reply(200, defaultCurrentContractState);
 
-      const result = await ethImpl.getStorageAt(contractAddress1, '0x101', EthImpl.numberTo0x(blockNumber));
+      const result = await ethImpl.getStorageAt(contractAddress1, '0x101', numberTo0x(blockNumber));
       expect(result).to.exist;
       expect(result).to.not.be.null;
 
@@ -4087,7 +4087,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
       restMock.onGet(`contracts/${contractAddress1}/state?timestamp=${defaultBlock.timestamp.to}&slot=0x0000101&limit=100&order=desc`).reply(200, defaultCurrentContractState);
 
-      const result = await ethImpl.getStorageAt(contractAddress1, '0x0000101', EthImpl.numberTo0x(blockNumber));
+      const result = await ethImpl.getStorageAt(contractAddress1, '0x0000101', numberTo0x(blockNumber));
       expect(result).to.exist;
       expect(result).to.not.be.null;
 
@@ -4102,7 +4102,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
       restMock.onGet(`contracts/${contractAddress1}/state?timestamp=${defaultBlock.timestamp.to}&slot=0x0000000000000000000000000000000000000000000000000000000000000101&limit=100&order=desc`).reply(200, defaultCurrentContractState);
 
-      const result = await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, EthImpl.numberTo0x(blockNumber));
+      const result = await ethImpl.getStorageAt(contractAddress1, defaultDetailedContractResults.state_changes[0].slot, numberTo0x(blockNumber));
       expect(result).to.exist;
       expect(result).to.not.be.null;
 
@@ -4144,7 +4144,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const args = [contractAddress1,
                     defaultDetailedContractResults.state_changes[0].slot,
-                    EthImpl.numberTo0x(blockNumber)];
+                    numberTo0x(blockNumber)];
 
       await RelayAssertions.assertRejection(predefined.RESOURCE_NOT_FOUND(), ethImpl.getStorageAt, false, ethImpl, args);
     });
@@ -4155,7 +4155,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
       restMock.onGet(`contracts/${contractAddress1}/state?timestamp=${defaultBlock.timestamp.to}&slot=${wrongSlot}&limit=100&order=desc`).reply(200, defaultContractStateEmptyArray);
 
-      const result = await ethImpl.getStorageAt(contractAddress1, wrongSlot, EthImpl.numberTo0x(blockNumber));
+      const result = await ethImpl.getStorageAt(contractAddress1, wrongSlot, numberTo0x(blockNumber));
       expect(result).to.equal(EthImpl.zeroHex32Byte);
     });
 
@@ -4165,7 +4165,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
       restMock.onGet(`contracts/${contractAddress1}/state?timestamp=${olderBlock.timestamp.to}&slot=${defaultOlderContractState.state[0].slot}&limit=100&order=desc`).reply(200, defaultOlderContractState);
 
-      const result = await ethImpl.getStorageAt(contractAddress1, defaultOlderContractState.state[0].slot, EthImpl.numberTo0x(olderBlock.number));
+      const result = await ethImpl.getStorageAt(contractAddress1, defaultOlderContractState.state[0].slot, numberTo0x(olderBlock.number));
       expect(result).to.equal(defaultOlderContractState.state[0].value);
     });
 
@@ -4177,7 +4177,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const args = [contractAddress1,
                     defaultDetailedContractResults.state_changes[0].slot,
-                    EthImpl.numberTo0x(blockNumber)];
+                    numberTo0x(blockNumber)];
 
       await RelayAssertions.assertRejection(predefined.RESOURCE_NOT_FOUND(), ethImpl.getStorageAt, false, ethImpl, args);
     });
@@ -4185,7 +4185,7 @@ describe('Eth calls using MirrorNode', async function () {
 
   describe('eth_getTransactionCount', async() => {
     const blockNumber = mockData.blocks.blocks[2].number;
-    const blockNumberHex = EthImpl.numberTo0x(blockNumber);
+    const blockNumberHex = numberTo0x(blockNumber);
     const transactionId = '0.0.1078@1686183420.196506746';
 
     const accountPath = `accounts/${mockData.account.evm_address}${noTransactions}`;
@@ -4217,7 +4217,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet(accountPath).reply(200, mockData.account);
       const nonce = await ethImpl.getTransactionCount(mockData.account.evm_address, null);
       expect(nonce).to.exist;
-      expect(nonce).to.equal(EthImpl.numberTo0x(mockData.account.ethereum_nonce));
+      expect(nonce).to.equal(numberTo0x(mockData.account.ethereum_nonce));
     });
 
     it('should return 0x0 nonce for block 0 consideration', async() => {
@@ -4238,14 +4238,14 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet(accountPath).reply(200, mockData.account);
       const nonce = await ethImpl.getTransactionCount(mockData.account.evm_address, EthImpl.blockLatest);
       expect(nonce).to.exist;
-      expect(nonce).to.equal(EthImpl.numberTo0x(mockData.account.ethereum_nonce));
+      expect(nonce).to.equal(numberTo0x(mockData.account.ethereum_nonce));
     });
 
     it('should return latest nonce for pending block', async() => {
       restMock.onGet(accountPath).reply(200, mockData.account);
       const nonce = await ethImpl.getTransactionCount(mockData.account.evm_address, EthImpl.blockPending);
       expect(nonce).to.exist;
-      expect(nonce).to.equal(EthImpl.numberTo0x(mockData.account.ethereum_nonce));
+      expect(nonce).to.equal(numberTo0x(mockData.account.ethereum_nonce));
     });
 
     it('should return 0x0 nonce for earliest block with valid block', async() => {
@@ -4310,7 +4310,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const nonce = await ethImpl.getTransactionCount(mockData.account.evm_address, blockNumberHex);
       expect(nonce).to.exist;
-      expect(nonce).to.equal(EthImpl.numberTo0x(mockData.account.ethereum_nonce));
+      expect(nonce).to.equal(numberTo0x(mockData.account.ethereum_nonce));
     });
 
     it('should return 0x0 nonce for historical numerical block with no ethereum transactions found', async() => {
@@ -4358,7 +4358,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const nonce = await ethImpl.getTransactionCount(mockData.account.evm_address, blockNumberHex);
       expect(nonce).to.exist;
-      expect(nonce).to.equal(EthImpl.numberTo0x(mockData.account.ethereum_nonce));
+      expect(nonce).to.equal(numberTo0x(mockData.account.ethereum_nonce));
     });
 
     it('should return valid nonce for historical numerical block', async() => {
@@ -4370,7 +4370,7 @@ describe('Eth calls using MirrorNode', async function () {
 
       const nonce = await ethImpl.getTransactionCount(mockData.account.evm_address, blockNumberHex);
       expect(nonce).to.exist;
-      expect(nonce).to.equal(EthImpl.numberTo0x(mockData.account.ethereum_nonce));
+      expect(nonce).to.equal(numberTo0x(mockData.account.ethereum_nonce));
     });
 
     it('should throw for -1 invalid block tag', async() => {
@@ -4766,14 +4766,14 @@ describe('Eth', async function () {
       const cacheKeySyntheticLog1 = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${defaultDetailedContractResultByHash.hash}`;
       const cachedLog = new Log({
         address: defaultLogs1[0].address,
-        blockHash: EthImpl.toHash32(defaultLogs1[0].block_hash),
-        blockNumber: EthImpl.numberTo0x(defaultLogs1[0].block_number),
+        blockHash: toHash32(defaultLogs1[0].block_hash),
+        blockNumber: numberTo0x(defaultLogs1[0].block_number),
         data: defaultLogs1[0].data,
-        logIndex: EthImpl.numberTo0x(defaultLogs1[0].index),
+        logIndex: numberTo0x(defaultLogs1[0].index),
         removed: false,
         topics: defaultLogs1[0].topics,
-        transactionHash: EthImpl.toHash32(defaultLogs1[0].transaction_hash),
-        transactionIndex: EthImpl.nullableNumberTo0x(defaultLogs1[0].transaction_index)
+        transactionHash: toHash32(defaultLogs1[0].transaction_hash),
+        transactionIndex: nullableNumberTo0x(defaultLogs1[0].transaction_index)
       });
 
       clientCache.set(cacheKeySyntheticLog1, cachedLog);

--- a/packages/relay/tests/lib/ethGetBlockBy.spec.ts
+++ b/packages/relay/tests/lib/ethGetBlockBy.spec.ts
@@ -33,6 +33,7 @@ import HAPIService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
 import { ClientCache } from '../../src/lib/clients';
 import { Log, Transaction } from '../../src/lib/model';
+import { nullableNumberTo0x, numberTo0x, nanOrNumberTo0x, toHash32 } from '../../../../packages/relay/src/formatters';
 
 const LRU = require('lru-cache');
 
@@ -355,24 +356,24 @@ describe('eth_getBlockBy', async function () {
     const getTranactionModel = (transactionHash) => {
       return new Transaction({
         accessList: undefined, // we don't support access lists for now, so punt
-        blockHash: EthImpl.toHash32(defaultDetailedContractResults.block_hash),
-        blockNumber: EthImpl.numberTo0x(defaultDetailedContractResults.block_number),
+        blockHash: toHash32(defaultDetailedContractResults.block_hash),
+        blockNumber: numberTo0x(defaultDetailedContractResults.block_number),
         chainId: defaultDetailedContractResults.chain_id,
         from: defaultDetailedContractResults.from.substring(0, 42),
-        gas: EthImpl.nanOrNumberTo0x(defaultDetailedContractResults.gas_used),
+        gas: nanOrNumberTo0x(defaultDetailedContractResults.gas_used),
         gasPrice: null,
         hash: transactionHash,
         input: defaultDetailedContractResults.function_parameters,
         maxPriorityFeePerGas: null,
         maxFeePerGas: null,
-        nonce: EthImpl.nanOrNumberTo0x(defaultDetailedContractResults.nonce),
+        nonce: nanOrNumberTo0x(defaultDetailedContractResults.nonce),
         r: EthImpl.zeroHex,
         s: EthImpl.zeroHex,
         to: defaultDetailedContractResults.to.substring(0, 42),
-        transactionIndex: EthImpl.nullableNumberTo0x(defaultDetailedContractResults.transaction_index),
-        type: EthImpl.nullableNumberTo0x(defaultDetailedContractResults.type),
-        v: EthImpl.nanOrNumberTo0x(defaultDetailedContractResults.v),
-        value: EthImpl.nanOrNumberTo0x(defaultDetailedContractResults.amount),
+        transactionIndex: nullableNumberTo0x(defaultDetailedContractResults.transaction_index),
+        type: nullableNumberTo0x(defaultDetailedContractResults.type),
+        v: nanOrNumberTo0x(defaultDetailedContractResults.v),
+        value: nanOrNumberTo0x(defaultDetailedContractResults.amount),
       });
     };
 

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -21,6 +21,7 @@
 import { expect } from 'chai';
 import { hexToASCII, decodeErrorMessage, formatTransactionId, parseNumericEnvVar, formatTransactionIdWithoutQueryParams } from '../../src/formatters';
 import constants from '../../src/lib/constants';
+import { formatContractResult } from '../../dist/formatters';
 
 describe('Formatters', () => {
     describe('hexToASCII', () => {
@@ -165,6 +166,93 @@ describe('Formatters', () => {
                 parseNumericEnvVar('TEST_ONLY_ENV_VAR_NUMERICSTRING', 'ETH_BLOCK_NUMBER_CACHE_TTL_MS_DEFAULT');
             expect(isNaN(value)).to.equal(false, 'should not be NaN');
             expect(value).to.equal(12345);
+        });
+    });
+
+    describe('formatContractResult', () => {
+        const contractResult = {
+            amount: 0,
+            from: '0x05fba803be258049a27b820088bab1cad2058871',
+            function_parameters: '0x08090033',
+            gas_used: 400000,
+            to: '0x0000000000000000000000000000000000000409',
+            hash: '0xfc4ab7133197016293d2e14e8cf9c5227b07357e6385184f1cd1cb40d783cfbd',
+            block_hash: '0xb0f10139fa0bf9e66402c8c0e5ed364e07cf83b3726c8045fabf86a07f4887130e4650cb5cf48a9f6139a805b78f0312',
+            block_number: 528,
+            transaction_index: 9,
+            chain_id: '0x12a',
+            gas_price: '0x',
+            max_fee_per_gas: '0x59',
+            max_priority_fee_per_gas: '0x',
+            r: '0x2af9d41244c702764ed86c5b9f1a734b075b91c4d9c65e78bc584b0e35181e42',
+            s: '0x3f0a6baa347876e08c53ffc70619ba75881841885b2bd114dbb1905cd57112a5',
+            type: 2,
+            v: 1,
+            nonce: 2
+        };
+
+        it('should return null if null is passed', () => {
+            expect(formatContractResult(null)).to.equal(null);
+        });
+
+        it('should return a valid match', () => {
+            const formattedResult: any = formatContractResult(contractResult);
+            expect(formattedResult.accessList).to.equal(undefined);
+            expect(formattedResult.blockHash).to.equal('0xb0f10139fa0bf9e66402c8c0e5ed364e07cf83b3726c8045fabf86a07f488713');
+            expect(formattedResult.blockNumber).to.equal('0x210');
+            expect(formattedResult.chainId).to.equal('0x12a');
+            expect(formattedResult.from).to.equal('0x05fba803be258049a27b820088bab1cad2058871');
+            expect(formattedResult.gas).to.equal('0x61a80');
+            expect(formattedResult.gasPrice).to.equal(null);
+            expect(formattedResult.hash).to.equal('0xfc4ab7133197016293d2e14e8cf9c5227b07357e6385184f1cd1cb40d783cfbd');
+            expect(formattedResult.input).to.equal('0x08090033');
+            expect(formattedResult.maxPriorityFeePerGas).to.equal(null);
+            expect(formattedResult.maxFeePerGas).to.equal('0x59');
+            expect(formattedResult.nonce).to.equal('0x2');
+            expect(formattedResult.r).to.equal('0x2af9d41244c702764ed86c5b9f1a734b075b91c4d9c65e78bc584b0e35181e42');
+            expect(formattedResult.s).to.equal('0x3f0a6baa347876e08c53ffc70619ba75881841885b2bd114dbb1905cd57112a5');
+            expect(formattedResult.to).to.equal('0x0000000000000000000000000000000000000409');
+            expect(formattedResult.transactionIndex).to.equal('0x9');
+            expect(formattedResult.type).to.equal('0x2');
+            expect(formattedResult.v).to.equal('0x1');
+            expect(formattedResult.value).to.equal('0x0');
+        });
+
+        it('should return nullable fields', () => {
+            const formattedResult: any = formatContractResult({
+                ...contractResult,
+                block_number: null,
+                gas_used: null,
+                gas_price: '0x',
+                max_priority_fee_per_gas: '0x',
+                max_fee_per_gas: '0x',
+                nonce: null,
+                r: null,
+                s: null,
+                transaction_index: null,
+                type: null,
+                v: null,
+                value: null
+            });
+            expect(formattedResult.accessList).to.equal(undefined);
+            expect(formattedResult.blockHash).to.equal('0xb0f10139fa0bf9e66402c8c0e5ed364e07cf83b3726c8045fabf86a07f488713');
+            expect(formattedResult.blockNumber).to.equal(null);
+            expect(formattedResult.chainId).to.equal('0x12a');
+            expect(formattedResult.from).to.equal('0x05fba803be258049a27b820088bab1cad2058871');
+            expect(formattedResult.gas).to.equal('0x0');
+            expect(formattedResult.gasPrice).to.equal(null);
+            expect(formattedResult.hash).to.equal('0xfc4ab7133197016293d2e14e8cf9c5227b07357e6385184f1cd1cb40d783cfbd');
+            expect(formattedResult.input).to.equal('0x08090033');
+            expect(formattedResult.maxPriorityFeePerGas).to.equal(null);
+            expect(formattedResult.maxFeePerGas).to.equal(null);
+            expect(formattedResult.nonce).to.equal('0x0');
+            expect(formattedResult.r).to.equal(null);
+            expect(formattedResult.s).to.equal(null);
+            expect(formattedResult.to).to.equal('0x0000000000000000000000000000000000000409');
+            expect(formattedResult.transactionIndex).to.equal(null);
+            expect(formattedResult.type).to.equal(null);
+            expect(formattedResult.v).to.equal('0x0');
+            expect(formattedResult.value).to.equal('0x0');
         });
     });
 });

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -19,9 +19,12 @@
  */
 
 import { expect } from 'chai';
-import { hexToASCII, decodeErrorMessage, formatTransactionId, parseNumericEnvVar, formatTransactionIdWithoutQueryParams } from '../../src/formatters';
+import {
+    hexToASCII, decodeErrorMessage, formatTransactionId, parseNumericEnvVar, formatTransactionIdWithoutQueryParams,
+    numberTo0x, formatContractResult, prepend0x, nullableNumberTo0x, nanOrNumberTo0x, toHash32, toNullableBigNumber, toNullIfEmptyHex
+} from '../../src/formatters';
 import constants from '../../src/lib/constants';
-import { formatContractResult } from '../../dist/formatters';
+import { BigNumber as BN } from "bignumber.js";
 
 describe('Formatters', () => {
     describe('hexToASCII', () => {
@@ -253,6 +256,78 @@ describe('Formatters', () => {
             expect(formattedResult.type).to.equal(null);
             expect(formattedResult.v).to.equal('0x0');
             expect(formattedResult.value).to.equal('0x0');
+        });
+    });
+
+    describe('prepend0x', () => {
+        it('should add a prefix if there is no one', () => {
+            expect(prepend0x('5644')).to.equal('0x5644');
+        });
+        it('should not add prefix if the string is already prefixed', () => {
+            expect(prepend0x('0x5644')).to.equal('0x5644');
+        });
+    });
+
+    describe('numberTo0x', () => {
+        it('should convert to hex a number type', () => {
+            expect(numberTo0x(1009)).to.equal('0x3f1');
+        });
+        it('should convert to hex a BigInt type', () => {
+            expect(numberTo0x(BigInt(6234))).to.equal('0x185a');
+        });
+    });
+
+    describe('nullableNumberTo0x', () => {
+        it('should be able to accept null', () => {
+            expect(nullableNumberTo0x(null)).to.equal(null);
+        });
+        it('should convert a valid number to hex', () => {
+            expect(nullableNumberTo0x(3867)).to.equal('0xf1b');
+        });
+    });
+
+    describe('nanOrNumberTo0x', () => {
+        it('should return null for nullable input', () => {
+            expect(nanOrNumberTo0x(null)).to.equal('0x0');
+        });
+        it('should return 0x0 for Nan input', () => {
+            expect(nanOrNumberTo0x(NaN)).to.equal('0x0');
+        });
+        it('should convert a number', () => {
+            expect(nanOrNumberTo0x(593)).to.equal('0x251');
+        });
+    });
+
+    describe('toHash32', () => {
+        it('should format more than 32 bytes hash to 32 bytes', () => {
+            expect(toHash32('0x9af1252ea00af08c2ebc78f35a6071a3736795dc53027ea746d710c46b0ef011dc4460630cf109972dafa76c4a56f530'))
+              .to.equal('0x9af1252ea00af08c2ebc78f35a6071a3736795dc53027ea746d710c46b0ef011');
+        });
+        it('should format exactly 32 bytes hash to 32 bytes', () => {
+            const hash32bytes = '0x92b761fa12ed062122c962dd84fce75ed6659e5bca328b6bb08077ff249682a';
+            expect(toHash32(hash32bytes))
+              .to.equal(hash32bytes);
+        });
+    });
+
+    describe('toNullableBigNumber', () => {
+        it('should return null for null input', () => {
+            expect(toNullableBigNumber(null)).to.equal(null);
+        });
+        it('should convert a valid hex to BigNumber', () => {
+            const bigNumberString = '0x9af1252ea00af08c2ebc78f35a6071a3736795dc53027ea746d710c46b0ef011dc4460630cf109972dafa76c4a56f530';
+            expect(toNullableBigNumber(bigNumberString))
+              .to.equal(new BN(bigNumberString).toString());
+        });
+    });
+
+    describe('toNullIfEmptyHex', () => {
+        it('should return null for empty hex', () => {
+            expect(toNullIfEmptyHex('0x')).to.equal(null);
+        });
+        it('should return value for non-nullable input', () => {
+            const value = '2911';
+            expect(toNullIfEmptyHex(value)).to.equal(value);
         });
     });
 });

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -68,6 +68,7 @@ import {
 } from '../helpers';
 import ClientService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
+import { numberTo0x } from '../../../../packages/relay/src/formatters';
 
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 
@@ -252,13 +253,13 @@ describe("Open RPC Specification", function () {
     });
 
     it('should execute "eth_getBlockByNumber" with hydrated = true', async function () {
-        const response = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), true);
+        const response = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), true);
 
         validateResponseSchema(methodsResponseSchema.eth_getBlockByNumber, response);
     });
 
     it('should execute "eth_getBlockByNumber" with hydrated = false', async function () {
-        const response = await ethImpl.getBlockByNumber(EthImpl.numberTo0x(blockNumber), false);
+        const response = await ethImpl.getBlockByNumber(numberTo0x(blockNumber), false);
 
         validateResponseSchema(methodsResponseSchema.eth_getBlockByNumber, response);
     });
@@ -325,13 +326,13 @@ describe("Open RPC Specification", function () {
     });
 
     it('should execute "eth_getTransactionByBlockHashAndIndex"', async function () {
-        const response = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, EthImpl.numberTo0x(defaultBlock.count));
+        const response = await ethImpl.getTransactionByBlockHashAndIndex(defaultBlock.hash, numberTo0x(defaultBlock.count));
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionByBlockHashAndIndex, response);
     });
 
     it('should execute "eth_getTransactionByBlockNumberAndIndex"', async function () {
-        const response = await ethImpl.getTransactionByBlockNumberAndIndex(EthImpl.numberTo0x(defaultBlock.number), EthImpl.numberTo0x(defaultBlock.count));
+        const response = await ethImpl.getTransactionByBlockNumberAndIndex(numberTo0x(defaultBlock.number), numberTo0x(defaultBlock.count));
 
         validateResponseSchema(methodsResponseSchema.eth_getTransactionByBlockNumberAndIndex, response);
     });

--- a/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
@@ -40,8 +40,8 @@ import TokenManagementContractJson from '../../contracts/TokenManagementContract
 
 import { predefined } from '../../../../relay/src/lib/errors/JsonRpcError';
 import { Utils } from '../../helpers/utils';
-import { EthImpl } from "@hashgraph/json-rpc-relay/dist/lib/eth";
 import RelayCall from "../../helpers/constants";
+import { numberTo0x } from '../../../../../packages/relay/src/formatters';
 
 describe('@precompile-calls Tests for eth_call with HTS', async function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -550,7 +550,7 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: '0x' + NON_EXISTING_ACCOUNT,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: CALLDATA_BALANCE_OF + accounts[0].address
             };
 
@@ -562,7 +562,7 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
             const callData = {
                 from: '0x' + NON_EXISTING_ACCOUNT,
                 to: htsImplAddress,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: CALLDATA_BALANCE_OF + NON_EXISTING_ACCOUNT.padStart(64, '0')
             };
 
@@ -578,7 +578,7 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: htsImplAddress,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: CALLDATA_ALLOWANCE + NON_EXISTING_ACCOUNT.padStart(64, '0') + account2LongZero.replace('0x', '').padStart(64, '0')
             };
 
@@ -595,7 +595,7 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: htsImplAddress,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: CALLDATA_ALLOWANCE + adminAccountLongZero.replace('0x', '').padStart(64, '0') + NON_EXISTING_ACCOUNT.padStart(64, '0')
             };
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -31,10 +31,10 @@ import { ContractFunctionParameters } from '@hashgraph/sdk';
 import parentContractJson from '../contracts/Parent.json';
 import logsContractJson from '../contracts/Logs.json';
 import { predefined } from '../../../relay/src/lib/errors/JsonRpcError';
-import { EthImpl } from '../../../../packages/relay/src/lib/eth';
 import Constants from '../../../relay/src/lib/constants';
 import RelayCalls from '../../tests/helpers/constants';
 const Address = RelayCalls;
+import { numberTo0x } from '../../../../packages/relay/src/formatters';
 
 describe('@api-batch-1 RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -128,7 +128,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
                 //empty params for get logs defaults to latest block, which doesn't have required logs, that's why we fetch the last 10
                 const logs = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS, [{
-                    fromBlock: EthImpl.numberTo0x(tenBlocksBehindLatest),
+                    fromBlock: numberTo0x(tenBlocksBehindLatest),
                     'address': [contractAddress, contractAddress2]
                 }], requestId);
 
@@ -195,7 +195,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             it('should be able to use `address` param', async () => {
                 //when we pass only address, it defaults to the latest block
                 const logs = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS, [{
-                    'fromBlock': EthImpl.numberTo0x(tenBlocksBehindLatest),
+                    'fromBlock': numberTo0x(tenBlocksBehindLatest),
                     'address': contractAddress
                 }], requestId);
                 expect(logs.length).to.be.greaterThan(0);
@@ -207,7 +207,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
             it('should be able to use `address` param with multiple addresses', async () => {
                 const logs = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS, [{
-                    'fromBlock': EthImpl.numberTo0x(tenBlocksBehindLatest),
+                    'fromBlock': numberTo0x(tenBlocksBehindLatest),
                     'address': [contractAddress, contractAddress2, Address.NON_EXISTING_ADDRESS]
                 }], requestId);
                 expect(logs.length).to.be.greaterThan(0);
@@ -277,7 +277,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                     blocksBehindLatest = currentBlock - 10;
                 }
                 const logs = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS, [{
-                    'fromBlock': EthImpl.numberTo0x(blocksBehindLatest),
+                    'fromBlock': numberTo0x(blocksBehindLatest),
                     'toBlock': 'latest',
                     'address': [contractAddress, contractAddress2]
                 }], requestId);
@@ -323,12 +323,12 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             });
 
             it('should execute "eth_getBlockByNumber", hydrated transactions = false', async function () {
-                const blockResult = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, [EthImpl.numberTo0x(mirrorBlock.number), false], requestId);
+                const blockResult = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, [numberTo0x(mirrorBlock.number), false], requestId);
                 Assertions.block(blockResult, mirrorBlock, mirrorTransactions, false);
             });
 
             it('@release should execute "eth_getBlockByNumber", hydrated transactions = true', async function () {
-                const blockResult = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, [EthImpl.numberTo0x(mirrorBlock.number), true], requestId);
+                const blockResult = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, [numberTo0x(mirrorBlock.number), true], requestId);
                 Assertions.block(blockResult, mirrorBlock, mirrorTransactions, true);
             });
 
@@ -343,7 +343,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             });
 
             it('@release should execute "eth_getBlockTransactionCountByNumber"', async function () {
-                const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_TRANSACTION_COUNT_BY_NUMBER, [EthImpl.numberTo0x(mirrorBlock.number)], requestId);
+                const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_TRANSACTION_COUNT_BY_NUMBER, [numberTo0x(mirrorBlock.number)], requestId);
                 expect(res).to.be.equal(ethers.utils.hexValue(mirrorBlock.count));
             });
 
@@ -383,8 +383,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         });
 
         describe('Transaction related RPC Calls', () => {
-            const defaultGasPrice = EthImpl.numberTo0x(Assertions.defaultGasPrice);
-            const defaultGasLimit = EthImpl.numberTo0x(3_000_000);
+            const defaultGasPrice = numberTo0x(Assertions.defaultGasPrice);
+            const defaultGasLimit = numberTo0x(3_000_000);
             const defaultLegacyTransactionData = {
                 value: ONE_TINYBAR,
                 gasPrice: defaultGasPrice,
@@ -415,13 +415,13 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
             it('@release should execute "eth_getTransactionByBlockHashAndIndex"', async function () {
                 const response = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_BLOCK_HASH_AND_INDEX,
-                    [mirrorContractDetails.block_hash.substring(0, 66), EthImpl.numberTo0x(mirrorContractDetails.transaction_index)], requestId);
+                    [mirrorContractDetails.block_hash.substring(0, 66), numberTo0x(mirrorContractDetails.transaction_index)], requestId);
                 Assertions.transaction(response, mirrorContractDetails);
             });
 
             it('should execute "eth_getTransactionByBlockHashAndIndex" for invalid block hash', async function () {
                 const response = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_BLOCK_HASH_AND_INDEX,
-                    [Address.NON_EXISTING_BLOCK_HASH, EthImpl.numberTo0x(mirrorContractDetails.transaction_index)], requestId);
+                    [Address.NON_EXISTING_BLOCK_HASH, numberTo0x(mirrorContractDetails.transaction_index)], requestId);
                 expect(response).to.be.null;
             });
 
@@ -432,17 +432,17 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             });
 
             it('@release should execute "eth_getTransactionByBlockNumberAndIndex"', async function () {
-                const response = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX, [EthImpl.numberTo0x(mirrorContractDetails.block_number), EthImpl.numberTo0x(mirrorContractDetails.transaction_index)], requestId);
+                const response = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX, [numberTo0x(mirrorContractDetails.block_number), numberTo0x(mirrorContractDetails.transaction_index)], requestId);
                 Assertions.transaction(response, mirrorContractDetails);
             });
 
             it('should execute "eth_getTransactionByBlockNumberAndIndex" for invalid index', async function () {
-                const response = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX, [EthImpl.numberTo0x(mirrorContractDetails.block_number), Address.NON_EXISTING_INDEX], requestId);
+                const response = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX, [numberTo0x(mirrorContractDetails.block_number), Address.NON_EXISTING_INDEX], requestId);
                 expect(response).to.be.null;
             });
 
             it('should execute "eth_getTransactionByBlockNumberAndIndex" for non-exising block number', async function () {
-                const response = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX, [Address.NON_EXISTING_BLOCK_NUMBER, EthImpl.numberTo0x(mirrorContractDetails.transaction_index)], requestId);
+                const response = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_BLOCK_NUMBER_AND_INDEX, [Address.NON_EXISTING_BLOCK_NUMBER, numberTo0x(mirrorContractDetails.transaction_index)], requestId);
                 expect(response).to.be.null;
             });
 

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -38,6 +38,7 @@ import Constants from '../../../../packages/relay/src/lib/constants';
 import RelayCalls from '../../tests/helpers/constants';
 import Helper from '../../tests/helpers/constants';
 import Address from '../../tests/helpers/constants';
+import { numberTo0x } from '../../../../packages/relay/src/formatters';
 
 describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -284,13 +285,13 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
         it('@release should execute "eth_getBalance" with latest block number', async function () {
             const latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [Utils.idToEvmAddress(getBalanceContractId.toString()), EthImpl.numberTo0x(latestBlock.number)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [Utils.idToEvmAddress(getBalanceContractId.toString()), numberTo0x(latestBlock.number)], requestId);
             expect(res).to.eq(ethers.utils.hexValue(ONE_WEIBAR));
         });
 
         it('@release should execute "eth_getBalance" with one block behind latest block number', async function () {
             const latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [Utils.idToEvmAddress(getBalanceContractId.toString()), EthImpl.numberTo0x(latestBlock.number - 1)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [Utils.idToEvmAddress(getBalanceContractId.toString()), numberTo0x(latestBlock.number - 1)], requestId);
             expect(res).to.eq(ethers.utils.hexValue(ONE_WEIBAR));
         });
 
@@ -302,12 +303,12 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
         it('@release should execute "eth_getBalance" with block number in the last 15 minutes', async function () {
             const latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
             const earlierBlockNumber = latestBlock.number - 2;
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [Utils.idToEvmAddress(getBalanceContractId.toString()), EthImpl.numberTo0x(earlierBlockNumber)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [Utils.idToEvmAddress(getBalanceContractId.toString()), numberTo0x(earlierBlockNumber)], requestId);
             expect(res).to.eq(ethers.utils.hexValue(ONE_WEIBAR));
         });
 
         it('@release should execute "eth_getBalance" with block number in the last 15 minutes for account that has performed contract deploys/calls"', async function () {
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, ['0x' + accounts[0].address, EthImpl.numberTo0x(blockNumberAtStartOfTests)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, ['0x' + accounts[0].address, numberTo0x(blockNumberAtStartOfTests)], requestId);
             const balanceAtBlock = BigInt(mirrorAccount0AtStartOfTests.balance.balance) * BigInt(Constants.TINYBAR_TO_WEIBAR_COEF);
             expect(res).to.eq(`0x${balanceAtBlock.toString(16)}`);
         });

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -38,6 +38,7 @@ import Helper from '../../tests/helpers/constants';
 import Address from '../../tests/helpers/constants';
 import Assertions from '../helpers/assertions';
 import RelayCalls from "../helpers/constants";
+import { numberTo0x } from '../../../../packages/relay/src/formatters';
 
 describe('@api-batch-3 RPC Server Acceptance Tests', function () {
     this.timeout(240 * 1000); // 240 seconds
@@ -103,7 +104,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: evmAddress,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
 
@@ -115,7 +116,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: evmAddress,
-                gas: EthImpl.numberTo0x(30000)
+                gas: numberTo0x(30000)
             };
 
             const res = await relay.call(RelayCall.ETH_ENDPOINTS.ETH_CALL, [callData, 'latest'], requestId);
@@ -126,7 +127,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: Address.NON_EXISTING_ADDRESS,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
 
@@ -137,7 +138,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         it('should execute "eth_call" without from field', async function () {
             const callData = {
                 to: evmAddress,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: BASIC_CONTRACT_PING_CALL_DATA
             };
 
@@ -414,7 +415,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: reverterEvmAddress,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: PURE_METHOD_CALL_DATA
             };
 
@@ -429,7 +430,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const callData = {
                 from: '0x' + accounts[0].address,
                 to: reverterEvmAddress,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: VIEW_METHOD_CALL_DATA
             };
 
@@ -443,7 +444,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         it('Returns revert reason in receipt for payable methods', async () => {
             const transaction = {
                 value: ONE_TINYBAR,
-                gasLimit: EthImpl.numberTo0x(30000),
+                gasLimit: numberTo0x(30000),
                 chainId: Number(CHAIN_ID),
                 to: reverterEvmAddress,
                 nonce: await relay.getAccountNonce('0x' + accounts[0].address, requestId),
@@ -498,7 +499,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                 for (const element of payableMethodsData) {
                     const transaction = {
                         // value: ONE_TINYBAR,
-                        gasLimit: EthImpl.numberTo0x(30000),
+                        gasLimit: numberTo0x(30000),
                         chainId: Number(CHAIN_ID),
                         to: reverterEvmAddress,
                         nonce: await relay.getAccountNonce('0x' + accounts[0].address, requestId),
@@ -584,7 +585,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
                     const callData = {
                         from: '0x' + accounts[0].address,
                         to: reverterEvmAddress,
-                        gas: EthImpl.numberTo0x(30000),
+                        gas: numberTo0x(30000),
                         data: element.data
                     };
 
@@ -626,7 +627,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
             const callData = {
                 from: '0x' + accounts[1].address,
                 to: htsImpl.address,
-                gas: EthImpl.numberTo0x(30000),
+                gas: numberTo0x(30000),
                 data: IS_TOKEN_ADDRESS_SIGNATURE + tokenAddress.replace('0x', '')
             };
 
@@ -641,8 +642,8 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         let deployerContract, mirrorContract, mirrorContractDetails, contractId,
             primaryAccountNonce, secondaryAccountNonce;
 
-        const defaultGasPrice = EthImpl.numberTo0x(Assertions.defaultGasPrice);
-        const defaultGasLimit = EthImpl.numberTo0x(3_000_000);
+        const defaultGasPrice = numberTo0x(Assertions.defaultGasPrice);
+        const defaultGasLimit = numberTo0x(3_000_000);
         const defaultTransaction = {
             value: ONE_TINYBAR,
             chainId: Number(CHAIN_ID),
@@ -674,17 +675,17 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         });
 
         it('@release should execute "eth_getTransactionCount" primary', async function () {
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [mirrorPrimaryAccount.evm_address, EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [mirrorPrimaryAccount.evm_address, numberTo0x(mirrorContractDetails.block_number)], requestId);
             expect(res).to.be.equal(Utils.add0xPrefix(Utils.toHex(primaryAccountNonce.toInt())));
         });
 
         it('should execute "eth_getTransactionCount" secondary', async function () {
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [mirrorSecondaryAccount.evm_address, EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [mirrorSecondaryAccount.evm_address, numberTo0x(mirrorContractDetails.block_number)], requestId);
             expect(res).to.be.equal(Utils.add0xPrefix(Utils.toHex(secondaryAccountNonce.toInt())));
         });
 
         it('@release should execute "eth_getTransactionCount" historic', async function () {
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [mirrorContract.evm_address, EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [mirrorContract.evm_address, numberTo0x(mirrorContractDetails.block_number)], requestId);
             expect(res).to.be.equal('0x2');
         });
 
@@ -694,12 +695,12 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         });
 
         it('@release should execute "eth_getTransactionCount" for account with id converted to evm_address', async function () {
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [Utils.idToEvmAddress(mirrorPrimaryAccount.account), EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [Utils.idToEvmAddress(mirrorPrimaryAccount.account), numberTo0x(mirrorContractDetails.block_number)], requestId);
             expect(res).to.be.equal(Utils.add0xPrefix(Utils.toHex(primaryAccountNonce.toInt())));
         });
 
         it('@release should execute "eth_getTransactionCount" contract with id converted to evm_address historic', async function () {
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [Utils.idToEvmAddress(contractId.toString()), EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [Utils.idToEvmAddress(contractId.toString()), numberTo0x(mirrorContractDetails.block_number)], requestId);
             expect(res).to.be.equal('0x2');
         });
 
@@ -709,7 +710,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         });
 
         it('should execute "eth_getTransactionCount" for non-existing address', async function () {
-            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [Address.NON_EXISTING_ADDRESS, EthImpl.numberTo0x(mirrorContractDetails.block_number)], requestId);
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT, [Address.NON_EXISTING_ADDRESS, numberTo0x(mirrorContractDetails.block_number)], requestId);
             expect(res).to.be.equal('0x0');
         });
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

The formatting method should be in `formatters.ts`, also tests are missing. The issue has been followed up by [PR](https://github.com/hashgraph/hedera-json-rpc-relay/pull/1506).

**Related issue(s)**:

Fixes #1593 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
