### PR TITLE
Fix `withdrawalsRoot`

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -1062,7 +1062,7 @@
                     },
                     "withdrawalsRoot": {
                         "title": "Withdrawals root",
-                        "default": "0x0"
+                        "default": "0x0000000000000000000000000000000000000000000000000000000000000000"
                     }
                 }
             },

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -71,7 +71,7 @@ export class Block {
       this.transactionsRoot = args.transactionsRoot;
       this.uncles = [];
       this.withdrawals = [];
-      this.withdrawalsRoot = '0x0';
+      this.withdrawalsRoot = '0x0000000000000000000000000000000000000000000000000000000000000000';
     }
   }
 


### PR DESCRIPTION
**Description**:
This PR fix the `withdrawalsRoot` value setting it to `0x0000000000000000000000000000000000000000000000000000000000000000`.

That parameter is not a `QUANTITY` but a `DATA` of 32 Bytes, so it cannot be `0x0` or some libraries, i.e., [ethers-rs](https://github.com/gakonst/ethers-rs) fail to parse the JSON result of operations related to blocks, like `eth_getBlockByNumber`, `eth_getBlockByHash`, etc.

**Related issue(s)**:

N/A

**Notes for reviewer**:

I discovered the problem while playing with ethers-rs. This is an example of the error, fixed after updating the `withdrawalsRoot` parameter:

```
Error: MiddlewareError { e: MiddlewareError(JsonRpcClientError(SerdeJson { err: Error("invalid length 1, expected a (both 0x-prefixed or not) hex string or byte array containing 32 bytes", line: 1, column: 1266), text: "{\"timestamp\":\"0x651f66ec\",\"difficulty\":\"0x0\",\"extraData\":\"0x\",\"gasLimit\":\"0xe4e1c0\",\"baseFeePerGas\":\"0x19e70448800\",\"gasUsed\":\"0x0\",\"logsBloom\":\"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000\",\"miner\":\"0x0000000000000000000000000000000000000000\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"nonce\":\"0x0000000000000000\",\"receiptsRoot\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"sha3Uncles\":\"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347\",\"size\":\"0x637\",\"stateRoot\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"totalDifficulty\":\"0x0\",\"transactions\":[],\"transactionsRoot\":\"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421\",\"uncles\":[],\"withdrawals\":[],\"withdrawalsRoot\":\"0x0\",\"number\":\"0x2cef22\",\"hash\":\"0x236a96bc5e845a17460c67623336f39608074119acc4b80ea15a0e021ecd36c4\",\"parentHash\":\"0x07a4fa76a187fa28f86a521eb567ea41110290079989c931d0cb675cad38300f\"}" })) }
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
