### PR TITLE
Environment variable fixes.

### DIFF
--- a/packages/server/tests/acceptance/cacheService.spec.ts
+++ b/packages/server/tests/acceptance/cacheService.spec.ts
@@ -24,7 +24,7 @@ import { Registry } from 'prom-client';
 const registry = new Registry();
 const Redis = require('ioredis');
 
-const { hostname, port } = new URL(process.env.REDIS_URL || '');
+const { hostname, port } = new URL(process.env.REDIS_URL || 'redis://127.0.0.1:6379');
 const redis = new Redis({
   port: port,
   host: hostname,

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -142,7 +142,7 @@ describe('RPC Server Acceptance Tests', function () {
     // set env variables for docker images until local-node is updated
     process.env['NETWORK_NODE_IMAGE_TAG'] = '0.41.0-alpha.3';
     process.env['HAVEGED_IMAGE_TAG'] = '0.41.0-alpha.3';
-    process.env['MIRROR_IMAGE_TAG'] = 'main';
+    process.env['MIRROR_IMAGE_TAG'] = '0.88.0-beta2';
 
     console.log(
       `Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`,


### PR DESCRIPTION
Sets mirror node version and default value for the redis server in the acceptance tests.

**Related issue(s)**:

Fixes #1706 

