### PR TITLE
Turned on allowance test, set correct byteCode for estimateGas test, a…

### DIFF
--- a/packages/server/tests/acceptance/erc20.spec.ts
+++ b/packages/server/tests/acceptance/erc20.spec.ts
@@ -233,8 +233,7 @@ describe('@erc20 Acceptance Tests', async function () {
                                         expect(toBalance.toString()).to.be.equal(amount.toString());
                                     });
 
-                                    // Issue #1514.
-                                    xit('decreases the spender allowance', async function () {
+                                    it('decreases the spender allowance', async function () {
                                         const allowance = await contract.allowance(tokenOwner, spender);
                                         expect(allowance.toString()).to.be.equal('0');
                                     });

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -139,7 +139,7 @@ describe('RPC Server Acceptance Tests', function () {
         // set env variables for docker images until local-node is updated
         process.env['NETWORK_NODE_IMAGE_TAG'] = '0.41.0-alpha.3';
         process.env['HAVEGED_IMAGE_TAG'] = '0.41.0-alpha.3';
-        process.env['MIRROR_IMAGE_TAG'] = '0.86.0-beta1';
+        process.env['MIRROR_IMAGE_TAG'] = 'main';
 
         console.log(`Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`);
 

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -60,7 +60,6 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     const ONE_TINYBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 10)));
     const ONE_WEIBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 18)));
 
-    const BASIC_CONTRACT_PING_CALL_DATA = '0x5c36b186';
     const BASIC_CONTRACT_ESTIMATE_GAS_CALL_DATA = '0x6080604052348015600f57600080fd5b50609e8061001e6000396000f3fe608060405260043610602a5760003560e01c80635c36b18614603557806383197ef014605557600080fd5b36603057005b600080fd5b348015604057600080fd5b50600160405190815260200160405180910390f35b348015606057600080fd5b50606633ff5b00fea2646970667358221220886a6d6d6c88bcfc0063129ca2391a3d98aee75ad7fe3e870ec6679215456a3964736f6c63430008090033';
     const EXCHANGE_RATE_FILE_ID = "0.0.112";
     const EXCHANGE_RATE_FILE_CONTENT_DEFAULT = "0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306";
@@ -135,7 +134,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             const expectedRes = `0x${(400000).toString(16)}`;
             const estimatedGas = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
                 to: basicContract.evm_address,
-                data: BASIC_CONTRACT_PING_CALL_DATA
+                data: BASIC_CONTRACT_ESTIMATE_GAS_CALL_DATA
             }], requestId);
             expect(estimatedGas).to.contain('0x');
             expect(estimatedGas).to.equal(expectedRes);

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -134,6 +134,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
             const expectedRes = `0x${(400000).toString(16)}`;
             const estimatedGas = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS, [{
                 to: basicContract.evm_address,
+                // must pass in valid bytecode to get a valid estimate
                 data: BASIC_CONTRACT_ESTIMATE_GAS_CALL_DATA
             }], requestId);
             expect(estimatedGas).to.contain('0x');

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2022 Hedera Hashgraph, LLC
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     const ONE_WEIBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 18)));
 
     const BASIC_CONTRACT_PING_CALL_DATA = '0x5c36b186';
+    const BASIC_CONTRACT_ESTIMATE_GAS_CALL_DATA = '0x6080604052348015600f57600080fd5b50609e8061001e6000396000f3fe608060405260043610602a5760003560e01c80635c36b18614603557806383197ef014605557600080fd5b36603057005b600080fd5b348015604057600080fd5b50600160405190815260200160405180910390f35b348015606057600080fd5b50606633ff5b00fea2646970667358221220886a6d6d6c88bcfc0063129ca2391a3d98aee75ad7fe3e870ec6679215456a3964736f6c63430008090033';
     const EXCHANGE_RATE_FILE_ID = "0.0.112";
     const EXCHANGE_RATE_FILE_CONTENT_DEFAULT = "0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306";
     const FEE_SCHEDULE_FILE_ID = "0.0.111";


### PR DESCRIPTION

**Description**:
Turned on allowance test, set correct byteCode for estimateGas test, and set mirror node tag to main to pick up corresponding mirror node fixes.

**Related issue(s)**:

Fixes #1514 , #1685 
