### PR TITLE
Add request-id as part of all response headers

### DIFF
--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -97,6 +97,7 @@ export default class KoaJsonRpc {
       let body, result;
 
       this.requestId = ctx.state.reqId;
+      ctx.set('request-id', this.requestId);
       
       if (this.token) {
         const headerToken = ctx.get('authorization').split(' ').pop();

--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -48,8 +48,9 @@ const INTERNAL_ERROR = "INTERNAL ERROR";
 const INVALID_PARAMS_ERROR = "INVALID PARAMS ERROR";
 const INVALID_REQUEST = "INVALID REQUEST";
 const IP_RATE_LIMIT_EXCEEDED = "IP RATE LIMIT EXCEEDED";
-const JSON_RPC_ERROR = "JSON RPC ERROR"
+const JSON_RPC_ERROR = "JSON RPC ERROR";
 const METHOD_NOT_FOUND = "METHOD NOT FOUND";
+const REQUEST_ID_HEADER_NAME = "X-Request-Id";
 
 const responseSuccessStatusCode = '200';
 
@@ -97,7 +98,7 @@ export default class KoaJsonRpc {
       let body, result;
 
       this.requestId = ctx.state.reqId;
-      ctx.set('request-id', this.requestId);
+      ctx.set(REQUEST_ID_HEADER_NAME, this.requestId);
       
       if (this.token) {
         const headerToken = ctx.get('authorization').split(' ').pop();

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -1800,9 +1800,10 @@ class BaseTest {
   }
 
   static validRequestIdCheck(response) {
-    expect(response.headers, "Default response: headers should have 'request-id' property").to.have.property('request-id');
-    expect(response.headers['request-id'], "Default response: 'headers[request-id]' should not be null").not.to.be.null;
-    expect(response.headers['request-id'], "Default response: 'headers[request-id]' should not be undefined").not.to.be.undefined;
+    const requestIdHeaderName = "X-Request-Id";
+    expect(response.headers, `Default response: headers should have '${requestIdHeaderName}' property`).to.have.property('request-id');
+    expect(response.headers[requestIdHeaderName], `Default response: 'headers[${requestIdHeaderName}]' should not be null`).not.to.be.null;
+    expect(response.headers[requestIdHeaderName], `Default response: 'headers[${requestIdHeaderName}]' should not be undefined`).not.to.be.undefined;
   }
 
   static validResponseCheck(response, options:any = {status: 200, statusText: 'OK'}) {

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -1800,7 +1800,7 @@ class BaseTest {
   }
 
   static validRequestIdCheck(response) {
-    const requestIdHeaderName = "X-Request-Id";
+    const requestIdHeaderName = "X-Request-Id".toLowerCase();
     expect(response.headers, `Default response: headers should have '${requestIdHeaderName}' property`).to.have.property(requestIdHeaderName);
     expect(response.headers[requestIdHeaderName], `Default response: 'headers[${requestIdHeaderName}]' should not be null`).not.to.be.null;
     expect(response.headers[requestIdHeaderName], `Default response: 'headers[${requestIdHeaderName}]' should not be undefined`).not.to.be.undefined;

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -1801,7 +1801,7 @@ class BaseTest {
 
   static validRequestIdCheck(response) {
     const requestIdHeaderName = "X-Request-Id";
-    expect(response.headers, `Default response: headers should have '${requestIdHeaderName}' property`).to.have.property('request-id');
+    expect(response.headers, `Default response: headers should have '${requestIdHeaderName}' property`).to.have.property(requestIdHeaderName);
     expect(response.headers[requestIdHeaderName], `Default response: 'headers[${requestIdHeaderName}]' should not be null`).not.to.be.null;
     expect(response.headers[requestIdHeaderName], `Default response: 'headers[${requestIdHeaderName}]' should not be undefined`).not.to.be.undefined;
   }

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -1799,6 +1799,12 @@ class BaseTest {
     });
   }
 
+  static validRequestIdCheck(response) {
+    expect(response.headers, "Default response: headers should have 'request-id' property").to.have.property('request-id');
+    expect(response.headers['request-id'], "Default response: 'headers[request-id]' should not be null").not.to.be.null;
+    expect(response.headers['request-id'], "Default response: 'headers[request-id]' should not be undefined").not.to.be.undefined;
+  }
+
   static validResponseCheck(response, options:any = {status: 200, statusText: 'OK'}) {
     expect(response.status).to.eq(options.status);
     expect(response.statusText).to.eq(options.statusText);
@@ -1815,6 +1821,7 @@ class BaseTest {
   static defaultResponseChecks(response) {
     BaseTest.validResponseCheck(response);
     BaseTest.validCorsCheck(response);
+    BaseTest.validRequestIdCheck(response);
     expect(response, "Default response: Should have 'data' property").to.have.property('data');
     expect(response.data, "Default response: 'data' should have 'id' property").to.have.property('id');
     expect(response.data, "Default response: 'data' should have 'jsonrpc' property").to.have.property('jsonrpc');
@@ -1825,6 +1832,7 @@ class BaseTest {
   }
 
   static errorResponseChecks(response, code, message, name?) {
+    BaseTest.validRequestIdCheck(response);
     expect(response, "Error response: should have 'data' property").to.have.property('data');
     expect(response.data, "Error response: 'data' should have 'id' property").to.have.property('id');
     expect(response.data, "Error response: 'data' should have 'jsonrpc' property").to.have.property('jsonrpc');
@@ -1860,6 +1868,7 @@ class BaseTest {
   }
 
   static invalidRequestSpecError(response: any, code: number, message: string) {
+    BaseTest.validRequestIdCheck(response);
     expect(response.status).to.eq(400);
     expect(response.statusText).to.eq('Bad Request');
     expect(response, "Default response: Should have 'data' property").to.have.property('data');


### PR DESCRIPTION
**Description**:
Add request-id as part of all response headers


**Related issue(s)**:

Fixes #1629 

**Notes for reviewer**:
<img width="1143" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/e29471f7-077d-4901-be7e-07e24203429b">



**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
