### PR TITLE
Fix `eth_estimateGas` transaction values formatting

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -119,16 +119,13 @@ const parseNumericEnvVar = (envVarName: string, fallbackConstantKey: string): nu
 }
 
 /**
- * Parse value from hex string to number, if value lenght is bigger than tinybar to weibar coef, it means that it's in weibar, which needs conversion to weibar.
+ * Parse weibar hex string to tinybar number, by applying tinybar to weibar coef.
  * @param value 
- * @returns parsedValue
+ * @returns tinybarValue
  */
-const valueHexToInt = (value: string): number => {
-    if (BigInt(value).toString().length > constants.TINYBAR_TO_WEIBAR_COEF.toString().length) {
-        const tinybarValue = BigInt(value) / BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
-        return Number(tinybarValue);
-    }
-    return parseInt(value);
+const weibarHexToTinyBarInt = (value: string): number => {
+    const tinybarValue = BigInt(value) / BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+    return Number(tinybarValue);
 }
 
 const formatContractResult = (cr: any) => {
@@ -195,5 +192,5 @@ export {
     hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId,
     formatTransactionIdWithoutQueryParams, parseNumericEnvVar, formatContractResult, prepend0x,
     numberTo0x, nullableNumberTo0x, nanOrNumberTo0x, toHash32, toNullableBigNumber, toNullIfEmptyHex,
-    generateRandomHex, valueHexToInt
+    generateRandomHex, weibarHexToTinyBarInt
 };

--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -172,7 +172,7 @@ const nullableNumberTo0x = (input: number | BigNumber): string | null => {
 };
 
 const nanOrNumberTo0x = (input: number | BigNumber): string => {
-    return input == null || input !== input ? numberTo0x(0) : numberTo0x(input);
+    return input == null || Number.isNaN(input) ? numberTo0x(0) : numberTo0x(input);
 };
 
 const toHash32 = (value: string): string => {

--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -120,12 +120,16 @@ const parseNumericEnvVar = (envVarName: string, fallbackConstantKey: string): nu
 
 /**
  * Parse weibar hex string to tinybar number, by applying tinybar to weibar coef.
+ * Return null, if value is not a valid hex. Null is the only other valid response that mirror-node accepts.
  * @param value 
  * @returns tinybarValue
  */
-const weibarHexToTinyBarInt = (value: string): number => {
-    const tinybarValue = BigInt(value) / BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
-    return Number(tinybarValue);
+const weibarHexToTinyBarInt = (value: string): number | null => {
+    if (value) {
+        const tinybarValue = BigInt(value) / BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+        return Number(tinybarValue);
+    }
+    return null;
 }
 
 const formatContractResult = (cr: any) => {

--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -131,15 +131,6 @@ const valueHexToInt = (value: string): number => {
     return parseInt(value);
 }
 
-/**
- * Parse gasPrice hex value to number.
- * @param gasPrice 
- * @returns parsedGasPrice
- */
-const gasPriceHexToInt = (gasPrice: string): number => {
-    return parseInt(gasPrice);
-}
-
 const formatContractResult = (cr: any) => {
     if (cr === null) {
         return null;
@@ -204,5 +195,5 @@ export {
     hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId,
     formatTransactionIdWithoutQueryParams, parseNumericEnvVar, formatContractResult, prepend0x,
     numberTo0x, nullableNumberTo0x, nanOrNumberTo0x, toHash32, toNullableBigNumber, toNullIfEmptyHex,
-    generateRandomHex, gasPriceHexToInt, valueHexToInt
+    generateRandomHex, valueHexToInt
 };

--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -118,6 +118,28 @@ const parseNumericEnvVar = (envVarName: string, fallbackConstantKey: string): nu
     return value;
 }
 
+/**
+ * Parse value from hex string to number, if value lenght is bigger than tinybar to weibar coef, it means that it's in weibar, which needs conversion to weibar.
+ * @param value 
+ * @returns parsedValue
+ */
+const valueHexToInt = (value: string): number => {
+    if (BigInt(value).toString().length > constants.TINYBAR_TO_WEIBAR_COEF.toString().length) {
+        const tinybarValue = BigInt(value) / BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+        return Number(tinybarValue);
+    }
+    return parseInt(value);
+}
+
+/**
+ * Parse gasPrice hex value to number.
+ * @param gasPrice 
+ * @returns parsedGasPrice
+ */
+const gasPriceHexToInt = (gasPrice: string): number => {
+    return parseInt(gasPrice);
+}
+
 const formatContractResult = (cr: any) => {
     if (cr === null) {
         return null;
@@ -182,5 +204,5 @@ export {
     hashNumber, formatRequestIdMessage, hexToASCII, decodeErrorMessage, formatTransactionId,
     formatTransactionIdWithoutQueryParams, parseNumericEnvVar, formatContractResult, prepend0x,
     numberTo0x, nullableNumberTo0x, nanOrNumberTo0x, toHash32, toNullableBigNumber, toNullIfEmptyHex,
-    generateRandomHex
+    generateRandomHex, gasPriceHexToInt, valueHexToInt
 };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -488,7 +488,7 @@ export class EthImpl implements Eth {
     if (transaction?.data?.length >= constants.FUNCTION_SELECTOR_CHAR_LENGTH)
       this.ethExecutionsCounter.labels(EthImpl.ethEstimateGas, transaction.data.substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH)).inc();
 
-    this.contractCallPrecheck(transaction);
+    this.contractCallFormat(transaction);
     let gas = EthImpl.gasTxBaseCost;
     try {
       const contractCallResponse = await this.mirrorNodeClient.postContractCall({
@@ -547,7 +547,7 @@ export class EthImpl implements Eth {
    * Perform value format precheck before making contract call towards the mirror node
    * @param transaction 
    */
-  contractCallPrecheck(transaction: any) {
+  contractCallFormat(transaction: any) {
     if (transaction.value) {
       transaction.value = weibarHexToTinyBarInt(transaction.value);
     }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -38,8 +38,7 @@ import {
   nanOrNumberTo0x,
   toHash32,
   toNullableBigNumber,
-  valueHexToInt,
-  gasPriceHexToInt
+  valueHexToInt
 } from '../formatters';
 import crypto from 'crypto';
 import HAPIService from './services/hapiService/hapiService';
@@ -548,12 +547,12 @@ export class EthImpl implements Eth {
    * Perform value format precheck before making contract call towards the mirror node
    * @param transaction 
    */
-  private contractCallPrecheck(transaction: any) {
+  contractCallPrecheck(transaction: any) {
     if (transaction.value) {
       transaction.value = valueHexToInt(transaction.value);
     }
     if (transaction.gasPrice) {
-      transaction.gasPrice = gasPriceHexToInt(transaction.gasPrice);
+      transaction.gasPrice = parseInt(transaction.gasPrice);
     }
   }
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -38,6 +38,8 @@ import {
   nanOrNumberTo0x,
   toHash32,
   toNullableBigNumber,
+  valueHexToInt,
+  gasPriceHexToInt
 } from '../formatters';
 import crypto from 'crypto';
 import HAPIService from './services/hapiService/hapiService';
@@ -487,7 +489,7 @@ export class EthImpl implements Eth {
     if (transaction?.data?.length >= constants.FUNCTION_SELECTOR_CHAR_LENGTH)
       this.ethExecutionsCounter.labels(EthImpl.ethEstimateGas, transaction.data.substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH)).inc();
 
-
+    this.contractCallPrecheck(transaction);
     let gas = EthImpl.gasTxBaseCost;
     try {
       const contractCallResponse = await this.mirrorNodeClient.postContractCall({
@@ -540,6 +542,19 @@ export class EthImpl implements Eth {
     this.logger.error(`${requestIdPrefix} Returning predefined gas: ${gas}`);
 
     return gas;
+  }
+
+  /**
+   * Perform value format precheck before making contract call towards the mirror node
+   * @param transaction 
+   */
+  private contractCallPrecheck(transaction: any) {
+    if (transaction.value) {
+      transaction.value = valueHexToInt(transaction.value);
+    }
+    if (transaction.gasPrice) {
+      transaction.gasPrice = gasPriceHexToInt(transaction.gasPrice);
+    }
   }
 
   /**

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -38,7 +38,7 @@ import {
   nanOrNumberTo0x,
   toHash32,
   toNullableBigNumber,
-  valueHexToInt
+  weibarHexToTinyBarInt
 } from '../formatters';
 import crypto from 'crypto';
 import HAPIService from './services/hapiService/hapiService';
@@ -549,7 +549,7 @@ export class EthImpl implements Eth {
    */
   contractCallPrecheck(transaction: any) {
     if (transaction.value) {
-      transaction.value = valueHexToInt(transaction.value);
+      transaction.value = weibarHexToTinyBarInt(transaction.value);
     }
     if (transaction.gasPrice) {
       transaction.gasPrice = parseInt(transaction.gasPrice);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3146,7 +3146,7 @@ describe('Eth calls using MirrorNode', async function () {
       gasPrice: "0xF4240"
     };
 
-    ethImpl.contractCallPrecheck(transaction);
+    ethImpl.contractCallFormat(transaction);
     expect(transaction.value).to.eq(1110);
     expect(transaction.gasPrice).to.eq(1000000);
   });

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1542,29 +1542,29 @@ describe('Eth calls using MirrorNode', async function () {
       const latestBlock = {
         ...defaultBlock,
         number: 4,
-        'timestamp': {
-          'from': `${timestamp3}.060890949`,
-          'to': `${timestamp4}.060890949`
+        timestamp: {
+          from: `${timestamp3}.060890949`,
+          to: `${timestamp4}.060890949`,
         },
-      }
-
+      };
+      
       const recentBlock = {
         ...defaultBlock,
         number: 2,
-        'timestamp': {
-          'from': `${timestamp2}.060890949`,
-          'to': `${timestamp3}.060890949`
+        timestamp: {
+          from: `${timestamp2}.060890949`,
+          to: `${timestamp3}.060890949`,
         },
-      }
-
+      };
+      
       const earlierBlock = {
         ...defaultBlock,
         number: 1,
-        'timestamp': {
-          'from': `${timestamp1}.060890949`,
-          'to': `${timestamp2}.060890949`
+        timestamp: {
+          from: `${timestamp1}.060890949`,
+          to: `${timestamp2}.060890949`,
         },
-      }
+      };
 
       beforeEach(async () => {
         mirrorNodeCache.clear();
@@ -1655,11 +1655,12 @@ describe('Eth calls using MirrorNode', async function () {
         const recentBlockWithinLastfifteen = {
           ...defaultBlock,
           number: 2,
-          'timestamp': {
-            'from': `${fromTimestamp}.002391003`,
-            'to': `${toTimestamp}.980351003`
+          timestamp: {
+            from: `${fromTimestamp}.002391003`,
+            to: `${toTimestamp}.980351003`,
           },
-        }
+        };
+        
         restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);
 
         restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
@@ -1702,9 +1703,9 @@ describe('Eth calls using MirrorNode', async function () {
         const recentBlockWithinLastfifteen = {
           ...defaultBlock,
           number: 2,
-          'timestamp': {
-            'from': '1651560899.060890921',
-            'to': `${blockTimestamp}.060890941`
+          timestamp: {
+            from: '1651560899.060890921',
+            to: `${blockTimestamp}.060890941`,
           },
         };
         restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);
@@ -1733,12 +1734,12 @@ describe('Eth calls using MirrorNode', async function () {
         const recentBlockWithinLastfifteen = {
           ...defaultBlock,
           number: 2,
-          'timestamp': {
-            'from': '1651560899.060890921',
-            'to': '1651560900.060890941'
+          timestamp: {
+            from: '1651560899.060890921',
+            to: '1651560900.060890941',
           },
         };
-
+        
         restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);
         restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
           account: contractId1,
@@ -1765,13 +1766,13 @@ describe('Eth calls using MirrorNode', async function () {
         const recentBlockWithinLastfifteen = {
           ...defaultBlock,
           number: 2,
-          'timestamp': {
-            'from': '1651560899.060890921',
-            'to': '1651560900.060890941'
+          timestamp: {
+            from: '1651560899.060890921',
+            to: '1651560900.060890941',
           },
         };
-
-        restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);
+        
+        restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);        
         restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
           account: contractId1,
           balance: {
@@ -1799,9 +1800,9 @@ describe('Eth calls using MirrorNode', async function () {
         const recentBlockWithinLastfifteen = {
           ...defaultBlock,
           number: 1,
-          'timestamp': {
-            'from': `1651550584.060890921`,
-            'to': `1651550585.060890941`
+          timestamp: {
+            from: '1651550584.060890921',
+            to: '1651550585.060890941',
           },
         };
         restMock.onGet(`blocks/1`).reply(200, recentBlockWithinLastfifteen);
@@ -1824,12 +1825,12 @@ describe('Eth calls using MirrorNode', async function () {
         const latestBlock = {
           ...defaultBlock,
           number: 4,
-          'timestamp': {
-            'from': `1651550595.060890941`,
-            'to': `1651550597.060890941`
+          timestamp: {
+            from: '1651550595.060890941',
+            to: '1651550597.060890941',
           },
         };
-
+        
         restMock.onGet('blocks?limit=1&order=desc').reply(200, {
           blocks: [latestBlock]
         });
@@ -1843,11 +1844,12 @@ describe('Eth calls using MirrorNode', async function () {
         const recentBlockWithinLastfifteen = {
           ...defaultBlock,
           number: 1,
-          'timestamp': {
-            'from': '1651550564.060890921',
-            'to': '1651550565.060890941'
+          timestamp: {
+            from: '1651550564.060890921',
+            to: '1651550565.060890941',
           },
         };
+        
         restMock.onGet(`blocks/1`).reply(200, recentBlockWithinLastfifteen);
         restMock.onGet(`accounts/${contractId1}?limit=100`).reply(200, {
           account: contractId1,
@@ -1880,13 +1882,13 @@ describe('Eth calls using MirrorNode', async function () {
             next: null
           }
         });
-
+        
         const latestBlock = {
           ...defaultBlock,
           number: 4,
-          'timestamp': {
-            'from': `1651550595.060890941`,
-            'to': `1651550597.060890941`
+          timestamp: {
+            from: '1651550595.060890941',
+            to: '1651550597.060890941',
           },
         };
 
@@ -1903,9 +1905,9 @@ describe('Eth calls using MirrorNode', async function () {
         const recentBlockWithinLastfifteen = {
           ...defaultBlock,
           number: 1,
-          'timestamp': {
-            'from': '1651550564.060890921',
-            'to': '1651550565.060890941'
+          timestamp: {
+            from: '1651550564.060890921',
+            to: '1651550565.060890941',
           },
         };
         restMock.onGet(`blocks/1`).reply(200, recentBlockWithinLastfifteen);
@@ -1944,9 +1946,9 @@ describe('Eth calls using MirrorNode', async function () {
         const latestBlock = {
           ...defaultBlock,
           number: 4,
-          'timestamp': {
-            'from': `1651550595.060890941`,
-            'to': `1651550597.060890941`
+          timestamp: {
+            from: '1651550595.060890941',
+            to: '1651550597.060890941',
           },
         };
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3136,6 +3136,19 @@ describe('Eth calls using MirrorNode', async function () {
     expect(result).to.equal(numberTo0x(constants.TX_DEFAULT_GAS_DEFAULT));
   });
 
+  it('should perform estimateGas precheck', async function () {
+    const transaction = {
+      from: "0x05fba803be258049a27b820088bab1cad2058871",
+      data: "0x",
+      value: "0x123",
+      gasPrice: "0x124"
+    };
+
+    ethImpl.contractCallPrecheck(transaction);
+    expect(transaction.value).to.eq(291);
+    expect(transaction.gasPrice).to.eq(292);
+  });
+
   describe('eth_gasPrice', async function () {
     it('eth_gasPrice', async function () {
       restMock.onGet(`network/fees`).reply(200, defaultNetworkFees);

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2907,7 +2907,7 @@ describe('Eth calls using MirrorNode', async function () {
       data: "0x",
       from: "0x81cb089c285e5ee3a7353704fb114955037443af",
       to: receiverAddress,
-      value: "0x1"
+      value: "0x2540BE400"
     };
     web3Mock.onPost('contracts/call', {...callData, estimate: true}).reply(501, {"errorMessage":"","statusCode":501});
 
@@ -3142,13 +3142,13 @@ describe('Eth calls using MirrorNode', async function () {
     const transaction = {
       from: "0x05fba803be258049a27b820088bab1cad2058871",
       data: "0x",
-      value: "0x123",
-      gasPrice: "0x124"
+      value: "0xA186B8E9800",
+      gasPrice: "0xF4240"
     };
 
     ethImpl.contractCallPrecheck(transaction);
-    expect(transaction.value).to.eq(291);
-    expect(transaction.gasPrice).to.eq(292);
+    expect(transaction.value).to.eq(1110);
+    expect(transaction.gasPrice).to.eq(1000000);
   });
 
   describe('eth_gasPrice', async function () {

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -336,5 +336,15 @@ describe('Formatters', () => {
             const value = "0x1027127DC00";
             expect(weibarHexToTinyBarInt(value)).to.eq(111);
         });
+
+        it('should convert weibar hex value to tinybar number', () => {
+            const value = undefined;
+            expect(weibarHexToTinyBarInt(value)).to.be.null;
+        });
+
+        it('should convert weibar hex value to tinybar number', () => {
+            const value = null;
+            expect(weibarHexToTinyBarInt(value)).to.be.null;
+        });
     });
 });

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -21,7 +21,7 @@
 import { expect } from 'chai';
 import {
     hexToASCII, decodeErrorMessage, formatTransactionId, parseNumericEnvVar, formatTransactionIdWithoutQueryParams,
-    numberTo0x, formatContractResult, prepend0x, nullableNumberTo0x, nanOrNumberTo0x, toHash32, toNullableBigNumber, toNullIfEmptyHex, valueHexToInt
+    numberTo0x, formatContractResult, prepend0x, nullableNumberTo0x, nanOrNumberTo0x, toHash32, toNullableBigNumber, toNullIfEmptyHex, weibarHexToTinyBarInt
 } from '../../src/formatters';
 import constants from '../../src/lib/constants';
 import { BigNumber as BN } from "bignumber.js";
@@ -331,15 +331,10 @@ describe('Formatters', () => {
         });
     });
 
-    describe('valueHexToInt', () => {
-        it('should convert big hex value to tinybar', () => {
+    describe('weibarHexToTinyBarInt', () => {
+        it('should convert weibar hex value to tinybar number', () => {
             const value = "0x1027127DC00";
-            expect(valueHexToInt(value)).to.eq(111);
-        });
-
-        it('should convert small hex value to tinybar', () => {
-            const value = "0x1B198";
-            expect(valueHexToInt(value)).to.eq(111000);
+            expect(weibarHexToTinyBarInt(value)).to.eq(111);
         });
     });
 });

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -21,7 +21,7 @@
 import { expect } from 'chai';
 import {
     hexToASCII, decodeErrorMessage, formatTransactionId, parseNumericEnvVar, formatTransactionIdWithoutQueryParams,
-    numberTo0x, formatContractResult, prepend0x, nullableNumberTo0x, nanOrNumberTo0x, toHash32, toNullableBigNumber, toNullIfEmptyHex
+    numberTo0x, formatContractResult, prepend0x, nullableNumberTo0x, nanOrNumberTo0x, toHash32, toNullableBigNumber, toNullIfEmptyHex, valueHexToInt
 } from '../../src/formatters';
 import constants from '../../src/lib/constants';
 import { BigNumber as BN } from "bignumber.js";
@@ -328,6 +328,18 @@ describe('Formatters', () => {
         it('should return value for non-nullable input', () => {
             const value = '2911';
             expect(toNullIfEmptyHex(value)).to.equal(value);
+        });
+    });
+
+    describe('valueHexToInt', () => {
+        it('should convert big hex value to tinybar', () => {
+            const value = "0x1027127DC00";
+            expect(valueHexToInt(value)).to.eq(111);
+        });
+
+        it('should convert small hex value to tinybar', () => {
+            const value = "0x1B198";
+            expect(valueHexToInt(value)).to.eq(111000);
         });
     });
 });

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -142,7 +142,8 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             expect(estimatedGas).to.equal(expectedRes);
         });
 
-        it('@release should execute "eth_estimateGas" for existing account', async function() {
+        // Skip this test for now because of bug in mirror-node https://github.com/hashgraph/hedera-mirror-node/issues/6612 in Additional bug fixes
+        xit('@release should execute "eth_estimateGas" for existing account', async function() {
             const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
                 to: mirrorSecondaryAccount.evm_address,
                 value: '0x1',
@@ -151,7 +152,8 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             expect(res).to.equal(EthImpl.gasTxBaseCost);
         });
 
-        it('@release should execute "eth_estimateGas" hollow account creation', async function() {
+        // Skip this test for now because of bug in mirror-node https://github.com/hashgraph/hedera-mirror-node/issues/6612 in Additional bug fixes
+        xit('@release should execute "eth_estimateGas" hollow account creation', async function() {
             const hollowAccount = ethers.Wallet.createRandom();
             const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
                 to: hollowAccount.address,


### PR DESCRIPTION
**Description**:
This PR fixes estimateGas, because in some cases it throws `Unable to parse JSON`. Ethereum tools are passing `value` and `gasPrice` fields as hex, but mirror-node is expecting int. To fix this we need to format properly this fields. Additional checks and more careful formatting is needed for the value to avoid losing accuracy.

**Related issue(s)**:

Fixes #1613 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
