### PR TITLE
eth_getBalance not found account for past 15 minutes block in the past read null fix

### DIFF
--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -2034,6 +2034,31 @@ describe('Eth calls using MirrorNode', async function () {
         const resBalance = await ethImpl.getBalance(notFoundEvmAddress, '1', getRequestId());
         expect(resBalance).to.equal(EthImpl.zeroHex);
       });
+
+      it('blockNumber is in the latest 15 minutes, mirror node balance for address not found 404 status', async () => {
+        // random eth address
+        const notFoundEvmAddress = "0x1234567890123456789012345678901234567890";
+        const blockTimestamp = '1651560900';
+        const recentBlockWithinLastfifteen = {
+          ...defaultBlock,
+          number: 2,
+          timestamp: {
+            from: '1651560899.060890921',
+            to: `${blockTimestamp}.060890941`,
+          },
+        };
+        restMock.onGet(`blocks/2`).reply(200, recentBlockWithinLastfifteen);
+        restMock.onGet(`accounts/${notFoundEvmAddress}?limit=100`).reply(404, {
+          _status: {
+            messages: [{ message: 'Not found' }]
+          }
+        });
+
+        const resBalance = await ethImpl.getBalance(notFoundEvmAddress, '2', getRequestId());
+        expect(resBalance).to.equal(EthImpl.zeroHex);
+
+      });
+
     });
 
     describe('Calculate balance at block timestamp', async function() {


### PR DESCRIPTION
**Description**:
When trying to fetch the balance for accounts that does not exists and a block number in the past 15 minutes is provided, there was a null check missing that provoked a unexpected error `500` be returned instead of the expected `0x0` response.

This PR adds the check and missing unit test.

**Related issue(s)**: #1648

Fixes #1670 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
