### PR TITLE
Stop treating CONTRACT_REVERT as ERROR

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -383,17 +383,22 @@ export class MirrorNodeClient {
 
     if (error.response && acceptedErrorResponses && acceptedErrorResponses.indexOf(effectiveStatusCode) !== -1) {
       this.logger.debug(`${requestIdPrefix} [${method}] ${path} ${effectiveStatusCode} status`);
-      if (pathLabel === MirrorNodeClient.CONTRACT_CALL_ENDPOINT) {
-        this.logger.warn(
-          `${requestIdPrefix} [${method}] ${path} Error details: ( StatusCode: '${effectiveStatusCode}', StatusText: '${
-            error.response.statusText
-          }', Data: '${JSON.stringify(error.response.data)}')`,
-        );
-      }
       return null;
     }
 
-    this.logger.error(new Error(error.message), `${requestIdPrefix} [${method}] ${path} ${effectiveStatusCode} status`);
+    // Contract Call returns 400 for a CONTRACT_REVERT but is a valid response, expected and should not be logged as error:
+    if (pathLabel === MirrorNodeClient.CONTRACT_CALL_ENDPOINT && effectiveStatusCode === 400) {
+      this.logger.debug(
+        `${requestIdPrefix} [${method}] ${path} Contract Revert: ( StatusCode: '${effectiveStatusCode}', StatusText: '${
+          error.response.statusText
+        }', Detail: '${JSON.stringify(error.response.detail)}',Data: '${JSON.stringify(error.response.data)}')`,
+      );
+    } else {
+      this.logger.error(
+        new Error(error.message),
+        `${requestIdPrefix} [${method}] ${path} ${effectiveStatusCode} status`,
+      );
+    }
 
     throw mirrorError;
   }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1499,7 +1499,7 @@ export class EthImpl implements Eth {
 
         if (e.isContractReverted()) {
           this.logger.trace(
-            `${requestIdPrefix} mirror node eth_call request encoutered contract revert. message: ${e.message}, details: ${e.detail}, data: ${e.data}`,
+            `${requestIdPrefix} mirror node eth_call request encountered contract revert. message: ${e.message}, details: ${e.detail}, data: ${e.data}`,
           );
           return predefined.CONTRACT_REVERT(e.detail || e.message, e.data);
         }

--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -49,6 +49,7 @@ const INVALID_PARAMS_ERROR = 'INVALID PARAMS ERROR';
 const INVALID_REQUEST = 'INVALID REQUEST';
 const IP_RATE_LIMIT_EXCEEDED = 'IP RATE LIMIT EXCEEDED';
 const JSON_RPC_ERROR = 'JSON RPC ERROR';
+const CONTRACT_REVERT = 'CONTRACT REVERT';
 const METHOD_NOT_FOUND = 'METHOD NOT FOUND';
 const REQUEST_ID_HEADER_NAME = 'X-Request-Id';
 
@@ -172,8 +173,24 @@ export default class KoaJsonRpc {
 
       ctx.body = jsonResp(body.id, null, result);
       if (result instanceof JsonRpcError) {
-        ctx.status = result.code == -32603 ? 500 : 400;
-        ctx.state.status = `${ctx.status} (${JSON_RPC_ERROR})`;
+        // What Status code to return for JsonRpcError
+        switch (result.code) {
+          // INTERNAL_ERROR
+          case -32603:
+            ctx.status = 500;
+            ctx.state.status = `${ctx.status} (${JSON_RPC_ERROR})`;
+            break;
+          // CONTRACT_REVERT
+          case -32008:
+            ctx.status = 200;
+            ctx.state.status = `${ctx.status} (${CONTRACT_REVERT})`;
+            break;
+          // ANYTHING ELSE
+          default:
+            ctx.status = 400;
+            ctx.state.status = `${ctx.status} (${JSON_RPC_ERROR})`;
+            break;
+        }
       }
     };
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -210,7 +210,10 @@ const logAndHandleResponse = async (methodName: any, methodParams: any, methodFu
 
     const response = await methodFunction(requestIdPrefix);
     if (response instanceof JsonRpcError) {
-      logger.error(`${requestIdPrefix} ${response.message}`);
+      // log only if it is not a contract revert
+      if (!(response.code === predefined.CONTRACT_REVERT().code)) {
+        logger.error(`${requestIdPrefix} ${response.message}`);
+      }
       return new JsonRpcError(
         {
           name: response.name,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -210,10 +210,13 @@ const logAndHandleResponse = async (methodName: any, methodParams: any, methodFu
 
     const response = await methodFunction(requestIdPrefix);
     if (response instanceof JsonRpcError) {
-      // log only if it is not a contract revert
-      if (!(response.code === predefined.CONTRACT_REVERT().code)) {
+      // log error only if it is not a contract revert, otherwise log it as debug
+      if (response.code === predefined.CONTRACT_REVERT().code) {
+        logger.debug(`${requestIdPrefix} ${response.message}`);
+      } else {
         logger.error(`${requestIdPrefix} ${response.message}`);
       }
+
       return new JsonRpcError(
         {
           name: response.name,

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -76,7 +76,13 @@ export default class RelayClient {
       Assertions.expectedError();
     } catch (e: any) {
       if (expectedRpcError.name === 'Contract revert executed') {
-        Assertions.jsonRpcError(e?.info?.error, expectedRpcError);
+        if (e?.info) {
+          Assertions.jsonRpcError(e.info.error, expectedRpcError);
+        } else if (e?.error) {
+          Assertions.jsonRpcError(e.error, expectedRpcError);
+        } else {
+          Assertions.expectedError();
+        }
       } else {
         Assertions.jsonRpcError(e?.response?.bodyJson?.error, expectedRpcError);
       }

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -23,6 +23,7 @@ import { Logger } from 'pino';
 import Assertions from '../helpers/assertions';
 import { predefined } from '../../../relay/src/lib/errors/JsonRpcError';
 import { Utils } from '../helpers/utils';
+import { expectedError } from '../../../relay/tests/helpers';
 
 export default class RelayClient {
   private readonly provider: ethers.JsonRpcProvider;
@@ -74,7 +75,11 @@ export default class RelayClient {
       );
       Assertions.expectedError();
     } catch (e: any) {
-      Assertions.jsonRpcError(e?.response?.bodyJson?.error, expectedRpcError);
+      if (expectedRpcError.name === 'Contract revert executed') {
+        Assertions.jsonRpcError(e?.info?.error, expectedRpcError);
+      } else {
+        Assertions.jsonRpcError(e?.response?.bodyJson?.error, expectedRpcError);
+      }
     }
   }
 


### PR DESCRIPTION
**Description**:
Stopped treating CONTRACT_REVERT as ERROR, MirrorNode returns 400 status, but is a valid and expected response. returning 200 status code on the relay and logging accordingly to avoid false error positives

Return 200 instead of 400 on Relay HTTP Status Code Response

Removed Error Logs from:
1. mirrorNodeClient.ts
2. server.ts

**Related issue(s)**:

Fixes #1616
Fixes #1596
Fixes #1707 


**Notes for reviewer**:

**Example Response:**
<img width="1338" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/8b6999fa-18c3-4b0c-8c0d-11b0ab0c35f7">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
