### PR TITLE
docs: add verification instructions in Hardhat example

### DIFF
--- a/tools/hardhat-example/.env.example
+++ b/tools/hardhat-example/.env.example
@@ -4,3 +4,5 @@ RECEIVER_PRIVATE_KEY=0x2e1d968b041d84dd120a5860cee60cd83f9374ef527ca86996317ada3
 RELAY_ENDPOINT='http://localhost:7546'
 
 MNEMONIC="here is where your twelve words mnemonic should be put my friend"
+
+TESTNET_OPERATOR_PRIVATE_KEY='<if you want to deploy on testnet go to https://portal.hedera.com/ to setup your private key>'

--- a/tools/hardhat-example/.env.example
+++ b/tools/hardhat-example/.env.example
@@ -5,4 +5,5 @@ RELAY_ENDPOINT='http://localhost:7546'
 
 MNEMONIC="here is where your twelve words mnemonic should be put my friend"
 
-TESTNET_OPERATOR_PRIVATE_KEY='<if you want to deploy on testnet go to https://portal.hedera.com/ to setup your private key>'
+# If you want to deploy on testnet go to https://portal.hedera.com/ to setup your private key
+TESTNET_OPERATOR_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000000

--- a/tools/hardhat-example/hardhat.config.js
+++ b/tools/hardhat-example/hardhat.config.js
@@ -21,7 +21,6 @@
 require('dotenv').config();
 require('@nomicfoundation/hardhat-toolbox');
 require('@nomicfoundation/hardhat-chai-matchers');
-require('@nomiclabs/hardhat-ethers');
 
 task('show-balance', async () => {
   const showBalance = require('./scripts/showBalance');
@@ -82,8 +81,20 @@ module.exports = {
     },
     testnet: {
       url: 'https://testnet.hashio.io/api',
-      accounts: [],
+      accounts: process.env.TESTNET_OPERATOR_PRIVATE_KEY
+        ? [process.env.TESTNET_OPERATOR_PRIVATE_KEY]
+        : [],
       chainId: 296,
     },
+  },
+
+  // https://hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify#verifying-on-sourcify
+  sourcify: {
+    // Enable it to support verification in Hedera's custom Sourcify instance
+    enabled: true,
+    // Needed to specify a different Sourcify server
+    apiUrl: 'https://server-verify.hashscan.io',
+    // Needed to specify a different Sourcify repository
+    browserUrl: 'https://repository-verify.hashscan.io',
   },
 };

--- a/tools/hardhat-example/package-lock.json
+++ b/tools/hardhat-example/package-lock.json
@@ -11,9 +11,9 @@
       },
       "devDependencies": {
         "@hashgraph/hedera-local": "^2.17.2",
-        "@nomicfoundation/hardhat-toolbox": "^2.0.1",
+        "@nomicfoundation/hardhat-toolbox": "^4.0.0",
         "dotenv": "^16.3.1",
-        "hardhat": "^2.18.1"
+        "hardhat": "^2.19.4"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -429,6 +429,12 @@
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
+    },
+    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "dev": true
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.7.0",
@@ -926,97 +932,6 @@
         "hedera": "build/index.js"
       }
     },
-    "node_modules/@hashgraph/hedera-local/node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dev": true,
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@hashgraph/hedera-local/node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@hashgraph/hedera-local/node_modules/@types/node": {
-      "version": "18.15.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-      "dev": true
-    },
-    "node_modules/@hashgraph/hedera-local/node_modules/aes-js": {
-      "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "dev": true
-    },
-    "node_modules/@hashgraph/hedera-local/node_modules/ethers": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.9.2.tgz",
-      "integrity": "sha512-YpkrtILnMQz5jSEsJQRTpduaGT/CXuLnUIuOYzHA0v/7c8IX91m2J48wSKjzGL5L9J/Us3tLoUdb+OwE3U+FFQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/ethers-io/"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@types/node": "18.15.13",
-        "aes-js": "4.0.0-beta.5",
-        "tslib": "2.4.0",
-        "ws": "8.5.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hashgraph/hedera-local/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
-    },
-    "node_modules/@hashgraph/hedera-local/node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@hashgraph/proto": {
       "version": "2.14.0-beta.3",
       "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.3.tgz",
@@ -1340,6 +1255,54 @@
         "node": ">=14"
       }
     },
