### PR TITLE
returning synthetic transaction when fetching it using eth_getTransac…

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1697,17 +1697,19 @@ export class EthImpl implements Eth {
   async getTransactionByHash(hash: string, requestIdPrefix?: string) {
     this.logger.trace(`${requestIdPrefix} getTransactionByHash(hash=${hash})`, hash);
 
-    // check if tx is synthetic and exists in cache
-    const cacheKeySyntheticLog = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${hash}`;
-    const cachedLog = await this.cacheService.getSharedWithFallback(
-      cacheKeySyntheticLog,
-      EthImpl.ethGetTransactionReceipt,
-      requestIdPrefix,
-    );
+    if (this.shouldPopulateSyntheticContractResults) {
+      // check if tx is synthetic and exists in cache
+      const cacheKeySyntheticLog = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${hash}`;
+      const cachedLog = await this.cacheService.getSharedWithFallback(
+        cacheKeySyntheticLog,
+        EthImpl.ethGetTransactionReceipt,
+        requestIdPrefix,
+      );
 
-    if (this.shouldPopulateSyntheticContractResults && cachedLog) {
-      const tx = this.createTransactionFromLog(cachedLog);
-      return tx;
+      if (cachedLog) {
+        const tx = this.createTransactionFromLog(cachedLog);
+        return tx;
+      }
     }
 
     const contractResult = await this.mirrorNodeClient.getContractResultWithRetry(hash, requestIdPrefix);
@@ -1749,7 +1751,7 @@ export class EthImpl implements Eth {
     this.logger.trace(`${requestIdPrefix} getTransactionReceipt(${hash})`);
 
     const cacheKey = `${constants.CACHE_KEY.ETH_GET_TRANSACTION_RECEIPT}_${hash}`;
-    const cachedResponse = false; //this.cacheService.get(cacheKey, EthImpl.ethGetTransactionReceipt, requestIdPrefix);
+    const cachedResponse = this.cacheService.get(cacheKey, EthImpl.ethGetTransactionReceipt, requestIdPrefix);
     if (cachedResponse) {
       this.logger.debug(
         `${requestIdPrefix} getTransactionReceipt returned cached response: ${JSON.stringify(cachedResponse)}`,

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -6006,5 +6006,37 @@ describe('Eth', async function () {
       );
       process.env.DEV_MODE = initialDevModeValue;
     });
+
+    it('returns synthetic transaction when it matchs cache', async function () {
+      // set cache with synthetic log
+      const cacheKeySyntheticLog1 = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${defaultDetailedContractResultByHash.hash}`;
+      const cachedLog = new Log({
+        address: defaultLogs1[0].address,
+        blockHash: toHash32(defaultLogs1[0].block_hash),
+        blockNumber: numberTo0x(defaultLogs1[0].block_number),
+        data: defaultLogs1[0].data,
+        logIndex: numberTo0x(defaultLogs1[0].index),
+        removed: false,
+        topics: defaultLogs1[0].topics,
+        transactionHash: toHash32(defaultLogs1[0].transaction_hash),
+        transactionIndex: nullableNumberTo0x(defaultLogs1[0].transaction_index),
+      });
+
+      cacheService.set(cacheKeySyntheticLog1, cachedLog, EthImpl.ethGetTransactionReceipt);
+
+      // w no mirror node requests
+      const transaction = await ethImpl.getTransactionByHash(defaultTxHash);
+
+      // Assert the matching tx
+      expect(transaction.blockHash).to.eq(cachedLog.blockHash);
+      expect(transaction.blockNumber).to.eq(cachedLog.blockNumber);
+      expect(transaction.from).to.eq(cachedLog.address);
+      expect(transaction.gas).to.eq(EthImpl.defaultTxGas);
+      expect(transaction.gasPrice).to.eq(EthImpl.invalidEVMInstruction);
+      expect(transaction.value).to.eq(EthImpl.oneTwoThreeFourHex);
+      expect(transaction.to).to.eq(cachedLog.address);
+      expect(transaction.hash).to.eq(cachedLog.transactionHash);
+      expect(transaction.transactionIndex).to.eq(cachedLog.transactionIndex);
+    });
   });
 });

--- a/packages/relay/tests/lib/eth.spec.ts
+++ b/packages/relay/tests/lib/eth.spec.ts
@@ -6007,9 +6007,9 @@ describe('Eth', async function () {
       process.env.DEV_MODE = initialDevModeValue;
     });
 
-    it('returns synthetic transaction when it matchs cache', async function () {
-      // set cache with synthetic log
-      const cacheKeySyntheticLog1 = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${defaultDetailedContractResultByHash.hash}`;
+    it('returns synthetic transaction when it matches cache', async function () {
+      // prepare cache with synthetic log
+      const cacheKeySyntheticLog = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${defaultDetailedContractResultByHash.hash}`;
       const cachedLog = new Log({
         address: defaultLogs1[0].address,
         blockHash: toHash32(defaultLogs1[0].block_hash),
@@ -6022,12 +6022,11 @@ describe('Eth', async function () {
         transactionIndex: nullableNumberTo0x(defaultLogs1[0].transaction_index),
       });
 
-      cacheService.set(cacheKeySyntheticLog1, cachedLog, EthImpl.ethGetTransactionReceipt);
+      cacheService.set(cacheKeySyntheticLog, cachedLog, EthImpl.ethGetTransactionReceipt);
 
-      // w no mirror node requests
       const transaction = await ethImpl.getTransactionByHash(defaultTxHash);
 
-      // Assert the matching tx
+      // Assert the respnse tx
       expect(transaction.blockHash).to.eq(cachedLog.blockHash);
       expect(transaction.blockNumber).to.eq(cachedLog.blockNumber);
       expect(transaction.from).to.eq(cachedLog.address);


### PR DESCRIPTION
**Description**:
It was reported by a member of the community that after fetching a block that contained synthetic transactions, it was posisble to fetch the transaction details using `eth_getTransactionReceipt` but not `eth_getTransactionByHash`.
So we are also including `synthetic transactions` on `eth_getTransactionByHash` to keep consistency between methods.

**Related issue(s)**:

Fixes #1794 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
