### PR TITLE
Override dev dep nx to 16.5.5 to fix build process on mac os m1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3936,11 +3936,11 @@
             }
         },
         "node_modules/@nrwl/tao": {
-            "version": "16.6.0",
-            "license": "MIT",
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.5.5.tgz",
+            "integrity": "sha512-6SYG3rlKkYvy/wauPwoUXQuN0PTJi95hCEC7lGfCEGye2Y/61UwJQf2xixMxafUM2X84WdEStEz3Jty85gVqkQ==",
             "dependencies": {
-                "nx": "16.6.0",
-                "tslib": "^2.3.0"
+                "nx": "16.5.5"
             },
             "bin": {
                 "tao": "index.js"
@@ -3961,12 +3961,103 @@
                 "nx": ">= 15 <= 17"
             }
         },
-        "node_modules/@nx/nx-linux-x64-gnu": {
-            "version": "16.6.0",
+        "node_modules/@nx/nx-darwin-arm64": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.5.5.tgz",
+            "integrity": "sha512-Zzwy7pkSDFTiWcBk78qDe4VzygO9kemtz/kbbLvpisZkUlZX9nIQnLHT80Ms++iqA0enIQAwdTcJiaIHLVd5JQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@nx/nx-darwin-x64": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.5.5.tgz",
+            "integrity": "sha512-d5O8BD5HFI2hJnMgVVV1pl2A+hlUmn4GxCZTmx2Tr329TYGdpvyXm8NnDFEAigZ77QVMHwFN6vqS07HARu+uVA==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@nx/nx-freebsd-x64": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.5.5.tgz",
+            "integrity": "sha512-SqTvbz21iUc8DHKgisX9pPuXc7/DngbiZxInlEHPXi8zUtyUOqZI3yQk4NVj3dqLBMLwEOZDgvXs0XxzB5nn+g==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@nx/nx-linux-arm-gnueabihf": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.5.5.tgz",
+            "integrity": "sha512-8C2KVFHqcyGViEgUicYo1frEgQARbD+CicIos6A5WRYLaxS+upb9FDblKU0eGYIwDp8oCagVjUjNX8d1WHLX7w==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@nx/nx-linux-arm64-gnu": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.5.5.tgz",
+            "integrity": "sha512-AGq4wp3Wn8bE0h2c7/bHj2wQWfp08DYJemwTNLkwLcoJWkUidLOBQePRvLxqPeo42Zmt3GYMi+fi5XtKCmvcjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@nx/nx-linux-arm64-musl": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.5.5.tgz",
+            "integrity": "sha512-xPTYjDCPnXLPXZThAzugiithZaIHk42rTxussMZA00Cx0iEkh5zohqtC0vGBnaAPNcMv0uyCiWABhL4RRUVp2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@nx/nx-linux-x64-gnu": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.5.5.tgz",
+            "integrity": "sha512-Rq55OWD4SObfo4sWpjvaijWg33dm+cOf8e2cO06t2EmLMdOyyVnpNdtpjXh6A9tSi3EU5xPfYiy3I9O6gWOnuw==",
+            "cpu": [
+                "x64"
+            ],
             "optional": true,
             "os": [
                 "linux"
@@ -3976,14 +4067,45 @@
             }
         },
         "node_modules/@nx/nx-linux-x64-musl": {
-            "version": "16.6.0",
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.5.5.tgz",
+            "integrity": "sha512-fnkSPv+VIKmQQOEQxFrGx5DlkHGxeH9Fzme6jwuDwmsvs+8Vv/uUnfcxkDZfJxKK+p27w37q3PQCfZGrFXE1cw==",
             "cpu": [
                 "x64"
             ],
-            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@nx/nx-win32-arm64-msvc": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.5.5.tgz",
+            "integrity": "sha512-9nWm+d+tlbxFMLvTLJqIfpTLDuSVDXfSBCSBampyeoI1mUALvq/6CVvWVBDlNqjmrZsYm0sudNqI4Ss7w3BUCQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/@nx/nx-win32-x64-msvc": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.5.5.tgz",
+            "integrity": "sha512-fB8miPr887GIGBDhyT6VX7MWX5aC40izEi+4GGSk38oh5dOUK9TLwjAEW/3vBE01fj5Hjcy0CPN7RA45fh/WUw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
             ],
             "engines": {
                 "node": ">= 10"
@@ -4158,8 +4280,9 @@
         },
         "node_modules/@parcel/watcher": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz",