+    "node_modules/@nomicfoundation/ethereumjs-block/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
     "node_modules/@nomicfoundation/ethereumjs-blockchain": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-7.0.2.tgz",
@@ -1436,6 +1399,54 @@
         "js-sdsl": "^4.1.4"
       }
     },
+    "node_modules/@nomicfoundation/ethereumjs-statemanager/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
     "node_modules/@nomicfoundation/ethereumjs-trie": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-6.0.2.tgz",
@@ -1527,23 +1538,37 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-chai-matchers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-1.0.6.tgz",
-      "integrity": "sha512-f5ZMNmabZeZegEfuxn/0kW+mm7+yV7VNDxLpMOMGXWFJ2l/Ct3QShujzDRF9cOkK9Ui/hbDeOWGZqyQALDXVCQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.3.tgz",
+      "integrity": "sha512-A40s7EAK4Acr8UP1Yudgi9GGD9Cca/K3LHt3DzmRIje14lBfHtg9atGQ7qK56vdPcTwKmeaGn30FzxMUfPGEMw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@ethersproject/abi": "^5.1.2",
         "@types/chai-as-promised": "^7.1.3",
         "chai-as-promised": "^7.1.1",
         "deep-eql": "^4.0.1",
         "ordinal": "^1.0.3"
       },
       "peerDependencies": {
-        "@nomiclabs/hardhat-ethers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
         "chai": "^4.2.0",
-        "ethers": "^5.0.0",
+        "ethers": "^6.1.0",
         "hardhat": "^2.9.4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-ethers": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.5.tgz",
+      "integrity": "sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "lodash.isequal": "^4.5.0"
+      },
+      "peerDependencies": {
+        "ethers": "^6.1.0",
+        "hardhat": "^2.0.0"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
@@ -1560,30 +1585,59 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-toolbox": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-2.0.2.tgz",
-      "integrity": "sha512-vnN1AzxbvpSx9pfdRHbUzTRIXpMLPXnUlkW855VaDk6N1pwRaQ2gNzEmFAABk4lWf11E00PKwFd/q27HuwYrYg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-toolbox/-/hardhat-toolbox-4.0.0.tgz",
+      "integrity": "sha512-jhcWHp0aHaL0aDYj8IJl80v4SZXWMS1A2XxXa1CA6pBiFfJKuZinCkO6wb+POAt0LIfXB3gA3AgdcOccrcwBwA==",
       "dev": true,
       "peerDependencies": {
-        "@ethersproject/abi": "^5.4.7",
-        "@ethersproject/providers": "^5.4.7",
-        "@nomicfoundation/hardhat-chai-matchers": "^1.0.0",
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.0",
+        "@nomicfoundation/hardhat-ethers": "^3.0.0",
         "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
-        "@nomiclabs/hardhat-ethers": "^2.0.0",
-        "@nomiclabs/hardhat-etherscan": "^3.0.0",
-        "@typechain/ethers-v5": "^10.1.0",
-        "@typechain/hardhat": "^6.1.2",
+        "@nomicfoundation/hardhat-verify": "^2.0.0",
+        "@typechain/ethers-v6": "^0.5.0",
+        "@typechain/hardhat": "^9.0.0",
         "@types/chai": "^4.2.0",
         "@types/mocha": ">=9.1.0",
-        "@types/node": ">=12.0.0",
+        "@types/node": ">=16.0.0",
         "chai": "^4.2.0",
-        "ethers": "^5.4.7",
+        "ethers": "^6.4.0",
         "hardhat": "^2.11.0",
         "hardhat-gas-reporter": "^1.0.8",
         "solidity-coverage": "^0.8.1",
         "ts-node": ">=8.0.0",
-        "typechain": "^8.1.0",
+        "typechain": "^8.3.0",
         "typescript": ">=4.5.0"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.3.tgz",
+      "integrity": "sha512-ESbRu9by53wu6VvgwtMtm108RSmuNsVqXtzg061D+/4R7jaWh/Wl/8ve+p6SdDX7vA1Z3L02hDO1Q3BY4luLXQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.1.2",
+        "@ethersproject/address": "^5.0.2",
+        "cbor": "^8.1.0",
+        "chalk": "^2.4.2",
+        "debug": "^4.1.1",
+        "lodash.clonedeep": "^4.5.0",
+        "semver": "^6.3.0",
+        "table": "^6.8.0",
+        "undici": "^5.14.0"
+      },
+      "peerDependencies": {
+        "hardhat": "^2.0.4"
+      }
+    },
+    "node_modules/@nomicfoundation/hardhat-verify/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@nomicfoundation/solidity-analyzer": {
@@ -1754,50 +1808,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-ethers": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.2.3.tgz",
-      "integrity": "sha512-YhzPdzb612X591FOe68q+qXVXGG2ANZRvDo0RRUtimev85rCrAlv/TLMEZw5c+kq9AbzocLTVX/h2jVIFPL9Xg==",
-      "dev": true,
-      "peer": true,
-      "peerDependencies": {
-        "ethers": "^5.0.0",
-        "hardhat": "^2.0.0"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-3.1.8.tgz",
-      "integrity": "sha512-v5F6IzQhrsjHh6kQz4uNrym49brK9K5bYCq2zQZ729RYRaifI9hHbtmK+KkIVevfhut7huQFEQ77JLRMAzWYjQ==",
-      "deprecated": "The @nomiclabs/hardhat-etherscan package is deprecated, please use @nomicfoundation/hardhat-verify instead",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abi": "^5.1.2",
-        "@ethersproject/address": "^5.0.2",
-        "cbor": "^8.1.0",
-        "chalk": "^2.4.2",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.1",
-        "lodash": "^4.17.11",
-        "semver": "^6.3.0",
-        "table": "^6.8.0",
-        "undici": "^5.14.0"
-      },
-      "peerDependencies": {
-        "hardhat": "^2.0.4"
-      }
-    },
-    "node_modules/@nomiclabs/hardhat-etherscan/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@openzeppelin/contracts": {
@@ -2093,10 +2103,10 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/@typechain/ethers-v5": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-10.2.1.tgz",
-      "integrity": "sha512-n3tQmCZjRE6IU4h6lqUGiQ1j866n5MTCBJreNEHHVWXa2u9GJTaeYyU1/k+1qLutkyw+sS6VAN+AbeiTqsxd/A==",
+    "node_modules/@typechain/ethers-v6": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz",
+      "integrity": "sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -2104,29 +2114,25 @@
         "ts-essentials": "^7.0.1"
       },
       "peerDependencies": {
-        "@ethersproject/abi": "^5.0.0",
-        "@ethersproject/providers": "^5.0.0",
-        "ethers": "^5.1.3",
-        "typechain": "^8.1.1",
-        "typescript": ">=4.3.0"
+        "ethers": "6.x",
+        "typechain": "^8.3.2",
+        "typescript": ">=4.7.0"
       }
     },
     "node_modules/@typechain/hardhat": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-6.1.6.tgz",
