### PR TITLE
Adds withdrawals and withdrawalsRoot properties with default values

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -953,7 +953,9 @@
                     "nonce",
                     "size",
                     "transactions",
-                    "uncles"
+                    "uncles",
+                    "withdrawals",
+                    "withdrawalsRoot"
                 ],
                 "properties": {
                     "parentHash": {
@@ -1052,6 +1054,17 @@
                         "items": {
                             "$ref": "#/components/schemas/hash32"
                         }
+                    },
+                    "withdrawals": {
+                        "title": "Withdrawals",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/hash32"
+                        }
+                    },
+                    "withdrawalsRoot": {
+                        "title": "Withdrawals root",
+                        "$ref": "#/components/schemas/hash32"
                     }
                 }
             },

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -1058,13 +1058,11 @@
                     "withdrawals": {
                         "title": "Withdrawals",
                         "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/hash32"
-                        }
+                        "default": []
                     },
                     "withdrawalsRoot": {
                         "title": "Withdrawals root",
-                        "$ref": "#/components/schemas/hash32"
+                        "default": "0x0"
                     }
                 }
             },

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -45,6 +45,8 @@ export class Block {
     public readonly transactions:string[] | Transaction[] = [];
     public readonly transactionsRoot:string = '0x0';
     public readonly uncles:string[] = [];
+    public readonly withdrawals:string[] = [];
+    public readonly withdrawalsRoot: string = '0x0';
 
     constructor(args?:any) {
         if (args) {
@@ -69,6 +71,8 @@ export class Block {
             this.transactions = args.transactions;
             this.transactionsRoot = args.transactionsRoot;
             this.uncles = [];
+            this.withdrawals = [];
+            this.withdrawalsRoot = '0x0';
         }
     }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR sets default values for withdrawals and withdrawalsRoot in block in order to conform to the Ehtereum JSON RPC Schema for getBlockByHas and getBlockByNumber methods
**Related issue(s)**:

Fixes #1620 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
