### PR TITLE
Removed 400 AcceptedErrorCodes from MirrorNodeClient for GET_ACCOUNTS_BY_ID_ENDPOINT path

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -91,7 +91,7 @@ export class MirrorNodeClient {
     private readonly MIRROR_NODE_RETRY_DELAY = parseInt(process.env.MIRROR_NODE_RETRY_DELAY || '250');
 
     static acceptedErrorStatusesResponsePerRequestPathMap: Map<string, Array<number>> = new Map([
-        [MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT, [400, 404]],
+        [MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT, [404]],
         [MirrorNodeClient.GET_BALANCE_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_BLOCK_ENDPOINT, [400, 404]],
         [MirrorNodeClient.GET_BLOCKS_ENDPOINT, [400, 404]],

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -371,6 +371,33 @@ describe('MirrorNodeClient', async function () {
     expect(result).to.be.null;
   });
 
+  it('getAccount (500) Unexpected error', async () => {
+    const evmAddress = '0x00000000000000000000000000000000000004f7';
+    mock.onGet(`accounts/${evmAddress}${noTransactions}`).reply(500, { error: 'unexpected error' });
+    let errorRaised = false;
+    try {
+      await mirrorNodeInstance.getAccount(evmAddress);
+    }
+    catch (error: any) {
+      errorRaised = true;
+      expect(error.message).to.equal(`Request failed with status code 500`);
+    }
+    expect(errorRaised).to.be.true;
+  });
+
+  it(`getAccount (400) validation error`, async () => {
+    const invalidAddress = "0x123";
+    mock.onGet(`accounts/${invalidAddress}${noTransactions}`).reply(400);
+    let errorRaised = false;
+    try {
+      await mirrorNodeInstance.getAccount(invalidAddress);
+    } catch (error: any) {
+      errorRaised = true;
+      expect(error.message).to.equal(`Request failed with status code 400`);
+    }
+    expect(errorRaised).to.be.true;
+  });
+
   it('`getTokenById`', async () => {
     mock.onGet(`tokens/${mockData.tokenId}`).reply(200, mockData.token);
 
@@ -1139,6 +1166,35 @@ describe('MirrorNodeClient', async function () {
       expect(transactions).to.exist;
       expect(transactions.transactions.length).to.equal(2);
     });
+
+    it('should throw Error with unexpected exception if mirror node returns unexpected error', async() => {
+      const address = '0x00000000000000000000000000000000000007b8';
+      mock.onGet(transactionPath(address, 1)).reply(500, { error: 'unexpected error' });
+      let errorRaised = false;
+      try {
+        await mirrorNodeInstance.getAccountLatestEthereumTransactionsByTimestamp(address, timestamp);
+      }
+      catch (error: any) {
+        errorRaised = true;
+        expect(error.message).to.equal(`Request failed with status code 500`);
+      }
+      expect(errorRaised).to.be.true;
+    });
+
+    it('should throw invalid address error if mirror node returns 400 error status', async() => {
+      const invalidAddress = '0x123';
+      mock.onGet(transactionPath(invalidAddress, 1)).reply(400, mockData.invalidParameter);
+      let errorRaised = false;
+      try {
+        await mirrorNodeInstance.getAccountLatestEthereumTransactionsByTimestamp(invalidAddress, timestamp);
+      } catch (error: any) {
+        errorRaised = true;
+        expect(error.message).to.equal(`Request failed with status code 400`);
+      }
+      expect(errorRaised).to.be.true;
+    });
+
+
   });
 
   describe('isValidContract', async() => {


### PR DESCRIPTION
**Description**:
Removed 400 from acceptedErrorCodes for GET_ACCOUNTS_BY_ID_ENDPOINT path, added UT to verify that errors are being thrown for both 400 and 500 error status codes

**Related issue(s)**:  #1276 

Fixes #

**Notes for reviewer**:
This replaces [PR 1649](https://github.com/hashgraph/hedera-json-rpc-relay/pull/1649)
And [PR 1366](https://github.com/hashgraph/hedera-json-rpc-relay/pull/1366)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
