### PR TITLE
Set the mirror-image-tag to 0.88.0 from main

### DIFF
--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -142,7 +142,7 @@ describe('RPC Server Acceptance Tests', function () {
     // set env variables for docker images until local-node is updated
     process.env['NETWORK_NODE_IMAGE_TAG'] = '0.41.0-alpha.3';
     process.env['HAVEGED_IMAGE_TAG'] = '0.41.0-alpha.3';
-    process.env['MIRROR_IMAGE_TAG'] = 'main';
+    process.env['MIRROR_IMAGE_TAG'] = '0.87.0';
 
     console.log(
       `Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`,


### PR DESCRIPTION
Set the mirror node tag version to 0.87.0

**Related issue(s)**:

Fixes #1706

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
