### PR TITLE
Fix failing subgraph CI

### DIFF
--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Start local graph-node
         run: npm run graph-local -- --detach
 
-      - name: Sleep for 10 seconds
-        run: sleep 10s
+      - name: Sleep for 20 seconds
+        run: sleep 20s
         shell: bash
 
       - name: Create subgraph


### PR DESCRIPTION
**Description**:
This PR fixes failing subgraph tests by bumping time between starting graph node and deploying subgraph from 10 to 20 seconds.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
