### PR TITLE
Improve info in case of tracing activities

### DIFF
--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -119,6 +119,8 @@ export default class KoaJsonRpc {
         return;
       }
 
+      this.logger.trace(`[Request ID: ${this.getRequestId()}] Request body ${JSON.stringify(body)}`);
+
       ctx.state.methodName = body.method;
       const methodName = body.method;
 
@@ -192,6 +194,7 @@ export default class KoaJsonRpc {
             break;
         }
       }
+      this.logger.trace(`[Request ID: ${this.getRequestId()}] Response body ${JSON.stringify(ctx.body)}`);
     };
   }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -30,7 +30,7 @@ import { formatRequestIdMessage } from './formatters';
 
 const mainLogger = pino({
   name: 'hedera-json-rpc-relay',
-  level: process.env.LOG_LEVEL || 'trace',
+  level: process.env.LOG_LEVEL || 'info',
   transport: {
     target: 'pino-pretty',
     options: {
@@ -81,6 +81,12 @@ app.getKoaApp().use(async (ctx, next) => {
       `${formatRequestIdMessage(ctx.state.reqId)} [${ctx.method}]: ${ctx.state.methodName} ${
         ctx.state.status
       } ${ms} ms`,
+    );
+    // log the response
+    logger.trace(
+      `${formatRequestIdMessage(ctx.state.reqId)} [${ctx.method}]: ${ctx.state.methodName} ${
+        ctx.state.status
+      } ${JSON.stringify(ctx.body)}`,
     );
     methodResponseHistogram.labels(ctx.state.methodName, `${ctx.status}`).observe(ms);
   }

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -37,7 +37,7 @@ import constants from '@hashgraph/json-rpc-relay/dist/lib/constants';
 
 const mainLogger = pino({
   name: 'hedera-json-rpc-relay',
-  level: process.env.LOG_LEVEL || 'trace',
+  level: process.env.LOG_LEVEL || 'info',
   transport: {
     target: 'pino-pretty',
     options: {


### PR DESCRIPTION
**Description**:
While conducting debug activities you often enable trace log level, and you want to check the actual requests and response between client and server (i.e., #1802).

This PR:
- adds info about request and response bodies when trace log level is enabled.
- reduces the default log level to `info` instead of `trace`

**Related issue(s)**:

N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
