### PR TITLE
Bump mirror and node container images.

### DIFF
--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -140,9 +140,9 @@ describe('RPC Server Acceptance Tests', function () {
 
   function runLocalHederaNetwork() {
     // set env variables for docker images until local-node is updated
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.41.0-alpha.3';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.41.0-alpha.3';
-    process.env['MIRROR_IMAGE_TAG'] = '0.88.0';
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.42.1';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.42.1';
+    process.env['MIRROR_IMAGE_TAG'] = '0.89.0';
 
     console.log(
       `Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`,


### PR DESCRIPTION
Bumps the container image versions for the mirror and consensus nodes, for release 0.33.0.  Issue # 1773

**Related issue(s)**:

Fixes #
