### PR TITLE
Removing cache for getBalance in dev mode and 'blockNumberOrTagOrHash' is explicit

### DIFF
--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -24,7 +24,8 @@
     "compile": "tsc -b tsconfig.json",
     "lint": "npx eslint --ext .js,.ts .",
     "format": "npx prettier --ignore-path ../../.gitignore --write \"**/*.+(js|ts|json)\"",
-    "test": "nyc ts-mocha --recursive './tests/**/*.spec.ts' './tests/**/**/*.spec.ts' --exit"
+    "test": "nyc ts-mocha --recursive './tests/**/*.spec.ts' './tests/**/**/*.spec.ts' --exit",
+    "test:balance": "nyc ts-mocha --recursive './tests/**/*.spec.ts' './tests/**/**/*.spec.ts' -g '@balance' --exit"
   },
   "dependencies": {
     "@ethersproject/asm": "^5.7.0",

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -261,6 +261,7 @@ export class EthImpl implements Eth {
   }
 
   private shouldUseCacheForBalance(tag: string | null): boolean {
+    // should only cache balance when is Not latest or pending and is not in dev mode
     return !CommonService.blockTagIsLatestOrPendingStrict(tag) && !CommonService.isDevMode;
   }
 

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -61,7 +61,7 @@ export class CommonService implements ICommonService {
   static blockLatest = 'latest';
   static blockEarliest = 'earliest';
   static blockPending = 'pending';
-  static isDevMode = !!(process.env.DEV_MODE && process.env.DEV_MODE === 'true');
+  static isDevMode = process.env.DEV_MODE === 'true';
 
   // function callerNames
   static latestBlockNumber = 'getLatestBlockNumber';

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -61,6 +61,7 @@ export class CommonService implements ICommonService {
   static blockLatest = 'latest';
   static blockEarliest = 'earliest';
   static blockPending = 'pending';
+  static isDevMode = !!(process.env.DEV_MODE && process.env.DEV_MODE === 'true');
 
   // function callerNames
   static latestBlockNumber = 'getLatestBlockNumber';
@@ -75,6 +76,10 @@ export class CommonService implements ICommonService {
     this.mirrorNodeClient = mirrorNodeClient;
     this.logger = logger;
     this.cacheService = cacheService;
+  }
+
+  public static blockTagIsLatestOrPendingStrict(tag: string | null): boolean {
+    return tag === CommonService.blockLatest || tag === CommonService.blockPending;
   }
 
   public blockTagIsLatestOrPending = (tag) => {


### PR DESCRIPTION
Removing cache for dev mode if blockNumberOrTagOrHash is explicitly 'latest' or 'pending'

**Related issue(s)**:
[Relay "getBalance" returns incorrect, cached response#1827](https://github.com/hashgraph/hedera-json-rpc-relay/issues/1827)