### PR TITLE
Upgrade @hashgraph/sdk from 2.32.0 to 2.37.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19633,7 +19633,7 @@
       "version": "0.36.0-SNAPSHOT",
       "dependencies": {
         "@ethersproject/asm": "^5.7.0",
-        "@hashgraph/sdk": "2.32.0",
+        "@hashgraph/sdk": "2.37.0",
         "@keyvhq/core": "^1.6.9",
         "axios": "^1.4.0",
         "axios-retry": "^3.5.1",
@@ -19985,7 +19985,7 @@
         "axios-retry": "^3.5.1",
         "chai": "^4.3.6",
         "ethers": "^6.7.0",
-        "execution-apis": "git+ssh://git@github.com/ethereum/execution-apis.git#584905270d8ad665718058060267061ecfd79ca5",
+        "execution-apis": "git://github.com/ethereum/execution-apis.git#584905270d8ad665718058060267061ecfd79ca5",
         "shelljs": "^0.8.5",
         "ts-mocha": "^9.0.2",
         "ts-node": "^10.8.1",
@@ -22124,7 +22124,7 @@
       "version": "file:packages/relay",
       "requires": {
         "@ethersproject/asm": "^5.7.0",
-        "@hashgraph/sdk": "2.32.0",
+        "@hashgraph/sdk": "2.37.0",
         "@keyvhq/core": "^1.6.9",
         "@types/chai": "^4.3.0",
         "@types/mocha": "^9.1.0",
@@ -22179,8 +22179,7 @@
           }
         },
         "@hashgraph/sdk": {
-          "version": "2.32.0",
-          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.32.0.tgz",
+          "version": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.32.0.tgz",
           "integrity": "sha512-KravYeq9/OWhVyTkLLpR+P3XleK6qEnkDKfQxA+8SuHSfkwWN1qTK7Nv6JBxk83gDeONFtaiMi950x3AVs+q8w==",
           "requires": {
             "@ethersproject/abi": "^5.7.0",
@@ -22383,7 +22382,7 @@
         "co-body": "6.1.0",
         "dotenv": "^16.0.0",
         "ethers": "^6.7.0",
-        "execution-apis": "git+ssh://git@github.com/ethereum/execution-apis.git#584905270d8ad665718058060267061ecfd79ca5",
+        "execution-apis": "git://github.com/ethereum/execution-apis.git#584905270d8ad665718058060267061ecfd79ca5",
         "koa": "^2.13.4",
         "koa-body-parser": "^0.2.1",
         "koa-cors": "^0.0.16",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ethersproject/asm": "^5.7.0",
-    "@hashgraph/sdk": "2.32.0",
+    "@hashgraph/sdk": "2.37.0",
     "@keyvhq/core": "^1.6.9",
     "axios": "^1.4.0",
     "axios-retry": "^3.5.1",


### PR DESCRIPTION
Bumped up to hashgraph sdk version 2.37.0 to avoid linux library issues.