### PR TITLE
refactor: Updating the configmap setup to take any ENV that is in the .Values.c…

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
@@ -6,4 +6,6 @@ metadata:
     app:  {{ template "json-rpc-relay-ws.name" . }}
     {{ include "json-rpc-relay-ws.labels" . | nindent 4 }}
 data:
-  {{ .Values.config | toYaml | nindent 2 }}
+  {{- range $key, $value := .Values.config }}
+    {{ $key }}: {{ if typeIs "float64" $value }}{{ $value | int64 | quote }}{{ else }}{{ $value | quote }}{{ end }}
+  {{- end }}

--- a/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
@@ -6,23 +6,4 @@ metadata:
     app:  {{ template "json-rpc-relay-ws.name" . }}
     {{ include "json-rpc-relay-ws.labels" . | nindent 4 }}
 data:
-  CHAIN_ID: {{ .Values.config.CHAIN_ID | quote }}
-  DEV_MODE: {{ .Values.config.DEV_MODE | quote }}
-  HEDERA_NETWORK: {{ required "A valid HEDERA_NETWORK must be present in" .Values.config.HEDERA_NETWORK | toJson }}
-  MIRROR_NODE_LIMIT_PARAM: {{ .Values.config.MIRROR_NODE_LIMIT_PARAM | quote }}
-  MIRROR_NODE_RETRIES: {{ .Values.config.MIRROR_NODE_RETRIES | quote }}
-  MIRROR_NODE_RETRY_DELAY: {{ .Values.config.MIRROR_NODE_RETRY_DELAY | quote }}
-  MIRROR_NODE_URL: {{ .Values.config.MIRROR_NODE_URL | quote }}
-  SUBSCRIPTIONS_ENABLED: "true"
-  WEB_SOCKET_HTTP_PORT: {{ .Values.config.WEB_SOCKET_HTTP_PORT | quote }}
-  WEB_SOCKET_PORT: {{ .Values.config.WEB_SOCKET_PORT | quote }}
-  WS_CONNECTION_LIMIT_PER_IP: {{ .Values.config.WS_CONNECTION_LIMIT_PER_IP | quote }}
-  WS_CONNECTION_LIMIT: {{ .Values.config.WS_CONNECTION_LIMIT | quote }}
-  WS_MAX_INACTIVITY_TTL: {{ .Values.config.WS_MAX_INACTIVITY_TTL | quote }}
-  WS_MULTIPLE_ADDRESSES_ENABLED: {{ .Values.config.WS_MULTIPLE_ADDRESSES_ENABLED | quote }}
-  WS_SUBSCRIPTION_LIMIT: {{ .Values.config.WS_SUBSCRIPTION_LIMIT | quote }}
-  WS_PING_INTERVAL: {{ .Values.config.WS_PING_INTERVAL | quote }}
-  REDIS_ENABLED: {{ .Values.config.REDIS_ENABLED | quote }}
-  REDIS_URL: {{ .Values.config.REDIS_URL | quote }}
-  REDIS_RECONNECT_DELAY_MS: {{ .Values.config.REDIS_RECONNECT_DELAY_MS | quote }}
-  MULTI_SET: {{ .Values.config.MULTI_SET | quote }}
+  {{ .Values.config | toYaml | nindent 2 }}

--- a/charts/hedera-json-rpc-relay/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay/templates/configmap.yaml
@@ -6,4 +6,6 @@ metadata:
     app:  {{ template "json-rpc-relay.name" . }}
     {{ include "json-rpc-relay.labels" . | nindent 4 }}
 data:
-  {{ .Values.config | toYaml | nindent 2 }}
+  {{- range $key, $value := .Values.config }}
+    {{ $key }}: {{ if typeIs "float64" $value }}{{ $value | int64 | quote }}{{ else }}{{ $value | quote }}{{ end }}
+  {{- end }}

--- a/charts/hedera-json-rpc-relay/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay/templates/configmap.yaml
@@ -6,36 +6,4 @@ metadata:
     app:  {{ template "json-rpc-relay.name" . }}
     {{ include "json-rpc-relay.labels" . | nindent 4 }}
 data:
