### PR TITLE
Fix eth_getBalance to accept hash

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -734,14 +734,14 @@ export class EthImpl implements Eth {
    * @param account
    * @param blockNumberOrTag
    */
-  async getBalance(account: string, blockNumberOrTag: string | null, requestIdPrefix?: string) {
+  async getBalance(account: string, blockNumberOrTagOrHash: string | null, requestIdPrefix?: string) {
     const latestBlockTolerance = 1;
-    this.logger.trace(`${requestIdPrefix} getBalance(account=${account}, blockNumberOrTag=${blockNumberOrTag})`);
+    this.logger.trace(`${requestIdPrefix} getBalance(account=${account}, blockNumberOrTag=${blockNumberOrTagOrHash})`);
 
     let latestBlock: LatestBlockNumberTimestamp | null | undefined;
     // this check is required, because some tools like Metamask pass for parameter latest block, with a number (ex 0x30ea)
     // tolerance is needed, because there is a small delay between requesting latest block from blockNumber and passing it here
-    if (!this.common.blockTagIsLatestOrPending(blockNumberOrTag)) {
+    if (!this.common.blockTagIsLatestOrPending(blockNumberOrTagOrHash)) {
       const cacheKey = `${constants.CACHE_KEY.ETH_BLOCK_NUMBER}`;
       const blockNumberCached = this.cache.get(cacheKey, EthImpl.ethGetBalance);
 
@@ -752,22 +752,22 @@ export class EthImpl implements Eth {
       } else {
         latestBlock = await this.blockNumberTimestamp(EthImpl.ethGetBalance, requestIdPrefix);
       }
-      const blockDiff = Number(latestBlock.blockNumber) - Number(blockNumberOrTag);
+      const blockDiff = Number(latestBlock.blockNumber) - Number(blockNumberOrTagOrHash);
 
       if (blockDiff <= latestBlockTolerance) {
-        blockNumberOrTag = EthImpl.blockLatest;
+        blockNumberOrTagOrHash = EthImpl.blockLatest;
       }
 
       // If ever we get the latest block from cache, and blockNumberOrTag is not latest, then we need to get the block timestamp
       // This should rarely happen.
-      if((blockNumberOrTag !== EthImpl.blockLatest) && (latestBlock.timeStampTo === "0")) {
+      if((blockNumberOrTagOrHash !== EthImpl.blockLatest) && (latestBlock.timeStampTo === "0")) {
         latestBlock = await this.blockNumberTimestamp(EthImpl.ethGetBalance, requestIdPrefix);
       }
     }
 
     // check cache first
     // create a key for the cache
-    const cacheKey = `${constants.CACHE_KEY.ETH_GET_BALANCE}-${account}-${blockNumberOrTag}`;
+    const cacheKey = `${constants.CACHE_KEY.ETH_GET_BALANCE}-${account}-${blockNumberOrTagOrHash}`;
     let cachedBalance = this.cache.get(cacheKey, EthImpl.ethGetBalance);
     if (cachedBalance) {
       this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(cachedBalance)}`);
@@ -780,8 +780,8 @@ export class EthImpl implements Eth {
     let mirrorAccount;
 
     try {
-      if (!this.common.blockTagIsLatestOrPending(blockNumberOrTag)) {
-        const block = await this.common.getHistoricalBlockResponse(blockNumberOrTag, true, requestIdPrefix);
+      if (!this.common.blockTagIsLatestOrPending(blockNumberOrTagOrHash)) {
+        const block = await this.common.getHistoricalBlockResponse(blockNumberOrTagOrHash, true, requestIdPrefix);
         if (block) {
           blockNumber = block.number;
 
@@ -855,7 +855,7 @@ export class EthImpl implements Eth {
         this.logger.debug(
             `${requestIdPrefix} Unable to find account ${account} in block ${JSON.stringify(
                 blockNumber
-            )}(${blockNumberOrTag}), returning 0x0 balance`
+            )}(${blockNumberOrTagOrHash}), returning 0x0 balance`
         );
         return EthImpl.zeroHex;
       }
@@ -1178,7 +1178,7 @@ export class EthImpl implements Eth {
       const contractExecuteResponse = await this.hapiService.getSDKClient().submitEthereumTransaction(transactionBuffer, EthImpl.ethSendRawTransaction, requestIdPrefix);
       txSubmitted = true;
       // Wait for the record from the execution.
-      let txId = contractExecuteResponse.transactionId.toString();
+      const txId = contractExecuteResponse.transactionId.toString();
       const formattedId = formatTransactionIdWithoutQueryParams(txId);
 
       // handle formattedId being null

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -458,7 +458,6 @@ export class EthImpl implements Eth {
     if (Array.isArray(blocks) && blocks.length > 0) {
       const currentBlock = numberTo0x(blocks[0].number);
       const timestamp = blocks[0].timestamp.to;
-      const hash = blocks[0].hash;
       const blockTimeStamp: LatestBlockNumberTimestamp = { blockNumber: currentBlock, timeStampTo: timestamp};
       // save the latest block number in cache
       this.cache.set(cacheKey, currentBlock, caller, this.ethBlockNumberCacheTtlMs, requestIdPrefix);
@@ -749,7 +748,6 @@ export class EthImpl implements Eth {
       if(blockNumberCached) {
         this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(blockNumberCached)}`);
         latestBlock = { blockNumber: blockNumberCached, timeStampTo: '0' };
-
       } else {
         latestBlock = await this.blockNumberTimestamp(EthImpl.ethGetBalance, requestIdPrefix);
       }
@@ -759,13 +757,12 @@ export class EthImpl implements Eth {
 
       if (blockNumberOrTagOrHash != null && blockNumberOrTagOrHash.length > 32) {
         isHash = true;
-      }
-
-      if (isHash && blockNumberOrTagOrHash != null) {
         blockHashNumber = await this.mirrorNodeClient.getBlock(blockNumberOrTagOrHash);
       }
 
-      const blockDiff = isHash ? Number(latestBlock.blockNumber) - Number(blockHashNumber.number) : Number(latestBlock.blockNumber) - Number(blockNumberOrTagOrHash);
+      const currentBlockNumber = isHash ? Number(blockHashNumber.number) : Number(blockNumberOrTagOrHash);
+
+      const blockDiff = Number(latestBlock.blockNumber) - currentBlockNumber;
       if (blockDiff <= latestBlockTolerance) {
         blockNumberOrTagOrHash = EthImpl.blockLatest;
       }

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1431,6 +1431,9 @@ describe('Eth calls using MirrorNode', async function () {
           }
         }]
       });
+      restMock.onGet(`blocks/${blockHash}`).reply(200, {
+          number: 10000
+        });
       restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -1433,7 +1433,7 @@ describe('Eth calls using MirrorNode', async function () {
       });
       restMock.onGet(`blocks/${blockHash}`).reply(200, {
           number: 10000
-        });
+      });
       restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
         account: contractAddress1,
         balance: {
@@ -1464,6 +1464,37 @@ describe('Eth calls using MirrorNode', async function () {
       });
 
       const resBalance = await ethImpl.getBalance(contractAddress1, blockNumber, getRequestId());
+      expect(resBalance).to.equal(defHexBalance);
+    });
+
+    it('should return balance from mirror node with block hash passed as param, one behind latest', async () => {
+      const blockHash = "0x43da6a71f66d6d46d2b487c8231c04f01b3ba3bd91d165266d8eb39de3c0152b";
+      restMock.onGet(`blocks?limit=1&order=desc`).reply(200, {
+        blocks: [{
+          number: 10000,
+          'timestamp': {
+            'from': `${blockTimestamp}.060890919`,
+            'to': '1651560389.060890949'
+          }
+        }]
+      });
+      restMock.onGet(`blocks/${blockHash}`).reply(200, {
+          number: 9998,
+          'timestamp': {
+            'from': '1651550386'
+          }
+      });
+
+      restMock.onGet(`balances?account.id=${contractAddress1}&timestamp=1651550386`).reply(200, {
+        account: contractAddress1,
+        balances: [
+          {
+            balance: defBalance
+          }
+        ]
+        });
+
+      const resBalance = await ethImpl.getBalance(contractAddress1, blockHash, getRequestId());
       expect(resBalance).to.equal(defHexBalance);
     });
 

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -470,7 +470,7 @@ describe('Eth calls using MirrorNode', async function () {
 
   this.beforeEach( () => {
     restMock.onGet('network/fees').reply(200, defaultNetworkFees);
-  })
+  });
 
   it('"eth_blockNumber" should return the latest block number', async function () {
     restMock.onGet('blocks?limit=1&order=desc').reply(200, {
@@ -587,7 +587,7 @@ describe('Eth calls using MirrorNode', async function () {
       restMock.onGet(`blocks/${blockHash}`).reply(200, defaultBlock);
       restMock.onGet('blocks?limit=1&order=desc').reply(200, mostRecentBlock);
       restMock.onGet(`contracts/results/logs?timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&limit=100&order=asc`).reply(200, defaultEthGetBlockByLogs);
-    })
+    });
 
     it('eth_getBlockByNumber with match', async function () {
 
@@ -1417,6 +1417,28 @@ describe('Eth calls using MirrorNode', async function () {
       });
 
       const resBalance = await ethImpl.getBalance(contractAddress1, blockNumber, getRequestId());
+      expect(resBalance).to.equal(defHexBalance);
+    });
+
+    it('should return balance from mirror node with block hash passed as param the same as latest', async () => {
+      const blockHash = "0x43da6a71f66d6d46d2b487c8231c04f01b3ba3bd91d165266d8eb39de3c0152b";
+      restMock.onGet(`blocks?limit=1&order=desc`).reply(200, {
+        blocks: [{
+          number: 10000,
+          'timestamp': {
+            'from': `${blockTimestamp}.060890919`,
+            'to': '1651560389.060890949'
+          }
+        }]
+      });
+      restMock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, {
+        account: contractAddress1,
+        balance: {
+          balance: defBalance
+        }
+      });
+
+      const resBalance = await ethImpl.getBalance(contractAddress1, blockHash, getRequestId());
       expect(resBalance).to.equal(defHexBalance);
     });
 

--- a/packages/server/src/validator/methods.ts
+++ b/packages/server/src/validator/methods.ts
@@ -14,7 +14,7 @@ export const METHODS = {
       required: true
     },
     1: {
-      type: 'blockNumber',
+      type: 'blockNumber|blockHash',
       required: true
     }
   },

--- a/packages/server/src/validator/utils.ts
+++ b/packages/server/src/validator/utils.ts
@@ -3,7 +3,7 @@ import { JsonRpcError, predefined } from '@hashgraph/json-rpc-relay';
 
 export function validateParam(index: number | string, param: any, validation: any) {
   const isArray = Array.isArray(validation.type);
-  const containsOr = validation.type.includes('|') ? true : false;
+  const containsOr = validation.type.includes('|');
   const paramType = getParamType(isArray, containsOr, validation.type);
 
   if (paramType === undefined) {

--- a/packages/server/src/validator/utils.ts
+++ b/packages/server/src/validator/utils.ts
@@ -3,7 +3,8 @@ import { JsonRpcError, predefined } from '@hashgraph/json-rpc-relay';
 
 export function validateParam(index: number | string, param: any, validation: any) {
   const isArray = Array.isArray(validation.type);
-  const paramType = isArray ? Validator.TYPES[validation.type[0]] :Validator. TYPES[validation.type];
+  const containsOr = validation.type.includes('|') ? true : false;
+  const paramType = getParamType(isArray, containsOr, validation.type);
 
   if (paramType === undefined) {
     throw predefined.INTERNAL_ERROR(`Missing or unsupported param type '${validation.type}'`);
@@ -13,12 +14,37 @@ export function validateParam(index: number | string, param: any, validation: an
     throw predefined.MISSING_REQUIRED_PARAMETER(index);
   }
 
-  if (param != null) {
-    const result = isArray? paramType.test(index, param, validation.type[1]) : paramType.test(param);
+  if (param != null && Array.isArray(paramType)) {
+    const results: any[] = [];
+    for(const type of paramType) {
+      const validator = Validator.TYPES[type];
+      const result = validator.test(param);
+        results.push(result);
+    }
+    if(results.every((item) => item === false)) {
+      throw predefined.INVALID_PARAMETER(index, `The value passed is not a valid blockHash/blockNumber/blockTag value: ${param}`);
+    }
+  }
+
+  if (param != null && !Array.isArray(paramType)) {
+    const result = isArray ? paramType.test(index, param, validation.type[1]) : paramType.test(param);
     if(result === false) {
       throw predefined.INVALID_PARAMETER(index, `${paramType.error}, value: ${param}`);
     }
   }
+}
+
+function getParamType(isArray: boolean, containsOr: boolean, validationType: string) {
+  let paramType;
+  if(isArray && !containsOr) {
+    paramType = Validator.TYPES[validationType[0]];
+  } else if (!isArray && containsOr) {
+    paramType = validationType.split('|');
+  } else {
+    paramType = Validator.TYPES[validationType];
+  }
+
+  return paramType;
 }
 
 export function validateObject(object: any, filters: any) {

--- a/packages/server/src/validator/utils.ts
+++ b/packages/server/src/validator/utils.ts
@@ -3,7 +3,7 @@ import { JsonRpcError, predefined } from '@hashgraph/json-rpc-relay';
 
 export function validateParam(index: number | string, param: any, validation: any) {
   const isArray = Array.isArray(validation.type);
-  const containsOr = validation.type.includes('|');
+  const containsOr = validation.type?.includes('|');
   const paramType = getParamType(isArray, containsOr, validation.type);
 
   if (paramType === undefined) {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -284,6 +284,12 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             expect(res).to.eq(ethers.toQuantity(ONE_WEIBAR));
         });
 
+        it('@release should execute "eth_getBalance" with latest block hash', async function () {
+            const latestBlock = (await mirrorNode.get(`/blocks?limit=1&order=desc`, requestId)).blocks[0];
+            const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [Utils.idToEvmAddress(getBalanceContractId.toString()), numberTo0x(latestBlock.number)], requestId);
+            expect(res).to.eq(ethers.toQuantity(ONE_WEIBAR));
+        });
+
         it('@release should execute "eth_getBalance" with pending', async function () {
             const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [Utils.idToEvmAddress(getBalanceContractId.toString()), 'pending'], requestId);
             expect(res).to.eq(ethers.toQuantity(ONE_WEIBAR));

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -667,7 +667,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `The value passed is not a valid blockHash/blockNumber/blockTag value: 123`);
 
         }
       });
@@ -683,7 +683,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 1: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`);
+          BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, 'The value passed is not a valid blockHash/blockNumber/blockTag value: newest');
         }
       });
     });
@@ -1641,7 +1641,7 @@ describe('RPC Server', async function() {
 
           Assertions.expectedError();
         } catch (error) {
-          console.log(error.response.data)
+          console.log(error.response.data);
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, `Invalid parameter 0: Can't use both blockHash and toBlock/fromBlock`);
         }
       });


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR modifies the validations used for eth_getBalance endpoint as well as the getBalance method itself in order to allow the user to get balance by block hash.

- Add possibility for multiple validations with | e.g not only blockNumber or blockHash, but both at the same time
- Add change so blockDiff can be calculated correctly even if blockHash is passed to getBalance
- Add unit and acceptance tests
- Fix tests after the change

**Related issue(s)**:

Fixes #1614 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