+            "integrity": "sha512-cTDi+FUDBIUOBKEtj+nhiJ71AZVlkAsQFuGQTun5tV9mwQBQgZvhCzG+URPQc8myeN32yRVZEfVAPCs1RW+Jvg==",
             "hasInstallScript": true,
-            "license": "MIT",
             "dependencies": {
                 "node-addon-api": "^3.2.1",
                 "node-gyp-build": "^4.3.0"
@@ -4174,7 +4297,8 @@
         },
         "node_modules/@parcel/watcher/node_modules/node-addon-api": {
             "version": "3.2.1",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -4954,11 +5078,13 @@
         },
         "node_modules/@yarnpkg/lockfile": {
             "version": "1.1.0",
-            "license": "BSD-2-Clause"
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
         },
         "node_modules/@yarnpkg/parsers": {
             "version": "3.0.0-rc.46",
-            "license": "BSD-2-Clause",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.46.tgz",
+            "integrity": "sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==",
             "dependencies": {
                 "js-yaml": "^3.10.0",
                 "tslib": "^2.4.0"
@@ -4969,14 +5095,16 @@
         },
         "node_modules/@yarnpkg/parsers/node_modules/argparse": {
             "version": "1.0.10",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dependencies": {
                 "sprintf-js": "~1.0.2"
             }
         },
         "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
             "version": "3.14.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "dependencies": {
                 "argparse": "^1.0.7",
                 "esprima": "^4.0.0"
