### PR TITLE
fix: formatting on standalone networks

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   CHAIN_ID: {{ .Values.config.CHAIN_ID | quote }}
   DEV_MODE: {{ .Values.config.DEV_MODE | quote }}
-  HEDERA_NETWORK: {{ required "A valid HEDERA_NETWORK must be present in" .Values.config.HEDERA_NETWORK | toJson | quote }}
+  HEDERA_NETWORK: {{ required "A valid HEDERA_NETWORK must be present in" .Values.config.HEDERA_NETWORK | toJson }}
   MIRROR_NODE_LIMIT_PARAM: {{ .Values.config.MIRROR_NODE_LIMIT_PARAM | quote }}
   MIRROR_NODE_RETRIES: {{ .Values.config.MIRROR_NODE_RETRIES | quote }}
   MIRROR_NODE_RETRY_DELAY: {{ .Values.config.MIRROR_NODE_RETRY_DELAY | quote }}

--- a/charts/hedera-json-rpc-relay/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
   ETH_GET_LOGS_BLOCK_RANGE_LIMIT: {{ .Values.config.ETH_GET_LOGS_BLOCK_RANGE_LIMIT | quote }}
   HBAR_RATE_LIMIT_TINYBAR: {{ .Values.config.HBAR_RATE_LIMIT_TINYBAR | quote }}
   HBAR_RATE_LIMIT_DURATION: {{ .Values.config.HBAR_RATE_LIMIT_DURATION | quote }}
-  HEDERA_NETWORK: {{ required "A valid HEDERA_NETWORK must be present in" .Values.config.HEDERA_NETWORK | toJson | quote }}
+  HEDERA_NETWORK: {{ required "A valid HEDERA_NETWORK must be present in" .Values.config.HEDERA_NETWORK | toJson }}
   INPUT_SIZE_LIMIT: {{ .Values.config.INPUT_SIZE_LIMIT | quote }}
   LIMIT_DURATION: {{ .Values.config.LIMIT_DURATION | quote }}
   MIRROR_NODE_LIMIT_PARAM: {{ .Values.config.MIRROR_NODE_LIMIT_PARAM | quote }}


### PR DESCRIPTION
**Description**:
Both the relay and websockets support using a standalone (Hedera) network to run test relays with.
Between helm and the SDK the formatting would get updated before being passed into the relay code, this is when the issue would arise.
```

> start
> npx lerna exec --scope @hashgraph/json-rpc-server -- npm run start

lerna notice cli v7.3.0
lerna info versioning independent
lerna notice filter including "@hashgraph/json-rpc-server"
lerna info filter [ '@hashgraph/json-rpc-server' ]
lerna info Executing command in 1 package: "npm run start"

> @hashgraph/json-rpc-server@0.35.2 start
> node dist/index.js

[2023-11-13 23:11:19.995 +0000] INFO (relay/64 on test-hashio-7b585746d6-kchmx): Configurations successfully loaded
/home/node/app/node_modules/@hashgraph/sdk/lib/client/NodeClient.cjs:279
        throw new Error(
        ^

Error: unknown network: {"1.1.1.1:50211":"0.0.3","2.2.2.2:50211":"0.0.4","3.3.3.3:50211":"0.0.5","4.4.4.4:50211":"0.0.6","5.5.5.5:50211":"0.0.7"}
    at NodeClient._setNetworkFromName (/home/node/app/node_modules/@hashgraph/sdk/lib/client/NodeClient.cjs:279:15)
    at new NodeClient (/home/node/app/node_modules/@hashgraph/sdk/lib/client/NodeClient.cjs:94:14)
    at NodeClient.forNetwork (/home/node/app/node_modules/@hashgraph/sdk/lib/client/NodeClient.cjs:151:12)
    at HAPIService.initClient (/home/node/app/packages/relay/dist/lib/services/hapiService/hapiService.js:144:35)
    at new HAPIService (/home/node/app/packages/relay/dist/lib/services/hapiService/hapiService.js:41:32)
    at new RelayImpl (/home/node/app/packages/relay/dist/lib/relay.js:60:29)
    at Object.<anonymous> (/home/node/app/packages/server/dist/server.js:57:15)
    at Module._compile (node:internal/modules/cjs/loader:1256:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
```

The network looks okay here in the error but that is not what is being sent by helm.  Helm is rendering 
```HEDERA_NETWORK: "{\"3.3.3.3:50211\":\"0.0.5\",\"1.1.1.1:50211\":\"0.0.3\",\"5.5.5.5:50211\":\"0.0.7\",\"4.4.4.4:50211\":\"0.0.6\",\"2.2.2.2:50211\":\"0.0.4\"}"
```
using `helm template hashio-test hedera-json-rpc-relay/hedera-json-rpc-relay -f test-hashio-values.yaml --version 0.26.0 --debug -s templates/configmap.yaml`

However, the SDK appears to also make some format edits before loading 
```
[2023-11-14 16:28:34.820 +0000] INFO (relay/65 on test-hashio-5dcdd49854-5zgms): SDK client successfully configured to "{\"1.1.1.1:50211\":\"0.0.3\",\"2.2.2.2:50211\":\"0.0.4\",\"3.3.3.3:50211\":\"0.0.5\",\"4.4.4.4:50211\":\"0.0.6\",\"5.5.5.5:50211\":\"0.0.7\"}" for account x.x.xxxxx with request timeout value: 10000
```

To get this setup to work correctly the formatting function `quote` was removed to allow the SDK read in the value correctly and start running.


