### PR TITLE
Fix Poller in docker build

### DIFF
--- a/packages/relay/src/lib/poller.ts
+++ b/packages/relay/src/lib/poller.ts
@@ -103,8 +103,10 @@ export class Poller {
 
   stop() {
     this.logger.info(`${LOGGER_PREFIX} Stopping polling`);
-    clearInterval(this.interval);
-    delete this.interval;
+    if (this.isPolling()) {
+      clearInterval(this.interval as NodeJS.Timeout);
+      delete this.interval;
+    }
   }
 
   async add(tag: string, callback: Function) {


### PR DESCRIPTION
**Description**:
This PR fixes the issue with the dockerbuild by casting the interval in the pooler as a Timeout.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