-  CHAIN_ID: {{ .Values.config.CHAIN_ID | quote }}
-  CONSENSUS_MAX_EXECUTION_TIME: {{ .Values.config.CONSENSUS_MAX_EXECUTION_TIME | quote }}
-  CONTRACT_QUERY_TIMEOUT_RETRIES: {{ .Values.config.CONTRACT_QUERY_TIMEOUT_RETRIES | quote }}
-  DEFAULT_RATE_LIMIT: {{ .Values.config.DEFAULT_RATE_LIMIT | quote }}
-  DEV_MODE: {{ .Values.config.DEV_MODE | quote }}
-  ETH_CALL_CACHE_TTL: {{ .Values.config.ETH_CALL_CACHE_TTL | quote }}
-  ETH_CALL_DEFAULT_TO_CONSENSUS_NODE: {{ .Values.config.ETH_CALL_DEFAULT_TO_CONSENSUS_NODE | quote }}
-  ETH_GET_LOGS_BLOCK_RANGE_LIMIT: {{ .Values.config.ETH_GET_LOGS_BLOCK_RANGE_LIMIT | quote }}
-  HBAR_RATE_LIMIT_TINYBAR: {{ .Values.config.HBAR_RATE_LIMIT_TINYBAR | quote }}
-  HBAR_RATE_LIMIT_DURATION: {{ .Values.config.HBAR_RATE_LIMIT_DURATION | quote }}
-  HEDERA_NETWORK: {{ required "A valid HEDERA_NETWORK must be present in" .Values.config.HEDERA_NETWORK | toJson }}
-  INPUT_SIZE_LIMIT: {{ .Values.config.INPUT_SIZE_LIMIT | quote }}
-  LIMIT_DURATION: {{ .Values.config.LIMIT_DURATION | quote }}
-  MIRROR_NODE_LIMIT_PARAM: {{ .Values.config.MIRROR_NODE_LIMIT_PARAM | quote }}
-  MIRROR_NODE_RETRIES: {{ .Values.config.MIRROR_NODE_RETRIES | quote }}
-  MIRROR_NODE_RETRY_DELAY: {{ .Values.config.MIRROR_NODE_RETRY_DELAY | quote }}
-  MIRROR_NODE_URL: {{ .Values.config.MIRROR_NODE_URL | quote }}
-  RATE_LIMIT_DISABLED: {{ .Values.config.RATE_LIMIT_DISABLED | quote }}
-  SERVER_PORT: {{ .Values.config.SERVER_PORT | quote }}
-  SUBSCRIPTIONS_ENABLED: {{ .Values.config.SUBSCRIPTIONS_ENABLED | quote }}
-  TIER_1_RATE_LIMIT: {{ .Values.config.TIER_1_RATE_LIMIT | quote }}
-  TIER_2_RATE_LIMIT: {{ .Values.config.TIER_2_RATE_LIMIT | quote }}
-  TIER_3_RATE_LIMIT: {{ .Values.config.TIER_3_RATE_LIMIT | quote }}
-  WEB_SOCKET_PORT: {{ .Values.config.WEB_SOCKET_PORT | quote }}
-  HAPI_CLIENT_TRANSACTION_RESET: {{ .Values.config.HAPI_CLIENT_TRANSACTION_RESET | quote }}
-  HAPI_CLIENT_DURATION_RESET: {{ .Values.config.HAPI_CLIENT_DURATION_RESET | quote }}
-  HAPI_CLIENT_ERROR_RESET: {{ .Values.config.HAPI_CLIENT_ERROR_RESET | quote }}
-  REDIS_ENABLED: {{ .Values.config.REDIS_ENABLED | quote }}
-  REDIS_URL: {{ .Values.config.REDIS_URL | quote }}
-  REDIS_RECONNECT_DELAY_MS: {{ .Values.config.REDIS_RECONNECT_DELAY_MS | quote }}
-  DEBUG_API_ENABLED: {{ .Values.config.DEBUG_API_ENABLED | quote }}
-  FILTER_API_ENABLED: {{ .Values.config.FILTER_API_ENABLED | quote }}
-  MULTI_SET: {{ .Values.config.MULTI_SET | quote }}
+  {{ .Values.config | toYaml | nindent 2 }}