-      "integrity": "sha512-BiVnegSs+ZHVymyidtK472syodx1sXYlYJJixZfRstHVGYTi8V1O7QG4nsjyb0PC/LORcq7sfBUcHto1y6UgJA==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-9.1.0.tgz",
+      "integrity": "sha512-mtaUlzLlkqTlfPwB3FORdejqBskSnh+Jl8AIJGjXNAQfRQ4ofHADPl1+oU7Z3pAJzmZbUXII8MhOLQltcHgKnA==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "fs-extra": "^9.1.0"
       },
       "peerDependencies": {
-        "@ethersproject/abi": "^5.4.7",
-        "@ethersproject/providers": "^5.4.7",
-        "@typechain/ethers-v5": "^10.2.1",
-        "ethers": "^5.4.7",
+        "@typechain/ethers-v6": "^0.5.1",
+        "ethers": "^6.1.0",
         "hardhat": "^2.9.9",
-        "typechain": "^8.1.1"
+        "typechain": "^8.3.2"
       }
     },
     "node_modules/@typechain/hardhat/node_modules/fs-extra": {
@@ -2381,9 +2387,9 @@
       }
     },
     "node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "dev": true
     },
     "node_modules/agent-base": {
@@ -3047,9 +3053,9 @@
       }
     },
     "node_modules/chai": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.0.tgz",
