### PR TITLE
Acceptance Tests TokenCreate Fix and Reliability Improvements

### DIFF
--- a/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/tokenCreate.spec.ts
@@ -106,12 +106,6 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
       requestId,
     );
 
-    // allow mirror node a 2 full record stream write windows (2 sec) and a buffer to persist setup details
-    await new Promise((r) => setTimeout(r, 5000));
-    await mirrorNode.get(`/accounts/${accounts[0].accountId}`, requestId);
-    await mirrorNode.get(`/accounts/${accounts[1].accountId}`, requestId);
-    await mirrorNode.get(`/accounts/${accounts[2].accountId}`, requestId);
-
     HTSTokenContractAddress = await createHTSToken();
     NftHTSTokenContractAddress = await createNftHTSToken();
     HTSTokenWithCustomFeesContractAddress = await createHTSTokenWithCustomFees();
@@ -123,6 +117,9 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
     mainContractOwner = mainContract;
     mainContractReceiverWalletFirst = mainContract.connect(accounts[1].wallet);
     mainContractReceiverWalletSecond = mainContract.connect(accounts[2].wallet);
+
+    // wait for mirror node to catch up before running tests
+    await new Promise((r) => setTimeout(r, 5000));
   });
 
   this.beforeEach(async () => {
@@ -131,7 +128,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
 
   async function deploymainContract(signer) {
     const mainFactory = new ethers.ContractFactory(TokenCreateJson.abi, TokenCreateJson.bytecode, signer);
-    const mainContract = await mainFactory.deploy(Constants.GAS.LIMIT_10_000_000);
+    const mainContract = await mainFactory.deploy(await Utils.gasOptions(requestId, 15_000_000));
     await mainContract.waitForDeployment();
 
     return mainContract.target;
@@ -403,7 +400,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
         amount,
         Constants.GAS.LIMIT_1_000_000,
       );
-      await new Promise((r) => setTimeout(r, 2000));
+      await new Promise((r) => setTimeout(r, 5000));
       expect(await HTSTokenContract.balanceOf(accounts[1].wallet.address)).to.be.equal(amount);
 
       {
@@ -545,6 +542,9 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
           .responseCode,
       ).to.equal(TX_SUCCESS_CODE);
 
+      // delay
+      await new Promise((r) => setTimeout(r, 5000));
+
       expect(await NFTokenContract.balanceOf(mainContract.target)).to.equal(BigInt(1));
       expect(await NFTokenContract.balanceOf(accounts[1].wallet.address)).to.equal(BigInt(0));
       expect(await NFTokenContract.balanceOf(accounts[2].wallet.address)).to.equal(BigInt(0));
@@ -569,7 +569,7 @@ describe('@tokencreate HTS Precompile Token Create Acceptance Tests', async func
         NftSerialNumber,
         Constants.GAS.LIMIT_1_000_000,
       );
-      await new Promise((r) => setTimeout(r, 2000));
+      await new Promise((r) => setTimeout(r, 5000));
       expect(await NFTokenContract.balanceOf(mainContract.target)).to.equal(BigInt(0));
       expect(await NFTokenContract.balanceOf(accounts[1].wallet.address)).to.equal(BigInt(1));
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -911,6 +911,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
         // Since the transactionId is not available in this context
         // Wait for the transaction to be processed and imported in the mirror node with axios-retry
+        await new Promise((r) => setTimeout(r, 5000));
+
         await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
         const receiverEndBalance = await relay.getBalance(mirrorContract.evm_address, 'latest', requestId);
         const balanceChange = receiverEndBalance - receiverInitialBalance;

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -771,6 +771,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
         // Since the transactionId is not available in this context
         // Wait for the transaction to be processed and imported in the mirror node with axios-retry
+        await new Promise((r) => setTimeout(r, 5000));
         await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
 
         const receiverEndBalance = await relay.getBalance(mirrorContract.evm_address, 'latest', requestId);

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -133,6 +133,8 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
     this.beforeAll(async () => {
       basicContract = await servicesNode.deployContract(basicContractJson);
+      // delay
+      await new Promise((r) => setTimeout(r, 5000));
     });
 
     it('@release should execute "eth_estimateGas"', async function () {

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -145,7 +145,7 @@ describe('@web-socket Acceptance Tests', async function () {
 
       await new Promise((resolve) => setTimeout(resolve, 2500));
 
-      expect(pings).to.eq(3);
+      expect(pings).to.greaterThanOrEqual(2);
     });
 
     it('@release Socket server responds to the eth_chainId event', async function () {

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -825,7 +825,7 @@ describe('@web-socket Acceptance Tests', async function () {
       const tx = await htsToken.transfer(htsAccounts[1].wallet.address, 1, Constants.GAS.LIMIT_1_000_000);
       await tx.wait();
 
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, 5000));
 
       const balanceAfter = await htsToken.balanceOf(htsAccounts[1].wallet.address);
       expect(balanceAfter.toString()).to.eq('1', 'token is successfully transferred');


### PR DESCRIPTION
**Description**:
Increasing some delays on the acceptance tests that are the most flaky.
Changing web-socket ping verification to be 2 or more, since sometimes is 2 and other 3.
Adding some delays right before calling balanceOf / eth_getBalance.
Adding some delays were needed
Reduced Flakyness Tests on rpc_batch1, rpc_batch2, tokenCreate and subscribe tests
Fixed Gas issue with TokenCreate Test.

**Related issue(s)**:

Fixes #1913 

**Notes for reviewer**:
<img width="1681" alt="image" src="https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/81bbd031-2674-4b5e-a84c-774575c80684">

** On the screenshot above everything passed at first try, however there are still some lingering flaky-ness on subscribe tests: "release captures transfer events" and  "release captures approve and transferFrom events"
see this [issue](https://github.com/hashgraph/hedera-json-rpc-relay/issues/1919) for follow-up

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
