### PR TITLE
fix: Status Code on Relay Response Logs

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -78,9 +78,7 @@ app.getKoaApp().use(async (ctx, next) => {
   } else {
     // log call type, method, status code and latency
     logger.info(
-      `${formatRequestIdMessage(ctx.state.reqId)} [${ctx.method}]: ${ctx.state.methodName} ${
-        ctx.state.status
-      } ${ms} ms`,
+      `${formatRequestIdMessage(ctx.state.reqId)} [${ctx.method}]: ${ctx.state.methodName} ${ctx.status} ${ms} ms`,
     );
     methodResponseHistogram.labels(ctx.state.methodName, `${ctx.status}`).observe(ms);
   }


### PR DESCRIPTION
**Description**:
Fixed regression where the status code returned by the relay was correctly tracked and observed on metrics but not on logs.

This was making it hard to troubleshoot and correlate the logs with the metrics

**Related issue(s)**:

Fixes #2084 

**Notes for reviewer**:
After Fix:
![image](https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/36df40cc-f427-4438-9305-ca095ef01db6)


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