-      "integrity": "sha512-x9cHNq1uvkCdU+5xTkNh5WtgD4e4yDFCsp9jVc7N7qVeKeftv3gO/ZrviX5d+3ZfxdYnZXZYujjRInu1RogU6A==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
       "dev": true,
       "peer": true,
       "dependencies": {
@@ -4008,6 +4014,55 @@
         "@scure/bip39": "1.1.1"
       }
     },
+    "node_modules/eth-gas-reporter/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
     "node_modules/ethereum-bloom-filters": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
@@ -4099,14 +4154,14 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.10.0.tgz",
+      "integrity": "sha512-nMNwYHzs6V1FR3Y4cdfxSQmNgZsRj1RiTU25JwvnJLmyzw9z3SKxNc2XKDuiXXo/v9ds5Mp9m6HBabgYQQ26tA==",
       "dev": true,
       "funding": [
         {
           "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+          "url": "https://github.com/sponsors/ethers-io/"
         },
         {
           "type": "individual",
@@ -4114,36 +4169,73 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
+      "dev": true
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/ethjs-unit": {
@@ -5417,6 +5509,20 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",

--- a/tools/hardhat-example/package.json
+++ b/tools/hardhat-example/package.json
@@ -6,9 +6,9 @@
   },
   "devDependencies": {
     "@hashgraph/hedera-local": "^2.17.2",
-    "@nomicfoundation/hardhat-toolbox": "^2.0.1",
+    "@nomicfoundation/hardhat-toolbox": "^4.0.0",
     "dotenv": "^16.3.1",
-    "hardhat": "^2.18.1"
+    "hardhat": "^2.19.4"
   },
   "dependencies": {
     "@hashgraph/smart-contracts": "github:hashgraph/hedera-smart-contracts#11c5017c1867b3f31012163cdac0aafa4a30b60a",

--- a/tools/hardhat-example/scripts/deployContract.js
+++ b/tools/hardhat-example/scripts/deployContract.js
@@ -24,7 +24,7 @@ module.exports = async () => {
   let wallet = (await ethers.getSigners())[0];
   const Greeter = await ethers.getContractFactory('Greeter', wallet);
   const greeter = await Greeter.deploy('initial_msg');
-  const contractAddress = (await greeter.deployTransaction.wait()).contractAddress;
+  const contractAddress = (await greeter.deploymentTransaction().wait()).contractAddress;
 
   console.log(`Greeter deployed to: ${contractAddress}`);
 

--- a/tools/hardhat-example/scripts/showBalance.js
+++ b/tools/hardhat-example/scripts/showBalance.js
@@ -22,7 +22,7 @@ const { ethers } = require('hardhat');
 
 module.exports = async () => {
   const wallet = (await ethers.getSigners())[0];
-  const balance = (await wallet.getBalance()).toString();
+  const balance = (await wallet.provider.getBalance(wallet.address)).toString();
   console.log(`The address ${wallet.address} has ${balance} tinybars`);
 
   return balance;

--- a/tools/hardhat-example/scripts/transferHbars.js
+++ b/tools/hardhat-example/scripts/transferHbars.js
@@ -24,7 +24,7 @@ module.exports = async (amount = 100_000_000_000) => {
   const wallet = (await ethers.getSigners())[0];
   const walletReceiver = (await ethers.getSigners())[1];
 
-  console.log(`Balance before tx: ${await walletReceiver.getBalance()}`);
+  console.log(`Balance before tx: ${await walletReceiver.provider.getBalance(walletReceiver.address)}`);
   // Keep in mind that TINYBAR to WEIBAR coefficient is 10_000_000_000
   await wallet.sendTransaction({
     to: walletReceiver.address,
@@ -32,5 +32,5 @@ module.exports = async (amount = 100_000_000_000) => {
   });
   //delay of 3 sec before fetching the new balance, because often it's too fast when querying and the balance is the same like before transfer transaciton
   await new Promise((r) => setTimeout(r, 3000));
-  console.log(`Balance after tx: ${await walletReceiver.getBalance()}`);
+  console.log(`Balance after tx: ${await walletReceiver.provider.getBalance(walletReceiver.address)}`);
 };

--- a/tools/hardhat-example/test/rpc.js
+++ b/tools/hardhat-example/test/rpc.js
@@ -36,11 +36,11 @@ describe('RPC', function () {
 
   it('should be able to transfer hbars between two accounts', async function () {
     let walletReceiver = signers[0];
-    const hbarsBefore = (await walletReceiver.getBalance()).toString();
+    const hbarsBefore = (await walletReceiver.provider.getBalance(walletReceiver.address)).toString();
     await hre.run('transfer-hbars');
     // add additional transfer to ensure file close on local node
     await hre.run('transfer-hbars');
-    const hbarsAfter = (await walletReceiver.getBalance()).toString();
+    const hbarsAfter = (await walletReceiver.provider.getBalance(walletReceiver.address)).toString();
     expect(hbarsBefore).to.not.be.equal(hbarsAfter);
   });
 

--- a/tools/hardhat-example/test/simple-vault.js
+++ b/tools/hardhat-example/test/simple-vault.js
@@ -50,13 +50,13 @@ describe('Test SimpleVault using the HTS System Contract Mock', function () {
     // - - - - - DEPLOY REQUISITE SYSTEM CONTRACT MOCKS - - - - -
     const HtsSystemContractMockFactory = await ethers.getContractFactory("HtsSystemContractMock");
     const HtsSystemContractMock = await HtsSystemContractMockFactory.deploy();
-    const htsSystemContractBytecode = await hre.network.provider.send("eth_getCode", [HtsSystemContractMock.address,]);
+    const htsSystemContractBytecode = await hre.network.provider.send("eth_getCode", [HtsSystemContractMock.target,]);
     await hre.network.provider.send("hardhat_setCode", [htsSystemContractAddress, htsSystemContractBytecode]);
     htsSystemContract = await hre.ethers.getContractAt("HtsSystemContractMock", htsSystemContractAddress);
 
     const ExchangeRatePrecompileMockFactory = await ethers.getContractFactory("ExchangeRatePrecompileMock");
     const ExchangeRatePrecompileMock = await ExchangeRatePrecompileMockFactory.deploy();
-    const exchangeRatePrecompileMockBytecode = await hre.network.provider.send("eth_getCode", [ExchangeRatePrecompileMock.address,]);
+    const exchangeRatePrecompileMockBytecode = await hre.network.provider.send("eth_getCode", [ExchangeRatePrecompileMock.target,]);
     await hre.network.provider.send("hardhat_setCode", [exchangeRateSystemContractAddress, exchangeRatePrecompileMockBytecode]);
     exchangeRateSystemContract = await hre.ethers.getContractAt("ExchangeRatePrecompileMock", exchangeRateSystemContractAddress);
 
@@ -87,10 +87,10 @@ describe('Test SimpleVault using the HTS System Contract Mock', function () {
 
     // - - - - - DEPLOY HTS Token via direct EOA call to HTS System Contract Mock - - - - -
 
-    const createTokenExpectedResult = await htsSystemContract.connect(deployer).callStatic.createFungibleToken(token, initialTotalSupply, decimals);
-    const factoryAddress = htsSystemContract.address;
+    const createTokenExpectedResult = await htsSystemContract.connect(deployer).createFungibleToken.staticCall(token, initialTotalSupply, decimals);
+    const factoryAddress = htsSystemContract.target;
     const factoryNonce = await ethers.provider.getTransactionCount(factoryAddress);
-    const computedTokenAddress = ethers.utils.getContractAddress({ from: factoryAddress, nonce: factoryNonce });
+    const computedTokenAddress = ethers.getCreateAddress({ from: factoryAddress, nonce: factoryNonce });
     const expectedTokenAddress = createTokenExpectedResult.tokenAddress;
 
     expect(computedTokenAddress).to.be.eq(expectedTokenAddress);
@@ -99,7 +99,7 @@ describe('Test SimpleVault using the HTS System Contract Mock', function () {
 
     const createTokenTx = await htsSystemContract.connect(deployer).createFungibleToken(token, initialTotalSupply, decimals);
     const createTokenRc = await createTokenTx.wait();
-    htsAddress = createTokenRc.events[1].args.token
+    htsAddress = createTokenRc.logs[1].args.token
 
     const factoryNonceFinal = await ethers.provider.getTransactionCount(htsSystemContractAddress)
     expect(factoryNonceInitial).to.be.eq(factoryNonceFinal - 1);
@@ -115,11 +115,11 @@ describe('Test SimpleVault using the HTS System Contract Mock', function () {
 
     const SimpleVaultFactory = await ethers.getContractFactory("SimpleVault");
     simpleVault = await SimpleVaultFactory.deploy();
-    await simpleVault.deployed();
+    await simpleVault.deploymentTransaction().wait();
 
-    await simpleVault.associate(htsTokenContract.address);
+    await simpleVault.associate(htsTokenContract.target);
 
-    const isAssociatedWithHtsToken = await simpleVault.isAssociated(htsTokenContract.address);
+    const isAssociatedWithHtsToken = await simpleVault.isAssociated(htsTokenContract.target);
     expect(isAssociatedWithHtsToken).to.be.true;
   });
 
@@ -127,23 +127,23 @@ describe('Test SimpleVault using the HTS System Contract Mock', function () {
     // - - - - - DEPLOY HTS Token via Proxy - - - - -
     const ProxyToHtsMock = await ethers.getContractFactory("ProxyToHtsMock");
     const proxyToHtsMock = await ProxyToHtsMock.deploy();
-    await proxyToHtsMock.deployed();
+    await proxyToHtsMock.deploymentTransaction().wait();
 
     const createTokenViaProxyTx = await proxyToHtsMock.createTokenForSender();
     const createTokenViaProxyRc = await createTokenViaProxyTx.wait();
 
-    const htsTokenAddress = topicToAddress(createTokenViaProxyRc.events[1].topics[1]);
+    const htsTokenAddress = topicToAddress(createTokenViaProxyRc.logs[1].topics[1]);
     const htsTokenByProxy = await hre.ethers.getContractAt("HederaFungibleToken", htsTokenAddress);
 
-    const balanceOfProxy = await htsTokenByProxy.balanceOf(proxyToHtsMock.address);
+    const balanceOfProxy = await htsTokenByProxy.balanceOf(proxyToHtsMock.target);
     const totalSupply = await htsTokenByProxy.totalSupply();
 
     expect(totalSupply).to.be.eq(balanceOfProxy);
 
-    await htsSystemContract.connect(deployer).associateToken(deployerAddress, htsTokenByProxy.address);
-    await proxyToHtsMock.connect(deployer).sweepToSender(htsTokenByProxy.address);
+    await htsSystemContract.connect(deployer).associateToken(deployerAddress, htsTokenByProxy.target);
+    await proxyToHtsMock.connect(deployer).sweepToSender(htsTokenByProxy.target);
 
-    const balanceOfProxyFinal = await htsTokenByProxy.balanceOf(proxyToHtsMock.address);
+    const balanceOfProxyFinal = await htsTokenByProxy.balanceOf(proxyToHtsMock.target);
     const balanceOfDeployerFinal = await htsTokenByProxy.balanceOf(deployerAddress);
 
     expect(0).to.be.eq(balanceOfProxyFinal);
@@ -152,38 +152,38 @@ describe('Test SimpleVault using the HTS System Contract Mock', function () {
 
   it('should be able to deposit and withdraw to and from the vault', async function () {
 
-    const depositAmount = 100;
+    const depositAmount = 100n;
 
-    const vaultInitialBalance = await htsTokenContract.balanceOf(simpleVault.address);
+    const vaultInitialBalance = await htsTokenContract.balanceOf(simpleVault.target);
     const deployerInitialBalance = await htsTokenContract.balanceOf(deployerAddress);
 
-    const valueForDeposit = await simpleVault.callStatic.getCentsInTinybar(2);
+    const valueForDeposit = await simpleVault.getCentsInTinybar.staticCall(2);
 
-    await htsTokenContract.connect(deployer).approve(simpleVault.address, depositAmount);
+    await htsTokenContract.connect(deployer).approve(simpleVault.target, depositAmount);
 
     await simpleVault.connect(deployer).deposit(htsAddress, depositAmount, {
       value: valueForDeposit
     });
 
-    const vaultBalanceAfterDeposit = await htsTokenContract.balanceOf(simpleVault.address);
+    const vaultBalanceAfterDeposit = await htsTokenContract.balanceOf(simpleVault.target);
     const deployerBalanceAfterDeposit = await htsTokenContract.balanceOf(deployerAddress);
 
-    expect(vaultBalanceAfterDeposit).to.be.eq(vaultInitialBalance.add(depositAmount));
-    expect(deployerBalanceAfterDeposit).to.be.eq(deployerInitialBalance.sub(depositAmount));
+    expect(vaultBalanceAfterDeposit).to.be.eq(vaultInitialBalance + depositAmount);
+    expect(deployerBalanceAfterDeposit).to.be.eq(deployerInitialBalance - depositAmount);
 
-    const withdrawAmount = 50;
+    const withdrawAmount = 50n;
 
-    const valueForWithdraw = await simpleVault.callStatic.getCentsInTinybar(1);
+    const valueForWithdraw = await simpleVault.getCentsInTinybar.staticCall(1);
 
     await simpleVault.connect(deployer).withdraw(htsAddress, withdrawAmount, {
       value: valueForWithdraw
     });
 
-    const vaultBalanceAfterWithdraw = await htsTokenContract.balanceOf(simpleVault.address);
+    const vaultBalanceAfterWithdraw = await htsTokenContract.balanceOf(simpleVault.target);
     const deployerBalanceAfterWithdraw = await htsTokenContract.balanceOf(deployerAddress);
 
-    expect(vaultBalanceAfterWithdraw).to.be.eq(vaultBalanceAfterDeposit.sub(withdrawAmount));
-    expect(deployerBalanceAfterWithdraw).to.be.eq(deployerBalanceAfterDeposit.add(withdrawAmount));
+    expect(vaultBalanceAfterWithdraw).to.be.eq(vaultBalanceAfterDeposit - withdrawAmount);
+    expect(deployerBalanceAfterWithdraw).to.be.eq(deployerBalanceAfterDeposit + withdrawAmount);
 
   });
 


### PR DESCRIPTION
Fixes 
- #2054.

> The Hardhat example does not provide instructions nor setup to verify the contract. It would be useful to devs to have an end-to-end solution to build, test, deploy and verify their smart contracts on Hedera.

**Description**:

This PR adds instructions to setup the verification of deployed smart contracts in a custom Sourcify instance. To do so, it includes a new `env` key to set up the user private key on _testnet_ and updates Hardhat dependencies. More specifically, `ethers.js`

There are breaking changes when migrating `ethers.js` _v5_ to _v6_ (this is because we had to update `hardhat-toolbox` for the custom verification to work).

- `getBalance` needs to be invoked from the `provider`
- Use `target` instead of `address` to get the address of a contract
- Use `METHOD.staticCall` instead of `callStatic.METHOD`
- Use `getCreateAddress` instead of `getContractAddress`
- Use `logs` instead of `events` to get the emitted events in a receipt
- Use native BigInt instead of BigNumber

Some of these changes can be found in the official `ethers.js` docs https://docs.ethers.org/v6/migrating/.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
