### PR TITLE
Created a separate new metric for tracking the method results, simila…

### DIFF
--- a/packages/server/src/koaJsonRpc/lib/HttpStatusCodeAndMessage.ts
+++ b/packages/server/src/koaJsonRpc/lib/HttpStatusCodeAndMessage.ts
@@ -1,0 +1,27 @@
+export class HttpStatusCodeAndMessage {
+  public statusCode: number;
+  public StatusName: string;
+
+  constructor(statusCode: number, statusName: string) {
+    this.statusCode = statusCode;
+    this.StatusName = statusName;
+  }
+}
+
+const INTERNAL_ERROR = 'INTERNAL ERROR';
+const INVALID_PARAMS_ERROR = 'INVALID PARAMS ERROR';
+const INVALID_REQUEST = 'INVALID REQUEST';
+const IP_RATE_LIMIT_EXCEEDED = 'IP RATE LIMIT EXCEEDED';
+const JSON_RPC_ERROR = 'JSON RPC ERROR';
+const CONTRACT_REVERT = 'CONTRACT REVERT';
+const METHOD_NOT_FOUND = 'METHOD NOT FOUND';
+
+export const RpcErrorCodeToStatusMap = {
+  '-32603': new HttpStatusCodeAndMessage(500, INTERNAL_ERROR),
+  '-32008': new HttpStatusCodeAndMessage(200, CONTRACT_REVERT),
+  '-32600': new HttpStatusCodeAndMessage(400, INVALID_REQUEST),
+  '-32602': new HttpStatusCodeAndMessage(400, INVALID_PARAMS_ERROR),
+  '-32601': new HttpStatusCodeAndMessage(400, METHOD_NOT_FOUND),
+  '-32605': new HttpStatusCodeAndMessage(409, IP_RATE_LIMIT_EXCEEDED),
+  default: new HttpStatusCodeAndMessage(400, JSON_RPC_ERROR),
+};


### PR DESCRIPTION
**Description**:
Adding Metrics to methods executed as part of a batch request.

**Related issue(s)**:

Fixes #1881 

**Notes for reviewer**:


**Existing Metric stays the same, but you can see is capturing `batch_requests` on the `method` label**
```
# TYPE rpc_relay_method_response histogram
rpc_relay_method_response_bucket{le="5",method="batch_requests",statusCode="200"} 0
rpc_relay_method_response_bucket{le="10",method="batch_requests",statusCode="200"} 0
rpc_relay_method_response_bucket{le="25",method="batch_requests",statusCode="200"} 0
rpc_relay_method_response_bucket{le="50",method="batch_requests",statusCode="200"} 0
rpc_relay_method_response_bucket{le="100",method="batch_requests",statusCode="200"} 0
rpc_relay_method_response_bucket{le="250",method="batch_requests",statusCode="200"} 0
rpc_relay_method_response_bucket{le="500",method="batch_requests",statusCode="200"} 0
rpc_relay_method_response_bucket{le="1000",method="batch_requests",statusCode="200"} 0
rpc_relay_method_response_bucket{le="2500",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_bucket{le="5000",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_bucket{le="10000",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_bucket{le="20000",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_bucket{le="30000",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_bucket{le="40000",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_bucket{le="50000",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_bucket{le="60000",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_bucket{le="+Inf",method="batch_requests",statusCode="200"} 1
rpc_relay_method_response_sum{method="batch_requests",statusCode="200"} 1625
rpc_relay_method_response_count{method="batch_requests",statusCode="200"} 1
```

**New Metric **
```
# TYPE rpc_relay_method_result histogram
rpc_relay_method_result_bucket{le="5",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="10",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="25",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="100",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="250",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="500",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="1000",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="2500",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5000",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="10000",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="20000",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="30000",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="40000",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50000",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="60000",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="+Inf",method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_sum{method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 5
rpc_relay_method_result_count{method="non_existent_method",statusCode="-32601",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="10",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="25",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="100",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="250",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="500",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="1000",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="2500",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5000",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="10000",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="20000",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="30000",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="40000",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50000",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="60000",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="+Inf",method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_sum{method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 5
rpc_relay_method_result_count{method="eth_chainId",statusCode="-32600",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="10",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="25",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="100",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="250",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="500",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="1000",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="2500",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5000",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="10000",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="20000",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="30000",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="40000",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50000",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="60000",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="+Inf",method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_sum{method="eth_chainId",statusCode="200",isPartOfBatch="true"} 21
rpc_relay_method_result_count{method="eth_chainId",statusCode="200",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="10",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="25",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="100",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="250",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="500",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="1000",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="2500",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5000",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="10000",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="20000",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="30000",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="40000",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50000",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="60000",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="+Inf",method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_sum{method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 19
rpc_relay_method_result_count{method="eth_getBlockByNumber",statusCode="-32602",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="10",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="25",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="100",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="250",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="500",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="1000",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="2500",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5000",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="10000",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="20000",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="30000",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="40000",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50000",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="60000",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="+Inf",method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_sum{method="eth_call",statusCode="-32005",isPartOfBatch="true"} 20
rpc_relay_method_result_count{method="eth_call",statusCode="-32005",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="10",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="25",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="50",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="100",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="250",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="500",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="1000",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 0
rpc_relay_method_result_bucket{le="2500",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="5000",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="10000",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="20000",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="30000",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="40000",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="50000",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="60000",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_bucket{le="+Inf",method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
rpc_relay_method_result_sum{method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1595
rpc_relay_method_result_count{method="debug_traceTransaction",statusCode="-32603",isPartOfBatch="true"} 1
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
