### PR TITLE
Adds new types of transactions

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -20,7 +20,7 @@
 
 import constants from "./lib/constants";
 import crypto from "crypto";
-import { Transaction } from './lib/model';
+import { Transaction, Transaction1559, Transaction2930 } from './lib/model';
 import { BigNumber } from '@hashgraph/sdk/lib/Transfer';
 import { BigNumber as BN } from "bignumber.js";
 
@@ -32,7 +32,7 @@ const hashNumber = (num) => {
 
 const generateRandomHex = (bytesLength = 16) => {
     return "0x" + crypto.randomBytes(bytesLength).toString('hex');
-}
+};
 
 /**
 * Format message prefix for logger.
@@ -73,11 +73,11 @@ const formatTransactionId = (transactionId: string): string | null => {
         return null;
     }
     
-    var transactionSplit = transactionId.split("@");
+    const transactionSplit = transactionId.split("@");
     const payer = transactionSplit[0];
     const timestamp = transactionSplit[1].replace(".","-");
     return `${payer}-${timestamp}`;
-}
+};
 
 /**
  * Retrieve formated transactionID without query params
@@ -137,28 +137,87 @@ const formatContractResult = (cr: any) => {
         return null;
     }
 
-    return new Transaction({
-        accessList: undefined,
-        blockHash: toHash32(cr.block_hash),
-        blockNumber: nullableNumberTo0x(cr.block_number),
-        chainId: cr.chain_id,
-        from: cr.from.substring(0, 42),
-        gas: nanOrNumberTo0x(cr.gas_used),
-        gasPrice: toNullIfEmptyHex(cr.gas_price),
-        hash: cr.hash.substring(0, 66),
-        input: cr.function_parameters,
-        maxPriorityFeePerGas: toNullIfEmptyHex(cr.max_priority_fee_per_gas),
-        maxFeePerGas: toNullIfEmptyHex(cr.max_fee_per_gas),
-        nonce: nanOrNumberTo0x(cr.nonce),
-        r: cr.r === null ? null : cr.r.substring(0, 66),
-        s: cr.s === null ? null : cr.s.substring(0, 66),
-        to: cr.to?.substring(0, 42),
-        transactionIndex: nullableNumberTo0x(cr.transaction_index),
-        type: nullableNumberTo0x(cr.type),
-        v: nanOrNumberTo0x(cr.v),
-        value: nanOrNumberTo0x(cr.amount)
-    });
-}
+    switch (cr.type) {
+        case 0: return new Transaction({
+            blockHash: toHash32(cr.block_hash),
+            blockNumber: nullableNumberTo0x(cr.block_number),
+            chainId: cr.chain_id,
+            from: cr.from.substring(0, 42),
+            gas: nanOrNumberTo0x(cr.gas_used),
+            gasPrice: toNullIfEmptyHex(cr.gas_price),
+            hash: cr.hash.substring(0, 66),
+            input: cr.function_parameters,
+            nonce: nanOrNumberTo0x(cr.nonce),
+            r: cr.r === null ? null : cr.r.substring(0, 66),
+            s: cr.s === null ? null : cr.s.substring(0, 66),
+            to: cr.to?.substring(0, 42),
+            transactionIndex: nullableNumberTo0x(cr.transaction_index),
+            type: nullableNumberTo0x(cr.type),
+            v: nanOrNumberTo0x(cr.v),
+            value: nanOrNumberTo0x(cr.amount)
+        }); // eip 155 fields
+        case 1: return new Transaction2930({
+            accessList: [],
+            blockHash: toHash32(cr.block_hash),
+            blockNumber: nullableNumberTo0x(cr.block_number),
+            chainId: cr.chain_id,
+            from: cr.from.substring(0, 42),
+            gas: nanOrNumberTo0x(cr.gas_used),
+            gasPrice: toNullIfEmptyHex(cr.gas_price),
+            hash: cr.hash.substring(0, 66),
+            input: cr.function_parameters,
+            maxPriorityFeePerGas: toNullIfEmptyHex(cr.max_priority_fee_per_gas),
+            maxFeePerGas: toNullIfEmptyHex(cr.max_fee_per_gas),
+            nonce: nanOrNumberTo0x(cr.nonce),
+            r: cr.r === null ? null : cr.r.substring(0, 66),
+            s: cr.s === null ? null : cr.s.substring(0, 66),
+            to: cr.to?.substring(0, 42),
+            transactionIndex: nullableNumberTo0x(cr.transaction_index),
+            type: nullableNumberTo0x(cr.type),
+            v: nanOrNumberTo0x(cr.v),
+            value: nanOrNumberTo0x(cr.amount)
+        }); // eip 2930 fields
+        case 2: return new Transaction1559({
+            blockHash: toHash32(cr.block_hash),
+            blockNumber: nullableNumberTo0x(cr.block_number),
+            chainId: cr.chain_id,
+            from: cr.from.substring(0, 42),
+            gas: nanOrNumberTo0x(cr.gas_used),
+            gasPrice: toNullIfEmptyHex(cr.gas_price),
+            hash: cr.hash.substring(0, 66),
+            input: cr.function_parameters,
+            maxPriorityFeePerGas: toNullIfEmptyHex(cr.max_priority_fee_per_gas),
+            maxFeePerGas: toNullIfEmptyHex(cr.max_fee_per_gas),
+            nonce: nanOrNumberTo0x(cr.nonce),
+            r: cr.r === null ? null : cr.r.substring(0, 66),
+            s: cr.s === null ? null : cr.s.substring(0, 66),
+            to: cr.to?.substring(0, 42),
+            transactionIndex: nullableNumberTo0x(cr.transaction_index),
+            type: nullableNumberTo0x(cr.type),
+            v: nanOrNumberTo0x(cr.v),
+            value: nanOrNumberTo0x(cr.amount)
+        }); // eip 1559 fields
+        case null: return new Transaction({
+            blockHash: toHash32(cr.block_hash),
+            blockNumber: nullableNumberTo0x(cr.block_number),
+            chainId: cr.chain_id,
+            from: cr.from.substring(0, 42),
+            gas: nanOrNumberTo0x(cr.gas_used),
+            gasPrice: toNullIfEmptyHex(cr.gas_price),
+            hash: cr.hash.substring(0, 66),
+            input: cr.function_parameters,
+            nonce: nanOrNumberTo0x(cr.nonce),
+            r: cr.r === null ? null : cr.r.substring(0, 66),
+            s: cr.s === null ? null : cr.s.substring(0, 66),
+            to: cr.to?.substring(0, 42),
+            transactionIndex: nullableNumberTo0x(cr.transaction_index),
+            type: nullableNumberTo0x(cr.type),
+            v: nanOrNumberTo0x(cr.v),
+            value: nanOrNumberTo0x(cr.amount)
+        }); //hapi
+    }
+    return null;
+};
 
 const prepend0x = (input: string): string => {
     return input.startsWith(EMPTY_HEX) ? input : EMPTY_HEX + input;

--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -137,84 +137,37 @@ const formatContractResult = (cr: any) => {
         return null;
     }
 
+    const commonFields = {
+        blockHash: toHash32(cr.block_hash),
+        blockNumber: nullableNumberTo0x(cr.block_number),
+        chainId: cr.chain_id,
+        from: cr.from.substring(0, 42),
+        gas: nanOrNumberTo0x(cr.gas_used),
+        gasPrice: toNullIfEmptyHex(cr.gas_price),
+        hash: cr.hash.substring(0, 66),
+        input: cr.function_parameters,
+        nonce: nanOrNumberTo0x(cr.nonce),
+        r: cr.r === null ? null : cr.r.substring(0, 66),
+        s: cr.s === null ? null : cr.s.substring(0, 66),
+        to: cr.to?.substring(0, 42),
+        transactionIndex: nullableNumberTo0x(cr.transaction_index),
+        type: nullableNumberTo0x(cr.type),
+        v: nanOrNumberTo0x(cr.v),
+        value: nanOrNumberTo0x(cr.amount),
+    };
+
     switch (cr.type) {
-        case 0: return new Transaction({
-            blockHash: toHash32(cr.block_hash),
-            blockNumber: nullableNumberTo0x(cr.block_number),
-            chainId: cr.chain_id,
-            from: cr.from.substring(0, 42),
-            gas: nanOrNumberTo0x(cr.gas_used),
-            gasPrice: toNullIfEmptyHex(cr.gas_price),
-            hash: cr.hash.substring(0, 66),
-            input: cr.function_parameters,
-            nonce: nanOrNumberTo0x(cr.nonce),
-            r: cr.r === null ? null : cr.r.substring(0, 66),
-            s: cr.s === null ? null : cr.s.substring(0, 66),
-            to: cr.to?.substring(0, 42),
-            transactionIndex: nullableNumberTo0x(cr.transaction_index),
-            type: nullableNumberTo0x(cr.type),
-            v: nanOrNumberTo0x(cr.v),
-            value: nanOrNumberTo0x(cr.amount)
-        }); // eip 155 fields
+        case 0: return new Transaction(commonFields); // eip 155 fields
         case 1: return new Transaction2930({
-            accessList: [],
-            blockHash: toHash32(cr.block_hash),
-            blockNumber: nullableNumberTo0x(cr.block_number),
-            chainId: cr.chain_id,
-            from: cr.from.substring(0, 42),
-            gas: nanOrNumberTo0x(cr.gas_used),
-            gasPrice: toNullIfEmptyHex(cr.gas_price),
-            hash: cr.hash.substring(0, 66),
-            input: cr.function_parameters,
-            maxPriorityFeePerGas: toNullIfEmptyHex(cr.max_priority_fee_per_gas),
-            maxFeePerGas: toNullIfEmptyHex(cr.max_fee_per_gas),
-            nonce: nanOrNumberTo0x(cr.nonce),
-            r: cr.r === null ? null : cr.r.substring(0, 66),
-            s: cr.s === null ? null : cr.s.substring(0, 66),
-            to: cr.to?.substring(0, 42),
-            transactionIndex: nullableNumberTo0x(cr.transaction_index),
-            type: nullableNumberTo0x(cr.type),
-            v: nanOrNumberTo0x(cr.v),
-            value: nanOrNumberTo0x(cr.amount)
+            ...commonFields,
+            accessList: []
         }); // eip 2930 fields
         case 2: return new Transaction1559({
-            blockHash: toHash32(cr.block_hash),
-            blockNumber: nullableNumberTo0x(cr.block_number),
-            chainId: cr.chain_id,
-            from: cr.from.substring(0, 42),
-            gas: nanOrNumberTo0x(cr.gas_used),
-            gasPrice: toNullIfEmptyHex(cr.gas_price),
-            hash: cr.hash.substring(0, 66),
-            input: cr.function_parameters,
+            ...commonFields,
             maxPriorityFeePerGas: toNullIfEmptyHex(cr.max_priority_fee_per_gas),
-            maxFeePerGas: toNullIfEmptyHex(cr.max_fee_per_gas),
-            nonce: nanOrNumberTo0x(cr.nonce),
-            r: cr.r === null ? null : cr.r.substring(0, 66),
-            s: cr.s === null ? null : cr.s.substring(0, 66),
-            to: cr.to?.substring(0, 42),
-            transactionIndex: nullableNumberTo0x(cr.transaction_index),
-            type: nullableNumberTo0x(cr.type),
-            v: nanOrNumberTo0x(cr.v),
-            value: nanOrNumberTo0x(cr.amount)
+            maxFeePerGas: toNullIfEmptyHex(cr.max_fee_per_gas)
         }); // eip 1559 fields
-        case null: return new Transaction({
-            blockHash: toHash32(cr.block_hash),
-            blockNumber: nullableNumberTo0x(cr.block_number),
-            chainId: cr.chain_id,
-            from: cr.from.substring(0, 42),
-            gas: nanOrNumberTo0x(cr.gas_used),
-            gasPrice: toNullIfEmptyHex(cr.gas_price),
-            hash: cr.hash.substring(0, 66),
-            input: cr.function_parameters,
-            nonce: nanOrNumberTo0x(cr.nonce),
-            r: cr.r === null ? null : cr.r.substring(0, 66),
-            s: cr.s === null ? null : cr.s.substring(0, 66),
-            to: cr.to?.substring(0, 42),
-            transactionIndex: nullableNumberTo0x(cr.transaction_index),
-            type: nullableNumberTo0x(cr.type),
-            v: nanOrNumberTo0x(cr.v),
-            value: nanOrNumberTo0x(cr.amount)
-        }); //hapi
+        case null: return new Transaction(commonFields); //hapi
     }
     return null;
 };

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -120,7 +120,6 @@ export class Receipt {
 }
 
 export class Transaction {
-    public readonly accessList!: AccessListEntry[] | null;
     public readonly blockHash!: string | null;
     public readonly blockNumber!: string | null;
     public readonly chainId!: string;
@@ -129,8 +128,6 @@ export class Transaction {
     public readonly gasPrice!: string;
     public readonly hash!: string;
     public readonly input!: string;
-    public readonly maxPriorityFeePerGas!: string;
-    public readonly maxFeePerGas!: string;
     public readonly nonce!: string;
     public readonly r!: string;
     public readonly s!: string;
@@ -141,7 +138,6 @@ export class Transaction {
     public readonly value!: string;
 
     constructor(args: any) {
-        this.accessList = args.accessList;
         this.blockHash = args.blockHash;
         this.blockNumber = args.blockNumber;
         this.chainId = args.chainId;
@@ -150,8 +146,6 @@ export class Transaction {
         this.gasPrice = args.gasPrice;
         this.hash = args.hash;
         this.input = args.input;
-        this.maxPriorityFeePerGas = args.maxPriorityFeePerGas;
-        this.maxFeePerGas = args.maxFeePerGas;
         this.nonce = args.nonce;
         this.r = args.r;
         this.s = args.s;
@@ -160,6 +154,26 @@ export class Transaction {
         this.type = args.type;
         this.v = args.v;
         this.value = args.value;
+    }
+}
+
+export class Transaction2930 extends Transaction {
+    public readonly accessList!: AccessListEntry[] | null | [];
+
+    constructor(args: any) {
+        super(args);
+        this.accessList = args.accessList;
+    }
+}
+
+export class Transaction1559 extends Transaction2930 {
+    public readonly maxPriorityFeePerGas!: string;
+    public readonly maxFeePerGas!: string;
+
+    constructor(args: any) {
+        super(args);
+        this.maxPriorityFeePerGas = args.maxPriorityFeePerGas;
+        this.maxFeePerGas = args.maxFeePerGas;
     }
 }
 

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -233,11 +233,9 @@ describe('Formatters', () => {
                 r: null,
                 s: null,
                 transaction_index: null,
-                type: null,
                 v: null,
                 value: null
             });
-            expect(formattedResult.accessList).to.equal(undefined);
             expect(formattedResult.blockHash).to.equal('0xb0f10139fa0bf9e66402c8c0e5ed364e07cf83b3726c8045fabf86a07f488713');
             expect(formattedResult.blockNumber).to.equal(null);
             expect(formattedResult.chainId).to.equal('0x12a');
@@ -253,7 +251,6 @@ describe('Formatters', () => {
             expect(formattedResult.s).to.equal(null);
             expect(formattedResult.to).to.equal('0x0000000000000000000000000000000000000409');
             expect(formattedResult.transactionIndex).to.equal(null);
-            expect(formattedResult.type).to.equal(null);
             expect(formattedResult.v).to.equal('0x0');
             expect(formattedResult.value).to.equal('0x0');
         });


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This PR modifies the formatContractResult method used in getTransactionByHash, getTransactionByBlockHashAndIndex and getTransactionByBlockNumberAndIndex and getBlock by adding new objects for the different types of ethereum transactions, namely 155 transaction, 2930 transactions and 1559 transactions. This is needed in order to conform to the [JSON-RPC ethereum schema](https://ethereum.github.io/execution-apis/api-documentation/) and return only the needed fields for each type of transactions. 
E.g Currently, for 155 and 2930 we return maxPriorityFeePerGas and maxFeePerGas with null values, which is not correct in regards to the JSON-RPC ethereum specs.

**Related issue(s)**:

Fixes #1657 #1656 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
