### PR TITLE
Fix timestamp from hex to decimal when querying the mirror node;

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1845,10 +1845,11 @@ export class EthImpl implements Eth {
 
   private async getCurrentGasPriceForBlock(blockHash: string, requestIdPrefix?: string): Promise<string> {
     const block = await this.getBlockByHash(blockHash, false);
+    const timestampDecimal = parseInt(block ? block.timestamp : '0', 16);
     const gasPriceForTimestamp = await this.getFeeWeibars(
       EthImpl.ethGetTransactionReceipt,
       requestIdPrefix,
-      block?.timestamp,
+      timestampDecimal > 0 ? timestampDecimal.toString() : '',
     );
 
     return numberTo0x(gasPriceForTimestamp);


### PR DESCRIPTION
**Description**:

This PR fixes an error in querying the mirror node with the wrong format for the timestamp parameter.

```sh
[GET] network/fees?timestamp=0x651f99d8 400 status
...
      "type": "Error",
      "message": "Request failed with status code 400",
...
      "type": "MirrorNodeClientError",
      "message": "Invalid parameter: timestamp",
...
```

In particular, the problem is the relay takes the value from the result of the previous `eth_getBlockByHash` operation, but that value is in hex and it should be converted to decimal for the Mirror Node to be able to use it as a parameter.


**Related issue(s)**:

N/A

**Notes for reviewer**:

This is an example of the error I encountered during some tests:

```
[2023-10-06 05:44:21.868 +0000] TRACE (localLRUCache/48904 on mcfly.local): undefined returning cached value eth_getBlockByHash_undefined_false:{"timestamp":"0x651f99d8","difficulty":"0x0","extraData":"0x","gasLimit":"0xe4e1c0","baseFeePerGas":"0x199c82cc000","gasUsed":"0x138800","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","miner":"0x0000000000000000000000000000000000000000","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","receiptsRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x1c17","stateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","totalDifficulty":"0x0","transactions":["0x5524e449184e92b48efcb6a10bbd534e091ac609b21a9f3de90e1ab8e7f77abf"],"transactionsRoot":"0x612e61273c89a84afbcc8743cfbbe354126d073a28adbdea274ea65c8718e889","uncles":[],"withdrawals":[],"withdrawalsRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","number":"0x2d0895","hash":"0x612e61273c89a84afbcc8743cfbbe354126d073a28adbdea274ea65c8718e889","parentHash":"0xeca3cc7c24114a01e75fb195b052ddc807f63a7eab1db59e55fc719f148c4a97"} on eth_GetBlockByHash call
[2023-10-06 05:44:21.982 +0000] ERROR (mirror-node/48904 on mcfly.local): undefined [GET] network/fees?timestamp=0x651f99d8 400 status
    err: {
      "type": "Error",
      "message": "Request failed with status code 400",
      "stack":
          Error: Request failed with status code 400
              at MirrorNodeClient.handleError (/Users/giuseppebertone/workspace/hedera/hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:235:31)
              at MirrorNodeClient.<anonymous> (/Users/giuseppebertone/workspace/hedera/hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:206:22)
              at Generator.throw (<anonymous>)
              at rejected (/Users/giuseppebertone/workspace/hedera/hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:25:65)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    }
[2023-10-06 05:44:21.983 +0000] WARN (relay-eth/48904 on mcfly.local): undefined Mirror Node threw an error retrieving fees. Fallback to network
    err: {
      "type": "MirrorNodeClientError",
      "message": "Invalid parameter: timestamp",
      "stack":
          Error: Invalid parameter: timestamp
              at MirrorNodeClient.handleError (/Users/giuseppebertone/workspace/hedera/hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:224:29)
              at MirrorNodeClient.<anonymous> (/Users/giuseppebertone/workspace/hedera/hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:206:22)
              at Generator.throw (<anonymous>)
              at rejected (/Users/giuseppebertone/workspace/hedera/hedera-json-rpc-relay/packages/relay/dist/lib/clients/mirrorNodeClient.js:25:65)
              at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      "statusCode": 400
    }
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
