### PR TITLE
Acceptance Test Token Create Fix: providing gas options to avoid issues

### DIFF
--- a/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
@@ -505,6 +505,9 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
       )[0].args;
       NftSerialNumber = Number(serialNumbers[0]);
 
+      // delay
+      await new Promise((r) => setTimeout(r, 5000));
+
       const balanceBeforeAccount0 = await NFTokenContract.balanceOf(accounts[0].wallet.address);
       const balanceBeforeAccount1 = await NFTokenContract.balanceOf(accounts[1].wallet.address);
 
@@ -589,6 +592,9 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
         (await txXfer.wait()).logs.filter((e) => e.fragment.name === Constants.HTS_CONTRACT_EVENTS.ResponseCode)[0].args
           .responseCode,
       ).to.equal(TX_SUCCESS_CODE);
+
+      // delay
+      await new Promise((r) => setTimeout(r, 5000));
 
       expect(await NFTokenContract.balanceOf(mainContract.target)).to.equal(BigInt(1));
       expect(await NFTokenContract.balanceOf(accounts[1].wallet.address)).to.equal(BigInt(0));

--- a/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
@@ -131,7 +131,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
 
   async function deploymainContract(signer) {
     const mainFactory = new ethers.ContractFactory(TokenCreateJson.abi, TokenCreateJson.bytecode, signer);
-    const mainContract = await mainFactory.deploy(Constants.GAS.LIMIT_10_000_000);
+    const mainContract = await mainFactory.deploy(await Utils.gasOptions(requestId, 15_000_000));
     await mainContract.waitForDeployment();
 
     return mainContract.target;

--- a/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
@@ -123,6 +123,9 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
     mainContractOwner = mainContract;
     mainContractReceiverWalletFirst = mainContract.connect(accounts[1].wallet);
     mainContractReceiverWalletSecond = mainContract.connect(accounts[2].wallet);
+
+    // wait for mirror node to catch up before running tests
+    await new Promise((r) => setTimeout(r, 5000));
   });
 
   this.beforeEach(async () => {
@@ -296,7 +299,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
 
   it('should check initial balances', async function () {
     // add delay for balance to update
-    await new Promise((r) => setTimeout(r, 5000));
+    await new Promise((r) => setTimeout(r, 10000));
     expect(await HTSTokenContract.balanceOf(accounts[0].wallet.address)).to.equal(BigInt(1000));
     expect(await HTSTokenContract.balanceOf(accounts[1].wallet.address)).to.equal(BigInt(0));
     expect(await HTSTokenContract.balanceOf(accounts[2].wallet.address)).to.equal(BigInt(0));

--- a/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
@@ -295,6 +295,8 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
   });
 
   it('should check initial balances', async function () {
+    // add delay for balance to update
+    await new Promise((r) => setTimeout(r, 5000));
     expect(await HTSTokenContract.balanceOf(accounts[0].wallet.address)).to.equal(BigInt(1000));
     expect(await HTSTokenContract.balanceOf(accounts[1].wallet.address)).to.equal(BigInt(0));
     expect(await HTSTokenContract.balanceOf(accounts[2].wallet.address)).to.equal(BigInt(0));
@@ -368,7 +370,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
         amount,
         Constants.GAS.LIMIT_1_000_000,
       );
-      await new Promise((r) => setTimeout(r, 5000));
+      await new Promise((r) => setTimeout(r, 10000));
       expect(await HTSTokenContract.balanceOf(mainContract.target)).to.equal(amount);
       expect(await HTSTokenContract.balanceOf(accounts[2].wallet.address)).to.be.equal(BigInt(0));
 
@@ -403,7 +405,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
         amount,
         Constants.GAS.LIMIT_1_000_000,
       );
-      await new Promise((r) => setTimeout(r, 2000));
+      await new Promise((r) => setTimeout(r, 10000));
       expect(await HTSTokenContract.balanceOf(accounts[1].wallet.address)).to.be.equal(amount);
 
       {
@@ -487,6 +489,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
     });
 
     it('should be able to transfer nft with transferFrom', async function () {
+      await new Promise((r) => setTimeout(r, 10000));
       expect(await NFTokenContract.balanceOf(accounts[0].wallet.address)).to.equal(BigInt(1));
       expect(await NFTokenContract.balanceOf(accounts[1].wallet.address)).to.equal(BigInt(0));
 
@@ -556,7 +559,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
         NftSerialNumber,
         Constants.GAS.LIMIT_1_000_000,
       );
-      await new Promise((r) => setTimeout(r, 5000));
+      await new Promise((r) => setTimeout(r, 10000));
       expect((await NFTokenContract.getApproved(NftSerialNumber)).toLowerCase()).to.be.oneOf([
         accounts[2].wallet.address.toLowerCase(),
         Utils.idToEvmAddress(accounts[2].accountId.toString()).toLowerCase(),
@@ -569,7 +572,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
         NftSerialNumber,
         Constants.GAS.LIMIT_1_000_000,
       );
-      await new Promise((r) => setTimeout(r, 2000));
+      await new Promise((r) => setTimeout(r, 10000));
       expect(await NFTokenContract.balanceOf(mainContract.target)).to.equal(BigInt(0));
       expect(await NFTokenContract.balanceOf(accounts[1].wallet.address)).to.equal(BigInt(1));
 
@@ -720,7 +723,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
           amount,
           Constants.GAS.LIMIT_1_000_000,
         );
-      await new Promise((r) => setTimeout(r, 5000));
+      await new Promise((r) => setTimeout(r, 10000));
       const balanceAfter = await HTSTokenContract.balanceOf(accounts[2].wallet.address);
 
       expect(balanceBefore + amount).to.equal(balanceAfter);

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -911,6 +911,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
         // Since the transactionId is not available in this context
         // Wait for the transaction to be processed and imported in the mirror node with axios-retry
+        await new Promise((r) => setTimeout(r, 5000));
+
         await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
         const receiverEndBalance = await relay.getBalance(mirrorContract.evm_address, 'latest', requestId);
         const balanceChange = receiverEndBalance - receiverInitialBalance;

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -133,6 +133,8 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
     this.beforeAll(async () => {
       basicContract = await servicesNode.deployContract(basicContractJson);
+      // delay
+      await new Promise((r) => setTimeout(r, 5000));
     });
 
     it('@release should execute "eth_estimateGas"', async function () {

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -145,7 +145,7 @@ describe('@web-socket Acceptance Tests', async function () {
 
       await new Promise((resolve) => setTimeout(resolve, 2500));
 
-      expect(pings).to.eq(3);
+      expect(pings).to.greaterThanOrEqual(2);
     });
 
     it('@release Socket server responds to the eth_chainId event', async function () {


### PR DESCRIPTION
**Description**:

- Increasing some delays on the acceptance tests that are the most flaky.
- Changing web-socket ping verification to be 2 or more, since sometimes is 2 and other 3.
- Isolating TokenCreate Test 
- Adding some delays right before calling `balanceOf` / `eth_getBalance`.
- Adding some delays were needed
- Reduced Flakyness Tests on rpc_batch1, rpc_batch2, tokenCreate and subscribe tests
- Fixed Gas issue with TokenCreate Test.

**Related issue(s)**:

Fixes

**Notes for reviewer**:

<img width="1458" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/5be5e5c4-7983-4f3a-bf8f-0861a65917f0">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
