### PR TITLE
eth_estimateGas Fixed for MetaMask issue #1935

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -281,6 +281,11 @@ app.useRpc('eth_blockNumber', async () => {
  * returns: Gas used - hex encoded integer
  */
 app.useRpc('eth_estimateGas', async (params: any) => {
+  // HotFix for Metamask sending `0x` on data param
+  if (params?.[0]?.data === '0x') {
+    delete params[0].data;
+  }
+
   return logAndHandleResponse('eth_estimateGas', params, (requestId) =>
     relay.eth().estimateGas(params?.[0], params?.[1], requestId),
   );

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -313,6 +313,25 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
         requestId,
       );
     });
+
+    it('should execute "eth_estimateGas" with data as 0x instead of null', async function () {
+      const res = await relay.call(
+        RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS,
+        [
+          {
+            from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
+            to: '0xae410f34f7487e2cd03396499cebb09b79f45d6e',
+            value: '0xa688906bd8b00000',
+            gas: '0xd97010',
+            data: '0x',
+          },
+        ],
+        requestId,
+      );
+      expect(res).to.contain('0x');
+      expect(res).to.not.be.equal('0x');
+      expect(res).to.not.be.equal('0x0');
+    });
   });
 
   describe('eth_gasPrice', async function () {


### PR DESCRIPTION
**Description**:
Hardcoded a fix for eth_estimateGas due to Metamask sending 0x on data field instead of 0x0 or not sending the field at all. 0x is equivalent to null or not sending the field.


**Related issue(s)**:

Fixes #1935

**Notes for reviewer**:
This has already been deployed and is working on `testnet` and `mainnet` as a HotFix on version `0.36.2`. 
see this [PR](https://github.com/hashgraph/hedera-json-rpc-relay/pull/1936)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