@@ -4987,7 +5115,8 @@
         },
         "node_modules/@zkochan/js-yaml": {
             "version": "0.0.6",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
+            "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -6943,7 +7072,8 @@
         },
         "node_modules/define-lazy-prop": {
             "version": "2.0.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
             "engines": {
                 "node": ">=8"
             }
@@ -8618,6 +8748,8 @@
         },
         "node_modules/ganache/node_modules/@trufflesuite/bigint-buffer": {
             "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.10.tgz",
+            "integrity": "sha512-pYIQC5EcMmID74t26GCC67946mgTJFiLXOT/BYozgrd4UEY2JHEGLhWi9cMiQCt5BSqFEvKkCHNnoj82SRjiEw==",
             "dev": true,
             "hasInstallScript": true,
             "inBundle": true,
@@ -8631,6 +8763,8 @@
         },
         "node_modules/ganache/node_modules/@trufflesuite/bigint-buffer/node_modules/node-gyp-build": {
             "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8642,6 +8776,8 @@
         },
         "node_modules/ganache/node_modules/@types/bn.js": {
             "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+            "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8651,24 +8787,32 @@
         },
         "node_modules/ganache/node_modules/@types/lru-cache": {
             "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/@types/node": {
             "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
+            "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/@types/seedrandom": {
             "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.1.tgz",
+            "integrity": "sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/base64-js": {
             "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true,
             "funding": [
                 {
@@ -8689,12 +8833,16 @@
         },
         "node_modules/ganache/node_modules/brorand": {
             "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/buffer": {
             "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
             "dev": true,
             "funding": [
                 {
@@ -8732,6 +8880,8 @@
         },
         "node_modules/ganache/node_modules/catering": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.0.tgz",
+            "integrity": "sha512-M5imwzQn6y+ODBfgi+cfgZv2hIUI6oYU/0f35Mdb1ujGeqeoI5tOnl9Q13DTH7LW+7er+NYq8stNOKZD/Z3U/A==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8744,6 +8894,8 @@
         },
         "node_modules/ganache/node_modules/elliptic": {
             "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8759,12 +8911,16 @@
         },
         "node_modules/ganache/node_modules/elliptic/node_modules/bn.js": {
             "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/emittery": {
             "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.0.tgz",
+            "integrity": "sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8777,6 +8933,8 @@
         },
         "node_modules/ganache/node_modules/hash.js": {
             "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8787,6 +8945,8 @@
         },
         "node_modules/ganache/node_modules/hmac-drbg": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8798,6 +8958,8 @@
         },
         "node_modules/ganache/node_modules/ieee754": {
             "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true,
             "funding": [
                 {
@@ -8818,12 +8980,16 @@
         },
         "node_modules/ganache/node_modules/inherits": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/ganache/node_modules/is-buffer": {
             "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
             "dev": true,
             "funding": [
                 {
@@ -8847,6 +9013,8 @@
         },
         "node_modules/ganache/node_modules/keccak": {
             "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+            "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
             "dev": true,
             "hasInstallScript": true,
             "inBundle": true,
@@ -8862,6 +9030,8 @@
         },
         "node_modules/ganache/node_modules/leveldown": {
             "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
+            "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
             "dev": true,
             "hasInstallScript": true,
             "inBundle": true,
@@ -8877,6 +9047,8 @@
         },
         "node_modules/ganache/node_modules/leveldown/node_modules/abstract-leveldown": {
             "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+            "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8894,6 +9066,8 @@
         },
         "node_modules/ganache/node_modules/leveldown/node_modules/level-concat-iterator": {
             "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+            "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8906,6 +9080,8 @@
         },
         "node_modules/ganache/node_modules/leveldown/node_modules/level-supports": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+            "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8915,30 +9091,40 @@
         },
         "node_modules/ganache/node_modules/minimalistic-assert": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
             "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/ganache/node_modules/minimalistic-crypto-utils": {
             "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/napi-macros": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+            "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/node-addon-api": {
             "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+            "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/node-gyp-build": {
             "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+            "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8950,6 +9136,8 @@
         },
         "node_modules/ganache/node_modules/queue-microtask": {
             "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
             "funding": [
                 {
@@ -8970,12 +9158,16 @@
         },
         "node_modules/ganache/node_modules/queue-tick": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+            "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/ganache/node_modules/readable-stream": {
             "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -8990,6 +9182,8 @@
         },
         "node_modules/ganache/node_modules/safe-buffer": {
             "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true,
             "funding": [
                 {
@@ -9010,6 +9204,8 @@
         },
         "node_modules/ganache/node_modules/secp256k1": {
             "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+            "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
             "dev": true,
             "hasInstallScript": true,
             "inBundle": true,
@@ -9025,6 +9221,8 @@
         },
         "node_modules/ganache/node_modules/string_decoder": {
             "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "dev": true,
             "inBundle": true,
             "license": "MIT",
@@ -9047,6 +9245,8 @@
         },
         "node_modules/ganache/node_modules/util-deprecate": {
             "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
             "dev": true,
             "inBundle": true,
             "license": "MIT"
@@ -10114,7 +10314,8 @@
         },
         "node_modules/is-docker": {
             "version": "2.2.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
             "bin": {
                 "is-docker": "cli.js"
             },
@@ -10387,7 +10588,8 @@
         },
         "node_modules/is-wsl": {
             "version": "2.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
             "dependencies": {
                 "is-docker": "^2.0.0"
             },
@@ -10830,7 +11032,8 @@
         },
         "node_modules/jsonc-parser": {
             "version": "3.2.0",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",
@@ -11627,7 +11830,8 @@
         },
         "node_modules/lines-and-columns": {
             "version": "2.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
+            "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
             "engines": {
                 "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             }
@@ -12808,10 +13012,6 @@
                 "node-gyp-build-test": "build-test.js"
             }
         },
-        "node_modules/node-machine-id": {
-            "version": "1.1.12",
-            "license": "MIT"
-        },
         "node_modules/node-preload": {
             "version": "0.2.1",
             "dev": true,
@@ -13175,11 +13375,12 @@
             "peer": true
         },
         "node_modules/nx": {
-            "version": "16.6.0",
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/nx/-/nx-16.5.5.tgz",
+            "integrity": "sha512-DHwoUtkirI52JIlCtRK78UI/Ik/VgCtM6FlkfPnFsy8PVyTYMQ40KoG6aZLHjqj5qxoGG2CUjcsbFjGXYrjDbw==",
             "hasInstallScript": true,
-            "license": "MIT",
             "dependencies": {
-                "@nrwl/tao": "16.6.0",
+                "@nrwl/tao": "16.5.5",
                 "@parcel/watcher": "2.0.4",
                 "@yarnpkg/lockfile": "^1.1.0",
                 "@yarnpkg/parsers": "3.0.0-rc.46",
@@ -13201,7 +13402,6 @@
                 "jsonc-parser": "3.2.0",
                 "lines-and-columns": "~2.0.3",
                 "minimatch": "3.0.5",
-                "node-machine-id": "1.1.12",
                 "npm-run-path": "^4.0.1",
                 "open": "^8.4.0",
                 "semver": "7.5.3",
@@ -13219,16 +13419,16 @@
                 "nx": "bin/nx.js"
             },
             "optionalDependencies": {
-                "@nx/nx-darwin-arm64": "16.6.0",
-                "@nx/nx-darwin-x64": "16.6.0",
-                "@nx/nx-freebsd-x64": "16.6.0",
-                "@nx/nx-linux-arm-gnueabihf": "16.6.0",
-                "@nx/nx-linux-arm64-gnu": "16.6.0",
-                "@nx/nx-linux-arm64-musl": "16.6.0",
-                "@nx/nx-linux-x64-gnu": "16.6.0",
-                "@nx/nx-linux-x64-musl": "16.6.0",
-                "@nx/nx-win32-arm64-msvc": "16.6.0",
-                "@nx/nx-win32-x64-msvc": "16.6.0"
+                "@nx/nx-darwin-arm64": "16.5.5",
+                "@nx/nx-darwin-x64": "16.5.5",
+                "@nx/nx-freebsd-x64": "16.5.5",
+                "@nx/nx-linux-arm-gnueabihf": "16.5.5",
+                "@nx/nx-linux-arm64-gnu": "16.5.5",
+                "@nx/nx-linux-arm64-musl": "16.5.5",
+                "@nx/nx-linux-x64-gnu": "16.5.5",
+                "@nx/nx-linux-x64-musl": "16.5.5",
+                "@nx/nx-win32-arm64-msvc": "16.5.5",
+                "@nx/nx-win32-x64-msvc": "16.5.5"
             },
             "peerDependencies": {
                 "@swc-node/register": "^1.4.2",
@@ -13695,7 +13895,8 @@
         },
         "node_modules/open": {
             "version": "8.4.2",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
             "dependencies": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",
@@ -20760,10 +20961,11 @@
             }
         },
         "@nrwl/tao": {
-            "version": "16.6.0",
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.5.5.tgz",
+            "integrity": "sha512-6SYG3rlKkYvy/wauPwoUXQuN0PTJi95hCEC7lGfCEGye2Y/61UwJQf2xixMxafUM2X84WdEStEz3Jty85gVqkQ==",
             "requires": {
-                "nx": "16.6.0",
-                "tslib": "^2.3.0"
+                "nx": "16.5.5"
             }
         },
         "@nx/devkit": {
@@ -20777,12 +20979,64 @@
                 "tslib": "^2.3.0"
             }
         },
+        "@nx/nx-darwin-arm64": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.5.5.tgz",
+            "integrity": "sha512-Zzwy7pkSDFTiWcBk78qDe4VzygO9kemtz/kbbLvpisZkUlZX9nIQnLHT80Ms++iqA0enIQAwdTcJiaIHLVd5JQ==",
+            "optional": true
+        },
+        "@nx/nx-darwin-x64": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.5.5.tgz",
+            "integrity": "sha512-d5O8BD5HFI2hJnMgVVV1pl2A+hlUmn4GxCZTmx2Tr329TYGdpvyXm8NnDFEAigZ77QVMHwFN6vqS07HARu+uVA==",
+            "optional": true
+        },
+        "@nx/nx-freebsd-x64": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.5.5.tgz",
+            "integrity": "sha512-SqTvbz21iUc8DHKgisX9pPuXc7/DngbiZxInlEHPXi8zUtyUOqZI3yQk4NVj3dqLBMLwEOZDgvXs0XxzB5nn+g==",
+            "optional": true
+        },
+        "@nx/nx-linux-arm-gnueabihf": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.5.5.tgz",
+            "integrity": "sha512-8C2KVFHqcyGViEgUicYo1frEgQARbD+CicIos6A5WRYLaxS+upb9FDblKU0eGYIwDp8oCagVjUjNX8d1WHLX7w==",
+            "optional": true
+        },
+        "@nx/nx-linux-arm64-gnu": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.5.5.tgz",
+            "integrity": "sha512-AGq4wp3Wn8bE0h2c7/bHj2wQWfp08DYJemwTNLkwLcoJWkUidLOBQePRvLxqPeo42Zmt3GYMi+fi5XtKCmvcjg==",
+            "optional": true
+        },
+        "@nx/nx-linux-arm64-musl": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.5.5.tgz",
+            "integrity": "sha512-xPTYjDCPnXLPXZThAzugiithZaIHk42rTxussMZA00Cx0iEkh5zohqtC0vGBnaAPNcMv0uyCiWABhL4RRUVp2w==",
+            "optional": true
+        },
         "@nx/nx-linux-x64-gnu": {
-            "version": "16.6.0",
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.5.5.tgz",
+            "integrity": "sha512-Rq55OWD4SObfo4sWpjvaijWg33dm+cOf8e2cO06t2EmLMdOyyVnpNdtpjXh6A9tSi3EU5xPfYiy3I9O6gWOnuw==",
             "optional": true
         },
         "@nx/nx-linux-x64-musl": {
-            "version": "16.6.0",
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.5.5.tgz",
+            "integrity": "sha512-fnkSPv+VIKmQQOEQxFrGx5DlkHGxeH9Fzme6jwuDwmsvs+8Vv/uUnfcxkDZfJxKK+p27w37q3PQCfZGrFXE1cw==",
+            "optional": true
+        },
+        "@nx/nx-win32-arm64-msvc": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.5.5.tgz",
+            "integrity": "sha512-9nWm+d+tlbxFMLvTLJqIfpTLDuSVDXfSBCSBampyeoI1mUALvq/6CVvWVBDlNqjmrZsYm0sudNqI4Ss7w3BUCQ==",
+            "optional": true
+        },
+        "@nx/nx-win32-x64-msvc": {
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.5.5.tgz",
+            "integrity": "sha512-fB8miPr887GIGBDhyT6VX7MWX5aC40izEi+4GGSk38oh5dOUK9TLwjAEW/3vBE01fj5Hjcy0CPN7RA45fh/WUw==",
             "optional": true
         },
         "@octokit/auth-token": {
@@ -20904,13 +21158,17 @@
         },
         "@parcel/watcher": {
             "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz",
+            "integrity": "sha512-cTDi+FUDBIUOBKEtj+nhiJ71AZVlkAsQFuGQTun5tV9mwQBQgZvhCzG+URPQc8myeN32yRVZEfVAPCs1RW+Jvg==",
             "requires": {
                 "node-addon-api": "^3.2.1",
                 "node-gyp-build": "^4.3.0"
             },
             "dependencies": {
                 "node-addon-api": {
-                    "version": "3.2.1"
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+                    "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
                 }
             }
         },
@@ -21484,10 +21742,14 @@
             "version": "1.1.2"
         },
         "@yarnpkg/lockfile": {
-            "version": "1.1.0"
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+            "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
         },
         "@yarnpkg/parsers": {
             "version": "3.0.0-rc.46",
+            "resolved": "https://registry.npmjs.org/@yarnpkg/parsers/-/parsers-3.0.0-rc.46.tgz",
+            "integrity": "sha512-aiATs7pSutzda/rq8fnuPwTglyVwjM22bNnK2ZgjrpAjQHSSl3lztd2f9evst1W/qnC58DRz7T7QndUDumAR4Q==",
             "requires": {
                 "js-yaml": "^3.10.0",
                 "tslib": "^2.4.0"
@@ -21495,12 +21757,16 @@
             "dependencies": {
                 "argparse": {
                     "version": "1.0.10",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+                    "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
                     "requires": {
                         "sprintf-js": "~1.0.2"
                     }
                 },
                 "js-yaml": {
                     "version": "3.14.1",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+                    "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
                     "requires": {
                         "argparse": "^1.0.7",
                         "esprima": "^4.0.0"
@@ -21510,6 +21776,8 @@
         },
         "@zkochan/js-yaml": {
             "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
+            "integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
             "requires": {
                 "argparse": "^2.0.1"
             }
@@ -22718,7 +22986,9 @@
             }
         },
         "define-lazy-prop": {
-            "version": "2.0.0"
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+            "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
         },
         "define-properties": {
             "version": "1.2.0",
@@ -23823,6 +24093,8 @@
             "dependencies": {
                 "@trufflesuite/bigint-buffer": {
                     "version": "1.1.10",
+                    "resolved": "https://registry.npmjs.org/@trufflesuite/bigint-buffer/-/bigint-buffer-1.1.10.tgz",
+                    "integrity": "sha512-pYIQC5EcMmID74t26GCC67946mgTJFiLXOT/BYozgrd4UEY2JHEGLhWi9cMiQCt5BSqFEvKkCHNnoj82SRjiEw==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23831,6 +24103,8 @@
                     "dependencies": {
                         "node-gyp-build": {
                             "version": "4.4.0",
+                            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
+                            "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
                             "bundled": true,
                             "dev": true
                         }
@@ -23838,6 +24112,8 @@
                 },
                 "@types/bn.js": {
                     "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+                    "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23846,31 +24122,43 @@
                 },
                 "@types/lru-cache": {
                     "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+                    "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==",
                     "bundled": true,
                     "dev": true
                 },
                 "@types/node": {
                     "version": "17.0.0",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
+                    "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
                     "bundled": true,
                     "dev": true
                 },
                 "@types/seedrandom": {
                     "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.1.tgz",
+                    "integrity": "sha512-giB9gzDeiCeloIXDgzFBCgjj1k4WxcDrZtGl6h1IqmUPlxF+Nx8Ve+96QCyDZ/HseB/uvDsKbpib9hU5cU53pw==",
                     "bundled": true,
                     "dev": true
                 },
                 "base64-js": {
                     "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+                    "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
                     "bundled": true,
                     "dev": true
                 },
                 "brorand": {
                     "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+                    "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
                     "bundled": true,
                     "dev": true
                 },
                 "buffer": {
                     "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23888,6 +24176,8 @@
                 },
                 "catering": {
                     "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.0.tgz",
+                    "integrity": "sha512-M5imwzQn6y+ODBfgi+cfgZv2hIUI6oYU/0f35Mdb1ujGeqeoI5tOnl9Q13DTH7LW+7er+NYq8stNOKZD/Z3U/A==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23896,6 +24186,8 @@
                 },
                 "elliptic": {
                     "version": "6.5.4",
+                    "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+                    "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23910,6 +24202,8 @@
                     "dependencies": {
                         "bn.js": {
                             "version": "4.12.0",
+                            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
                             "bundled": true,
                             "dev": true
                         }
@@ -23917,11 +24211,15 @@
                 },
                 "emittery": {
                     "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.10.0.tgz",
+                    "integrity": "sha512-AGvFfs+d0JKCJQ4o01ASQLGPmSCxgfU9RFXvzPvZdjKK8oscynksuJhWrSTSw7j7Ep/sZct5b5ZhYCi8S/t0HQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "hash.js": {
                     "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+                    "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23931,6 +24229,8 @@
                 },
                 "hmac-drbg": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+                    "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23941,21 +24241,29 @@
                 },
                 "ieee754": {
                     "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
                     "bundled": true,
                     "dev": true
                 },
                 "inherits": {
                     "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+                    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "is-buffer": {
                     "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "keccak": {
                     "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+                    "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23966,6 +24274,8 @@
                 },
                 "leveldown": {
                     "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.0.tgz",
+                    "integrity": "sha512-8C7oJDT44JXxh04aSSsfcMI8YiaGRhOFI9/pMEL7nWJLVsWajDPTRxsSHTM2WcTVY5nXM+SuRHzPPi0GbnDX+w==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -23976,6 +24286,8 @@
                     "dependencies": {
                         "abstract-leveldown": {
                             "version": "7.2.0",
+                            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+                            "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
                             "bundled": true,
                             "dev": true,
                             "requires": {
@@ -23989,6 +24301,8 @@
                         },
                         "level-concat-iterator": {
                             "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+                            "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
                             "bundled": true,
                             "dev": true,
                             "requires": {
@@ -23997,6 +24311,8 @@
                         },
                         "level-supports": {
                             "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+                            "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
                             "bundled": true,
                             "dev": true
                         }
@@ -24004,41 +24320,57 @@
                 },
                 "minimalistic-assert": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+                    "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
                     "bundled": true,
                     "dev": true
                 },
                 "minimalistic-crypto-utils": {
                     "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+                    "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
                     "bundled": true,
                     "dev": true
                 },
                 "napi-macros": {
                     "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+                    "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
                     "bundled": true,
                     "dev": true
                 },
                 "node-addon-api": {
                     "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+                    "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==",
                     "bundled": true,
                     "dev": true
                 },
                 "node-gyp-build": {
                     "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+                    "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
                     "bundled": true,
                     "dev": true
                 },
                 "queue-microtask": {
                     "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+                    "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
                     "bundled": true,
                     "dev": true
                 },
                 "queue-tick": {
                     "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.0.tgz",
+                    "integrity": "sha512-ULWhjjE8BmiICGn3G8+1L9wFpERNxkf8ysxkAer4+TFdRefDaXOCV5m92aMB9FtBVmn/8sETXLXY6BfW7hyaWQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "readable-stream": {
                     "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24049,11 +24381,15 @@
                 },
                 "safe-buffer": {
                     "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
                     "bundled": true,
                     "dev": true
                 },
                 "secp256k1": {
                     "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
+                    "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24064,6 +24400,8 @@
                 },
                 "string_decoder": {
                     "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -24080,6 +24418,8 @@
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                    "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
                     "bundled": true,
                     "dev": true
                 }
@@ -24723,7 +25063,9 @@
             }
         },
         "is-docker": {
-            "version": "2.2.1"
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
         },
         "is-extglob": {
             "version": "2.1.1"
@@ -24861,6 +25203,8 @@
         },
         "is-wsl": {
             "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
             "requires": {
                 "is-docker": "^2.0.0"
             }
@@ -25135,7 +25479,9 @@
             "version": "2.2.3"
         },
         "jsonc-parser": {
-            "version": "3.2.0"
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
         },
         "jsonfile": {
             "version": "6.1.0",
@@ -25378,7 +25724,7 @@
                 "npm-packlist": "5.1.1",
                 "npm-registry-fetch": "^14.0.5",
                 "npmlog": "^6.0.2",
-                "nx": ">=16.5.1 < 17",
+                "nx": "16.5.5",
                 "p-map": "4.0.0",
                 "p-map-series": "2.1.0",
                 "p-pipe": "3.1.0",
@@ -25673,7 +26019,9 @@
             }
         },
         "lines-and-columns": {
-            "version": "2.0.3"
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
+            "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w=="
         },
         "load-json-file": {
             "version": "6.2.0",
@@ -26433,9 +26781,6 @@
         "node-gyp-build": {
             "version": "4.3.0"
         },
-        "node-machine-id": {
-            "version": "1.1.12"
-        },
         "node-preload": {
             "version": "0.2.1",
             "dev": true,
@@ -26684,19 +27029,21 @@
             }
         },
         "nx": {
-            "version": "16.6.0",
+            "version": "16.5.5",
+            "resolved": "https://registry.npmjs.org/nx/-/nx-16.5.5.tgz",
+            "integrity": "sha512-DHwoUtkirI52JIlCtRK78UI/Ik/VgCtM6FlkfPnFsy8PVyTYMQ40KoG6aZLHjqj5qxoGG2CUjcsbFjGXYrjDbw==",
             "requires": {
-                "@nrwl/tao": "16.6.0",
-                "@nx/nx-darwin-arm64": "16.6.0",
-                "@nx/nx-darwin-x64": "16.6.0",
-                "@nx/nx-freebsd-x64": "16.6.0",
-                "@nx/nx-linux-arm-gnueabihf": "16.6.0",
-                "@nx/nx-linux-arm64-gnu": "16.6.0",
-                "@nx/nx-linux-arm64-musl": "16.6.0",
-                "@nx/nx-linux-x64-gnu": "16.6.0",
-                "@nx/nx-linux-x64-musl": "16.6.0",
-                "@nx/nx-win32-arm64-msvc": "16.6.0",
-                "@nx/nx-win32-x64-msvc": "16.6.0",
+                "@nrwl/tao": "16.5.5",
+                "@nx/nx-darwin-arm64": "16.5.5",
+                "@nx/nx-darwin-x64": "16.5.5",
+                "@nx/nx-freebsd-x64": "16.5.5",
+                "@nx/nx-linux-arm-gnueabihf": "16.5.5",
+                "@nx/nx-linux-arm64-gnu": "16.5.5",
+                "@nx/nx-linux-arm64-musl": "16.5.5",
+                "@nx/nx-linux-x64-gnu": "16.5.5",
+                "@nx/nx-linux-x64-musl": "16.5.5",
+                "@nx/nx-win32-arm64-msvc": "16.5.5",
+                "@nx/nx-win32-x64-msvc": "16.5.5",
                 "@parcel/watcher": "2.0.4",
                 "@yarnpkg/lockfile": "^1.1.0",
                 "@yarnpkg/parsers": "3.0.0-rc.46",
@@ -26718,7 +27065,6 @@
                 "jsonc-parser": "3.2.0",
                 "lines-and-columns": "~2.0.3",
                 "minimatch": "3.0.5",
-                "node-machine-id": "1.1.12",
                 "npm-run-path": "^4.0.1",
                 "open": "^8.4.0",
                 "semver": "^7.5.3",
@@ -27029,6 +27375,8 @@
         },
         "open": {
             "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+            "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
             "requires": {
                 "define-lazy-prop": "^2.0.0",
                 "is-docker": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     },
     "overrides": {
         "protobufjs": "^7.2.4",
-        "semver": "^7.5.3"
+        "semver": "^7.5.3",
+        "nx": "16.5.5"
     }
 }


### PR DESCRIPTION
**Description**:
Override dev dep nx to 16.5.5 to fix build process on mac os m1

**Related issue(s)**:

Fixes #1633 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
