### PR TITLE
Support synthetic logs in eth_subscribe

### DIFF
--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -142,6 +142,18 @@ export default {
             PENDING_TRANSACTION: 'pendingTransaction'
         },
         TTL: parseInt(process.env.FILTER_TTL || '300000')   // default is 5 minutes
+    },
+
+    METHODS: {
+        ETH_SUBSCRIBE: 'eth_subscribe',
+        ETH_UNSUBSCRIBE: 'eth_unsubscribe',
+        ETH_CHAIN_ID: 'eth_chainId',
+    },
+
+    SUBSCRIBE_EVENTS: {
+        LOGS: 'logs',
+        NEW_HEADS: 'newHeads',
+        NEW_PENDING_TRANSACTIONS: 'newPendingTransactions'
     }
 };
 

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -699,6 +699,7 @@ describe('@web-socket Acceptance Tests', async function() {
         before(async function() {
             htsAccounts[0] = await servicesNode.createAliasAccount(400, relay.provider, requestId);
             htsAccounts[1] = await servicesNode.createAliasAccount(200, relay.provider, requestId);
+            htsAccounts[2] = await servicesNode.createAliasAccount(5, relay.provider, requestId);
 
             const htsResult = await servicesNode.createHTS({
                 tokenName: 'TEST_TOKEN',
@@ -709,6 +710,7 @@ describe('@web-socket Acceptance Tests', async function() {
             });
 
             await servicesNode.associateHTSToken(htsAccounts[1].accountId, htsResult.receipt.tokenId, htsAccounts[1].privateKey, htsResult.client, requestId);
+            await servicesNode.associateHTSToken(htsAccounts[2].accountId, htsResult.receipt.tokenId, htsAccounts[2].privateKey, htsResult.client, requestId);
 
             const tokenAddress = Utils.idToEvmAddress(htsResult.receipt.tokenId.toString());
             htsToken = new ethers.Contract(tokenAddress, IERC20Json.abi, htsAccounts[0].wallet);
@@ -717,26 +719,25 @@ describe('@web-socket Acceptance Tests', async function() {
         beforeEach(async function() {
             wsHtsProvider = await new ethers.WebSocketProvider(WS_RELAY_URL);
             htsEventsReceived = [];
+            wsHtsProvider.on( {
+                address: htsToken.target
+            }, (event) => {
+                htsEventsReceived.push(event);
+            });
         });
 
         afterEach(async function() {
             await wsHtsProvider.websocket.close();
         });
 
-        it('subscribes to hts token and captures all logs', async function() {
-            wsHtsProvider.on( {
-                address: htsToken.target
-            }, (event) => {
-                htsEventsReceived.push(event);
-            });
-
+        it('captures transfer events', async function() {
             const balanceBefore = await htsToken.balanceOf(htsAccounts[1].wallet.address);
             expect(balanceBefore.toString()).to.eq('0', 'verify initial balance');
 
             const tx = await htsToken.transfer(htsAccounts[1].wallet.address, 1, Constants.GAS.LIMIT_1_000_000);
-            await tx.wait();
+            const rec = await tx.wait();
 
-            new Promise(resolve => setTimeout(resolve, 2000));
+            await new Promise(resolve => setTimeout(resolve, 2000));
 
             const balanceAfter = await htsToken.balanceOf(htsAccounts[1].wallet.address);
             expect(balanceAfter.toString()).to.eq('1', 'token is successfully transferred');
@@ -745,6 +746,38 @@ describe('@web-socket Acceptance Tests', async function() {
             assertions.expectLogArgs(htsEventsReceived[0], htsToken, [
                 htsAccounts[0].wallet.address,
                 htsAccounts[1].wallet.address,
+                BigInt(1)
+            ]);
+        });
+
+        it('captures approve and transferFrom events', async function() {
+            const tx = await htsToken.approve(htsAccounts[1].wallet.address, 1, Constants.GAS.LIMIT_1_000_000);
+            await tx.wait();
+
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+            const allowance = await htsToken.allowance(htsAccounts[0].wallet.address, htsAccounts[1].wallet.address);
+            expect(allowance.toString()).to.eq('1', 'token is successfully approved');
+
+            const tx2 = await htsToken.connect(htsAccounts[1].wallet).transferFrom(htsAccounts[0].wallet.address, htsAccounts[2].wallet.address, 1, Constants.GAS.LIMIT_1_000_000);
+            await tx2.wait();
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+            // FIXME enable assert when allowance bug is fixed in mirror node (expected to be fixed in v0.87)
+            // const allowanceAfter = await htsToken.allowance(htsAccounts[0].wallet.address, htsAccounts[1].wallet.address);
+            // expect(allowanceAfter.toString()).to.eq('0', 'token is successfully transferred');
+
+            expect(htsEventsReceived.length).to.eq(2, 'logs are captured');
+
+            assertions.expectLogArgs(htsEventsReceived[0], htsToken, [
+                htsAccounts[0].wallet.address,
+                htsAccounts[1].wallet.address,
+                BigInt(1)
+            ]);
+
+            assertions.expectLogArgs(htsEventsReceived[1], htsToken, [
+                htsAccounts[0].wallet.address,
+                htsAccounts[2].wallet.address,
                 BigInt(1)
             ]);
         });

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -735,7 +735,7 @@ describe('@web-socket Acceptance Tests', async function() {
             expect(balanceBefore.toString()).to.eq('0', 'verify initial balance');
 
             const tx = await htsToken.transfer(htsAccounts[1].wallet.address, 1, Constants.GAS.LIMIT_1_000_000);
-            const rec = await tx.wait();
+            await tx.wait();
 
             await new Promise(resolve => setTimeout(resolve, 2000));
 

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -754,7 +754,7 @@ describe('@web-socket Acceptance Tests', async function() {
             const tx = await htsToken.transfer(htsAccounts[1].wallet.address, 1, Constants.GAS.LIMIT_1_000_000);
             await tx.wait();
 
-            await new Promise(resolve => setTimeout(resolve, 2000));
+            await new Promise(resolve => setTimeout(resolve, 3000));
 
             const balanceAfter = await htsToken.balanceOf(htsAccounts[1].wallet.address);
             expect(balanceAfter.toString()).to.eq('1', 'token is successfully transferred');
@@ -809,7 +809,7 @@ describe('@web-socket Acceptance Tests', async function() {
 
         it('Calling eth_subscribe Logs with a non existent address should fail', async function() {
             const missingContract = "0xea4168c4cbb744ec22dea4a4bfc5f74b6fe27816";
-            const expectedError = predefined.INVALID_PARAMETER(`filters.address`, `${missingContract} is not a valid contract type or does not exists`);
+            const expectedError = predefined.INVALID_PARAMETER(`filters.address`, `${missingContract} is not a valid contract or token type or does not exists`);
 
             await Assertions.assertPredefinedRpcError(expectedError, wsProvider.send, true, wsProvider, ['eth_subscribe', ["logs", {"address": missingContract}]]);
         });

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -33,6 +33,7 @@ import ConnectionLimiter from "./ConnectionLimiter";
 import { formatRequestIdMessage } from "@hashgraph/json-rpc-relay/dist/formatters";
 import { EthSubscribeLogsParamsObject } from "@hashgraph/json-rpc-server/dist/validator";
 import { v4 as uuid } from 'uuid';
+import constants from "@hashgraph/json-rpc-relay/dist/lib/constants";
 
 const mainLogger = pino({
     name: 'hedera-json-rpc-relay',
@@ -88,9 +89,10 @@ function getMultipleAddressesEnabled() {
 }
 
 async function validateIsContractAddress(address, requestId) {
-    const isContract = await mirrorNodeClient.isValidContract(address, requestId)
-    if (!isContract) {
-        throw new JsonRpcError(predefined.INVALID_PARAMETER(`filters.address`, `${address} is not a valid contract type or does not exists`), requestId);
+
+    const isContractOrToken = await mirrorNodeClient.resolveEntityType(address, [constants.TYPE_CONTRACT, constants.TYPE_TOKEN], 'eth_subscribe', requestId)
+    if (!isContractOrToken) {
+        throw new JsonRpcError(predefined.INVALID_PARAMETER(`filters.address`, `${address} is not a valid contract or token type or does not exists`), requestId);
     }
 }
 


### PR DESCRIPTION
**Description**:
Fixes the address validation logic before creating a subscription through `eth_subscribe`. It now checks if the address is of an existing contract or token. This makes it possible to subscribe to `transfer` and `approve` events generated by HTS tokens.

**Related issue(s)**:

Fixes #1602 