### PR TITLE
Foundry Forge Create Contract Fix

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -1228,7 +1228,8 @@
                         "required": [
                             "yParity",
                             "r",
-                            "s"
+                            "s",
+                            "v"
                         ],
                         "properties": {
                             "yParity": {
@@ -1251,6 +1252,19 @@
                             "s": {
                                 "title": "s",
                                 "$ref": "#/components/schemas/uint"
+                            },
+                            "v": {
+                                "title": "v",
+                                "description": "For backwards compatibility",
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/byte"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/null"
+                                    }
+                                ]
+
                             }
                         }
                     }
@@ -1307,7 +1321,7 @@
                 ]
             },
             "TransactionSigned": {
-                "oneOf": [
+                "anyOf": [
                     {
                         "$ref": "#/components/schemas/Transaction1559Signed"
                     },

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -1255,7 +1255,7 @@
                             },
                             "v": {
                                 "title": "v",
-                                "description": "For backwards compatibility",
+                                "description": "For backwards compatibility, `v` is optionally provided as an alternative to `yParity`. This field is DEPRECATED and all use of it should migrate to `yParity`.",
                                 "oneOf": [
                                     {
                                         "$ref": "#/components/schemas/byte"

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -164,7 +164,6 @@ export class Transaction2930 extends Transaction {
   public readonly yParity!: string | null;
 
   constructor(args: any) {
-    //const { v, ...parentArgs } = args;
     super(args);
     this.yParity = args.v;
     this.accessList = args.accessList;

--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -45,7 +45,7 @@ export class Block {
   public readonly transactionsRoot: string = '0x0';
   public readonly uncles: string[] = [];
   public readonly withdrawals: string[] = [];
-  public readonly withdrawalsRoot: string = '0x0';
+  public readonly withdrawalsRoot: string = '0x0000000000000000000000000000000000000000000000000000000000000000';
 
   constructor(args?: any) {
     if (args) {
@@ -164,9 +164,9 @@ export class Transaction2930 extends Transaction {
   public readonly yParity!: string | null;
 
   constructor(args: any) {
-    const { v, ...parentArgs } = args;
-    super(parentArgs);
-    this.yParity = v;
+    //const { v, ...parentArgs } = args;
+    super(args);
+    this.yParity = args.v;
     this.accessList = args.accessList;
   }
 }

--- a/packages/relay/tests/assertions.ts
+++ b/packages/relay/tests/assertions.ts
@@ -134,5 +134,6 @@ export default class RelayAssertions {
     expect(block.stateRoot).equal(EthImpl.zeroHex32Byte);
     expect(block.totalDifficulty).equal(EthImpl.zeroHex);
     expect(block.uncles).to.deep.equal([]);
+    expect(block.withdrawalsRoot).to.equal(EthImpl.zeroHex32Byte);
   };
 }

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -212,7 +212,7 @@ describe('Formatters', () => {
       expect(formattedResult.transactionIndex).to.equal('0x9');
       expect(formattedResult.type).to.equal('0x2');
       expect(formattedResult.yParity).to.equal('0x1');
-      expect(formattedResult.v).to.equal(undefined);
+      expect(formattedResult.v).to.equal(`0x1`);
       expect(formattedResult.value).to.equal('0x0');
     });
 
@@ -246,7 +246,7 @@ describe('Formatters', () => {
       expect(formattedResult.s).to.equal(null);
       expect(formattedResult.to).to.equal('0x0000000000000000000000000000000000000409');
       expect(formattedResult.transactionIndex).to.equal(null);
-      expect(formattedResult.v).to.equal(undefined);
+      expect(formattedResult.v).to.equal(`0x0`);
       expect(formattedResult.yParity).to.equal('0x0');
       expect(formattedResult.value).to.equal('0x0');
     });


### PR DESCRIPTION
**Description**:
For compatibility with foundry forge command, we are modifying the block response to have withdrawalsRoot as a long 32Bytes hex 0 and signed transactions to have both yparity and v values.

Changes to the unit tests that were affected

**Related issue(s)**: #1797 

Fixes #1824 
Fixes #1800 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**After the Fix:**
<img width="1145" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/096bba70-62db-460c-99bf-c6933f6c1e9b">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
