### PR TITLE
Acceptance Tests: Upgrading Network node to version '0.42.6' and mirror-node to '0.90.0'

### DIFF
--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -140,8 +140,8 @@ describe('RPC Server Acceptance Tests', function () {
 
   function runLocalHederaNetwork() {
     // set env variables for docker images until local-node is updated
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.43.0';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.43.0';
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.42.6';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.42.6';
     process.env['MIRROR_IMAGE_TAG'] = '0.90.0';
 
     console.log(

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -140,9 +140,9 @@ describe('RPC Server Acceptance Tests', function () {
 
   function runLocalHederaNetwork() {
     // set env variables for docker images until local-node is updated
-    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.42.1';
-    process.env['HAVEGED_IMAGE_TAG'] = '0.42.1';
-    process.env['MIRROR_IMAGE_TAG'] = '0.89.0';
+    process.env['NETWORK_NODE_IMAGE_TAG'] = '0.43.0';
+    process.env['HAVEGED_IMAGE_TAG'] = '0.43.0';
+    process.env['MIRROR_IMAGE_TAG'] = '0.90.0';
 
     console.log(
       `Docker container versions, services: ${process.env['NETWORK_NODE_IMAGE_TAG']}, mirror: ${process.env['MIRROR_IMAGE_TAG']}`,


### PR DESCRIPTION
**Description**:
Upgrading Network node to version '0.42.6' and mirror-node to '0.90.0'


**Related issue(s)**: #1839 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
