### PR TITLE
Fixed Null exception for transaction receipts

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1820,7 +1820,7 @@ export class EthImpl implements Eth {
         effectiveGasPrice: nanOrNumberTo0x(Number.parseInt(effectiveGas) * 10_000_000_000),
         root: receiptResponse.root,
         status: receiptResponse.status,
-        type: numberTo0x(receiptResponse.type),
+        type: nullableNumberTo0x(receiptResponse.type),
       };
 
       if (receiptResponse.error_message) {

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -5610,6 +5610,24 @@ describe('Eth', async function () {
       expect(receipt.effectiveGasPrice).to.eq('0x0');
     });
 
+    it('Handles null type', async function () {
+      const contractResult = {
+        ...defaultDetailedContractResultByHash,
+        type: null,
+      };
+
+      const uniqueTxHash = '0x07cdd7b820375d10d73af57a6a3e84353645fdb1305ea58ff52daa53ec640533';
+
+      restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, contractResult);
+      restMock.onGet(`contracts/${defaultDetailedContractResultByHash.created_contract_ids[0]}`).reply(404);
+      const receipt = await ethImpl.getTransactionReceipt(uniqueTxHash);
+
+      expect(receipt).to.exist;
+      if (receipt == null) return;
+
+      expect(receipt.type).to.be.null;
+    });
+
     it('handles empty bloom', async function () {
       const receiptWith0xBloom = {
         ...defaultDetailedContractResultByHash,


### PR DESCRIPTION
**Description**:
Applying [HotFix](https://github.com/hashgraph/hedera-json-rpc-relay/pull/1734) onto main.


**Related issue(s)**: 
#1734
#1733 

Fixes #

**Notes for reviewer**:
This is being deployed into production environments with release `0.31.2`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
