### PR TITLE
Add Rate Limits to batch request itself

### DIFF
--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -219,7 +219,7 @@ export default class KoaJsonRpc {
     }
 
     // verify rate limit for batch request
-    const batchRequestTotalLimit = this.registryTotal[BATCH_REQUEST_METHOD_NAME];
+    const batchRequestTotalLimit = this.methodConfig[BATCH_REQUEST_METHOD_NAME].total;
     // check rate limit for method and ip
     if (this.rateLimit.shouldRateLimit(ctx.ip, BATCH_REQUEST_METHOD_NAME, batchRequestTotalLimit, this.requestId)) {
       return jsonResp(null, new IPRateLimitExceeded(BATCH_REQUEST_METHOD_NAME), undefined);

--- a/packages/server/src/koaJsonRpc/lib/methodConfiguration.ts
+++ b/packages/server/src/koaJsonRpc/lib/methodConfiguration.ts
@@ -174,4 +174,7 @@ export const methodConfiguration = {
   debug_traceTransaction: {
     total: tier1rateLimit,
   },
+  batch_request: {
+    total: tier1rateLimit,
+  },
 };


### PR DESCRIPTION
**Description**:
Add Rate Limits to batch request itself

**Related issue(s)**:

Fixes #1880 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
