### PR TITLE
docs: minor - update error messages related to batch to point to config value

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -274,12 +274,12 @@ export const predefined = {
   BATCH_REQUESTS_DISABLED: new JsonRpcError({
     name: 'Batch requests disabled',
     code: -32202,
-    message: 'Batch requests are disabled',
+    message: 'Batch requests are disabled. See configuration value for BATCH_REQUESTS_ENABLED.',
   }),
   BATCH_REQUESTS_AMOUNT_MAX_EXCEEDED: (amount: number, max: number) =>
     new JsonRpcError({
       name: 'Batch requests amount max exceeded',
       code: -32203,
-      message: `Batch request amount ${amount} exceeds max ${max}`,
+      message: `Batch request amount ${amount} exceeds max ${max}. See configuration value for BATCH_REQUESTS_MAX_SIZE.`,
     }),
 };

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -2331,7 +2331,9 @@ class BaseTest {
     expect(response.statusText).to.eq('Bad Request');
 
     expect(response.data.error.name).to.eq('Batch requests disabled');
-    expect(response.data.error.message).to.eq('Batch requests are disabled');
+    expect(response.data.error.message).to.eq(
+      'Batch requests are disabled. See configuration value for BATCH_REQUESTS_ENABLED.',
+    );
     expect(response.data.error.code).to.eq(-32202);
   }
 
@@ -2345,7 +2347,9 @@ class BaseTest {
     expect(response.status).to.eq(400);
     expect(response.statusText).to.eq('Bad Request');
     expect(response.data.error.name).to.eq('Batch requests amount max exceeded');
-    expect(response.data.error.message).to.eq(`Batch request amount ${amount} exceeds max ${max}`);
+    expect(response.data.error.message).to.eq(
+      `Batch request amount ${amount} exceeds max ${max}. See configuration value for BATCH_REQUESTS_MAX_SIZE.`,
+    );
     expect(response.data.error.code).to.eq(-32203);
   }
 


### PR DESCRIPTION
## What

- Update error message for `BATCH_REQUESTS_DISABLED` to point to config option `BATCH_REQUESTS_ENABLED`.
- Update error message for `BATCH_REQUESTS_AMOUNT_MAX_EXCEEDED` to point to config option `BATCH_REQUESTS_MAX_SIZE`.

## Why

- Make the error message more useful, by pointing in the right direction

## Refs

- https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/docs/configuration.md#server