### PR TITLE
Fix: eth_estimateGas Errors when providing `gas` field

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -611,7 +611,9 @@ export class EthImpl implements Eth {
     if (transaction.gasPrice) {
       transaction.gasPrice = parseInt(transaction.gasPrice);
     }
-
+    if (transaction.gas) {
+      transaction.gas = parseInt(transaction.gas);
+    }
     // Support either data or input. https://ethereum.github.io/execution-apis/api-documentation/ lists input but many EVM tools still use data.
     if (transaction.input && transaction.data === undefined) {
       transaction.data = transaction.input;

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -3782,11 +3782,13 @@ describe('Eth calls using MirrorNode', async function () {
       data: '0x',
       value: '0xA186B8E9800',
       gasPrice: '0xF4240',
+      gas: '0xd97010',
     };
 
     ethImpl.contractCallFormat(transaction);
     expect(transaction.value).to.eq(1110);
     expect(transaction.gasPrice).to.eq(1000000);
+    expect(transaction.gas).to.eq(14250000);
   });
 
   describe('eth_gasPrice', async function () {


### PR DESCRIPTION
**Description**:
Addresses Issue [1738](https://github.com/hashgraph/hedera-json-rpc-relay/issues/1738) by formatting `gas` field before sending the tx data to the **mirror-node contracts/call** endpoint.

Mirror node is expecting a decimal number, and relay is getting a Hex string of the number.


**Related issue(s)**:

Fixes #1738 

**Notes for reviewer**:

I've verified and there are no other fields that need correct transformation from hex string to decimal number.
(see doc [api of mirror node](https://testnet.mirrornode.hedera.com/api/v1/docs/#/contracts/contractsCall))



<img width="1427" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/6b440ac9-badb-4d70-88fe-f37d34aedf29">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
