### PR TITLE
Usage of Shared Cache for Synthetic transaction receipts

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1737,7 +1737,7 @@ export class EthImpl implements Eth {
     }
 
     const cacheKeySyntheticLog = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${hash}`;
-    const cachedLog = this.cacheService.getSharedWithFallback(
+    const cachedLog = await this.cacheService.getSharedWithFallback(
       cacheKeySyntheticLog,
       EthImpl.ethGetTransactionReceipt,
       requestIdPrefix,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1737,7 +1737,11 @@ export class EthImpl implements Eth {
     }
 
     const cacheKeySyntheticLog = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${hash}`;
-    const cachedLog = this.cacheService.get(cacheKeySyntheticLog, EthImpl.ethGetTransactionReceipt, requestIdPrefix);
+    const cachedLog = this.cacheService.getSharedWithFallback(
+      cacheKeySyntheticLog,
+      EthImpl.ethGetTransactionReceipt,
+      requestIdPrefix,
+    );
     if (cachedLog) {
       const receipt: any = {
         blockHash: cachedLog.blockHash,
@@ -1992,7 +1996,14 @@ export class EthImpl implements Eth {
         transactionArray.push(transaction);
 
         const cacheKey = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${log.transactionHash}`;
-        this.cacheService.set(cacheKey, log, EthImpl.ethGetBlockByHash, this.syntheticLogCacheTtl, requestIdPrefix);
+        this.cacheService.set(
+          cacheKey,
+          log,
+          EthImpl.ethGetBlockByHash,
+          this.syntheticLogCacheTtl,
+          requestIdPrefix,
+          true,
+        );
       });
     } else {
       filteredLogs = logs.filter((log) => !transactionArray.includes(log.transactionHash));
@@ -2000,7 +2011,14 @@ export class EthImpl implements Eth {
         transactionArray.push(log.transactionHash);
 
         const cacheKey = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${log.transactionHash}`;
-        this.cacheService.set(cacheKey, log, EthImpl.ethGetBlockByHash, this.syntheticLogCacheTtl, requestIdPrefix);
+        this.cacheService.set(
+          cacheKey,
+          log,
+          EthImpl.ethGetBlockByHash,
+          this.syntheticLogCacheTtl,
+          requestIdPrefix,
+          true,
+        );
       });
 
       this.logger.trace(

--- a/packages/relay/src/lib/services/cacheService/cacheService.ts
+++ b/packages/relay/src/lib/services/cacheService/cacheService.ts
@@ -149,6 +149,21 @@ export class CacheService {
   }
 
   /**
+   * If SharedCacheEnabled will use shared, otherwise will fallback to internal cache.
+   * @param {string} key - The cache key.
+   * @param {string} callingMethod - The name of the calling method.
+   * @param {string} [requestIdPrefix] - The optional request ID prefix.
+   * @returns {Promise<any>} A Promise that resolves with the cached value or null if not found.
+   */
+  public getSharedWithFallback(key: string, callingMethod: string, requestIdPrefix?: string): any {
+    if (this.isSharedCacheEnabled) {
+      return this.getAsync(key, callingMethod, requestIdPrefix);
+    } else {
+      return this.get(key, callingMethod, requestIdPrefix);
+    }
+  }
+
+  /**
    * Retrieves a value from the internal cache.
    *
    * @param {string} key - The cache key.

--- a/packages/relay/tests/lib/services/cacheService/cacheService.spec.ts
+++ b/packages/relay/tests/lib/services/cacheService/cacheService.spec.ts
@@ -66,6 +66,16 @@ describe('CacheService Test Suite', async function () {
 
       expect(cachedValue).to.be.null;
     });
+
+    it('should be able to get from internal cache when calling getSharedWithFallback', async function () {
+      const key = 'string';
+      const value = 'value';
+
+      cacheService.set(key, value, callingMethod, undefined, undefined, true);
+      const cachedValue = cacheService.getSharedWithFallback(key, callingMethod);
+
+      expect(cachedValue).eq(value);
+    });
   });
 
   describe('Shared Cache Test Suite', async function () {
@@ -108,6 +118,18 @@ describe('CacheService Test Suite', async function () {
       const cachedValue = await cacheService.getAsync(key, callingMethod, undefined);
 
       expect(cachedValue).to.be.null;
+    });
+
+    it('should be able to get from shared cache with fallback to internal cache', async function () {
+      const key = 'string';
+      const value = 'value';
+
+      cacheService.set(key, value, callingMethod, undefined, undefined, true);
+
+      mock.stub(cacheService, 'getAsync').returns(value);
+      const cachedValue = await cacheService.getSharedWithFallback(key, callingMethod, undefined);
+
+      expect(cachedValue).eq(value);
     });
   });
 });


### PR DESCRIPTION
**Description**:
- Refactored getBlock and eth_getTransactionReceipt to use Shared Cache when working with synthetic receipts for HTS transactions.
- Added Unit Tests where needed.

**Related issue(s)**:

Fixes #1599
Fixes #1627

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
