### PR TITLE
Improve logs message when falling back to consensus node due to unsupported calls

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1484,6 +1484,7 @@ export class EthImpl implements Eth {
     value: string | null,
     requestIdPrefix?: string,
   ): Promise<string | JsonRpcError> {
+    let callData: any = {};
     try {
       this.logger.debug(
         `${requestIdPrefix} Making eth_call on contract ${call.to} with gas ${gas} and call data "${call.data}" from "${call.from}" using mirror-node.`,
@@ -1492,7 +1493,7 @@ export class EthImpl implements Eth {
         call.data,
         call.from,
       );
-      const callData = {
+      callData = {
         ...call,
         gas,
         value,
@@ -1529,7 +1530,9 @@ export class EthImpl implements Eth {
           const errorTypeMessage =
             e.isNotSupported() || e.isNotSupportedSystemContractOperaton() ? 'Unsupported' : 'Unhandled';
           this.logger.trace(
-            `${requestIdPrefix} ${errorTypeMessage} mirror node eth_call request, retrying with consensus node. details: ${e.detail}, data: ${e.data}`,
+            `${requestIdPrefix} ${errorTypeMessage} mirror node eth_call request, retrying with consensus node. details: ${JSON.stringify(
+              callData,
+            )} with error: "${e.message}"`,
           );
           return await this.callConsensusNode(call, gas, requestIdPrefix);
         }


### PR DESCRIPTION
**Description**:
Improving log message to include `callData` (input) as well as the e.message (error reason) with all instances of eth_call fallback on consensus node (git unsupported calls)


**Related issue(s)**:

Fixes #1940 

**Notes for reviewer**:
This is an example of the logs produced by the change:
```
[Request ID: daf5090c-d1a4-43b5-a2b2-5f519b09ea2f] Unsupported mirror node eth_call request, retrying with consensus node. details: {"to":"0x00000000000000000000000000000000000b2ad5","data":"0x01ffc9a780ac58cd00000000000000000000000000000000000000000000000000000000","gas":400000,"value":null,"estimate":false} with error: "Precompile not supported for non-static frames"
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
