### PR TITLE
upgrading chart-testing-action to 2.6.1

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install ct
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Run lint
         run: ct lint --config .github/ct.yaml --all

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -57,7 +57,7 @@ jobs:
           tags: localhost:5001/${{ github.repository }}:test
 
       - name: Install ct
-        uses: helm/chart-testing-action@v2.4.0
+        uses: helm/chart-testing-action@v2.6.1
 
       - name: Install chart
         run: ct install --helm-extra-args="--timeout 10m" --all


### PR DESCRIPTION
**Description**:
upgrading chart-testing-action to 2.6.1 due to an issue on CI tests for charts, due to a cosign update that is making it impossible to verify. 

**Related issue(s)**:

Fixes #
<img width="1150" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/24cadeec-9f95-40be-8f25-cc435151dcfa">

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
