### PR TITLE
Set type of Poller.ts interval to any to get a docker image built.

### DIFF
--- a/packages/relay/src/lib/poller.ts
+++ b/packages/relay/src/lib/poller.ts
@@ -34,7 +34,7 @@ export class Poller {
   private eth: Eth;
   private logger: Logger;
   private polls: Poll[];
-  private interval?: any;
+  private interval?: NodeJS.Timer;
   private latestBlock?: string;
   private pollingInterval: number;
   private activePollsGauge: Gauge;
@@ -103,7 +103,7 @@ export class Poller {
 
   stop() {
     this.logger.info(`${LOGGER_PREFIX} Stopping polling`);
-    clearInterval(this.interval);
+    clearInterval(this.interval as NodeJS.Timeout);
     delete this.interval;
   }
 

--- a/packages/relay/src/lib/poller.ts
+++ b/packages/relay/src/lib/poller.ts
@@ -34,7 +34,7 @@ export class Poller {
   private eth: Eth;
   private logger: Logger;
   private polls: Poll[];
-  private interval?: NodeJS.Timer;
+  private interval?: any;
   private latestBlock?: string;
   private pollingInterval: number;
   private activePollsGauge: Gauge;


### PR DESCRIPTION
Potential build fix.  Issue: #1865   Docker image build started failing due to a NodeJS.Timer vs NodeJS.Timeout class type issue.  This PR addresses that.

**Related issue(s)**:

Fixes #