### PR DESCRIPTION
…onfig for the corresponding chart of relay or relay-websockets

**Description**:
Moving the configmap for relay and relay-websockets charts to pull in any value that is being set.  This will allow for expanding the confi variables deployed without needing to update the chart(s) each time to include the corresponding config update.  Now any new variables that are added to `.Values.config` of each chart will be included in the update

**Related issue(s)**:
N/A

**Notes for reviewer**:
this is the contents of the configmap generated using the following deploy command:

```
helm install relay-deploy-test2 charts/hedera-json-rpc-relay --set config.MIRROR_NODE_URL=http://fullstack-deployment-rest --set config.MIRROR_NODE_URL_WEB3=http://fullstack-deployment-web3 --set config.CHAIN_ID=298 --set config.LOG_LEVEL=debug --set config.HEDERA_NETWORK=previewnet --set image.tag=main
```

```
k get configmaps relay-deploy-test2-hedera-json-rpc-relay -o yaml
apiVersion: v1
data:
  CHAIN_ID: "298"
  CLIENT_TRANSPORT_SECURITY: "false"
  CONSENSUS_MAX_EXECUTION_TIME: "15000"
  CONTRACT_QUERY_TIMEOUT_RETRIES: "3"
  DEBUG_API_ENABLED: "false"
  DEFAULT_RATE_LIMIT: "200"
  DEV_MODE: "false"
  ETH_CALL_CACHE_TTL: "200"
  ETH_CALL_DEFAULT_TO_CONSENSUS_NODE: "false"
  ETH_GET_LOGS_BLOCK_RANGE_LIMIT: "1000"
  FILTER_API_ENABLED: "true"
  GAS_PRICE_TINY_BAR_BUFFER: "10000000000"
  HAPI_CLIENT_DURATION_RESET: "3600000"
  HAPI_CLIENT_ERROR_RESET: '[50]'
  HAPI_CLIENT_TRANSACTION_RESET: "50"
  HBAR_RATE_LIMIT_DURATION: "60000"
  HBAR_RATE_LIMIT_TINYBAR: "5000000000"
  HEDERA_NETWORK: previewnet
  INPUT_SIZE_LIMIT: "1"
  LIMIT_DURATION: "60000"
  LOG_LEVEL: debug
  MIRROR_NODE_LIMIT_PARAM: "100"
  MIRROR_NODE_RETRIES: "3"
  MIRROR_NODE_RETRY_DELAY: "250"
  MIRROR_NODE_URL: http://fullstack-deployment-rest
  MIRROR_NODE_URL_WEB3: http://fullstack-deployment-web3
  MULTI_SET: "true"
  OPERATOR_ID_ETH_SENDRAWTRANSACTION: ""
  OPERATOR_ID_MAIN: ""
  OPERATOR_KEY_ETH_SENDRAWTRANSACTION: ""
  OPERATOR_KEY_MAIN: ""
  RATE_LIMIT_DISABLED: "false"
  REDIS_ENABLED: "false"
  REDIS_RECONNECT_DELAY_MS: "1000"
  REDIS_URL: ""
  SDK_REQUEST_TIMEOUT: "10000"
  SERVER_PORT: "7546"
  SUBSCRIPTIONS_ENABLED: "false"
  TIER_1_RATE_LIMIT: "100"
  TIER_2_RATE_LIMIT: "200"
  TIER_3_RATE_LIMIT: "400"
  WEB_SOCKET_PORT: "8546"
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: relay-deploy-test2
    meta.helm.sh/release-namespace: default
  creationTimestamp: "2024-05-11T04:31:48Z"
  labels:
    app: hedera-json-rpc-relay
    app.kubernetes.io/instance: relay-deploy-test2
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: hedera-json-rpc-relay
    app.kubernetes.io/version: 0.48.0-SNAPSHOT
    helm.sh/chart: hedera-json-rpc-relay-0.48.0-SNAPSHOT
  name: relay-deploy-test2-hedera-json-rpc-relay
  namespace: default
  resourceVersion: "419"
  uid: be6cf576-06bf-446b-8fec-3dd73a072898
```
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
