### PR TITLE
fix: Enables getStorageAt to accept blockHashes

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -439,7 +439,7 @@
                     "name": "Block",
                     "required": false,
                     "schema": {
-                        "$ref": "#/components/schemas/BlockNumberOrTag"
+                        "$ref": "#/components/schemas/BlockNumberOrTagOrHash"
                     }
                 }
             ],
@@ -1441,6 +1441,23 @@
                     {
                         "title": "Block tag",
                         "$ref": "#/components/schemas/BlockTag"
+                    }
+                ]
+            },
+            "BlockNumberOrTagOrHash": {
+                "title": "Block number or tag",
+                "oneOf": [
+                    {
+                        "title": "Block number",
+                        "$ref": "#/components/schemas/uint"
+                    },
+                    {
+                        "title": "Block tag",
+                        "$ref": "#/components/schemas/BlockTag"
+                    },
+                    {
+                        "title": "Block hash",
+                        "$ref": "#/components/schemas/hash32"
                     }
                 ]
             },

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -793,20 +793,20 @@ export class EthImpl implements Eth {
   async getStorageAt(
     address: string,
     slot: string,
-    blockNumberOrTag?: string | null,
+    blockNumberOrTagOrHash?: string | null,
     requestIdPrefix?: string,
   ): Promise<string> {
     this.logger.trace(
-      `${requestIdPrefix} getStorageAt(address=${address}, slot=${slot}, blockNumberOrTag=${blockNumberOrTag})`,
+      `${requestIdPrefix} getStorageAt(address=${address}, slot=${slot}, blockNumberOrOrHashTag=${blockNumberOrTagOrHash})`,
     );
 
     let result = EthImpl.zeroHex32Byte; // if contract or slot not found then return 32 byte 0
 
-    const blockResponse = await this.common.getHistoricalBlockResponse(blockNumberOrTag, false, requestIdPrefix);
+    const blockResponse = await this.common.getHistoricalBlockResponse(blockNumberOrTagOrHash, false, requestIdPrefix);
     // To save a request to the mirror node for `latest` and `pending` blocks, we directly return null from `getHistoricalBlockResponse`
     // But if a block number or `earliest` tag is passed and the mirror node returns `null`, we should throw an error.
-    if (!this.common.blockTagIsLatestOrPending(blockNumberOrTag) && blockResponse == null) {
-      throw predefined.RESOURCE_NOT_FOUND(`block '${blockNumberOrTag}'.`);
+    if (!this.common.blockTagIsLatestOrPending(blockNumberOrTagOrHash) && blockResponse == null) {
+      throw predefined.RESOURCE_NOT_FOUND(`block '${blockNumberOrTagOrHash}'.`);
     }
 
     const blockEndTimestamp = blockResponse?.timestamp?.to;

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -149,16 +149,16 @@ export class CommonService implements ICommonService {
    * @param returnLatest
    */
   public async getHistoricalBlockResponse(
-    blockNumberOrTag?: string | null,
+    blockNumberOrTagOrHash?: string | null,
     returnLatest?: boolean,
     requestIdPrefix?: string | undefined,
   ): Promise<any> {
-    if (!returnLatest && this.blockTagIsLatestOrPending(blockNumberOrTag)) {
+    if (!returnLatest && this.blockTagIsLatestOrPending(blockNumberOrTagOrHash)) {
       return null;
     }
 
-    const blockNumber = Number(blockNumberOrTag);
-    if (blockNumberOrTag != null && blockNumberOrTag.length < 32 && !isNaN(blockNumber)) {
+    const blockNumber = Number(blockNumberOrTagOrHash);
+    if (blockNumberOrTagOrHash != null && blockNumberOrTagOrHash.length < 32 && !isNaN(blockNumber)) {
       const latestBlockResponse = await this.mirrorNodeClient.getLatestBlock(requestIdPrefix);
       const latestBlock = latestBlockResponse.blocks[0];
       if (blockNumber > latestBlock.number + this.maxBlockRange) {
@@ -166,20 +166,20 @@ export class CommonService implements ICommonService {
       }
     }
 
-    if (blockNumberOrTag == null || this.blockTagIsLatestOrPending(blockNumberOrTag)) {
+    if (blockNumberOrTagOrHash == null || this.blockTagIsLatestOrPending(blockNumberOrTagOrHash)) {
       const latestBlockResponse = await this.mirrorNodeClient.getLatestBlock(requestIdPrefix);
       return latestBlockResponse.blocks[0];
     }
 
-    if (blockNumberOrTag == CommonService.blockEarliest) {
+    if (blockNumberOrTagOrHash == CommonService.blockEarliest) {
       return await this.mirrorNodeClient.getBlock(0, requestIdPrefix);
     }
 
-    if (blockNumberOrTag.length < 32) {
-      return await this.mirrorNodeClient.getBlock(Number(blockNumberOrTag), requestIdPrefix);
+    if (blockNumberOrTagOrHash.length < 32) {
+      return await this.mirrorNodeClient.getBlock(Number(blockNumberOrTagOrHash), requestIdPrefix);
     }
 
-    return await this.mirrorNodeClient.getBlock(blockNumberOrTag, requestIdPrefix);
+    return await this.mirrorNodeClient.getBlock(blockNumberOrTagOrHash, requestIdPrefix);
   }
 
   /**

--- a/packages/relay/tests/lib/eth/eth_getStorageAt.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getStorageAt.spec.ts
@@ -37,6 +37,7 @@ import {
   DETAILD_CONTRACT_RESULT_NOT_FOUND,
   MOST_RECENT_BLOCK,
   OLDER_BLOCK,
+  BLOCK_HASH,
 } from './eth-config';
 import { predefined } from '../../../src/lib/errors/JsonRpcError';
 import RelayAssertions from '../../assertions';
@@ -72,6 +73,7 @@ describe('@ethGetStorageAt eth_getStorageAt spec', async function () {
     currentMaxBlockRange = Number(process.env.ETH_GET_TRANSACTION_COUNT_MAX_BLOCK_RANGE);
     process.env.ETH_GET_TRANSACTION_COUNT_MAX_BLOCK_RANGE = '1';
     restMock.onGet(`blocks/${BLOCK_NUMBER}`).reply(200, DEFAULT_BLOCK);
+    restMock.onGet(`blocks/${BLOCK_HASH}`).reply(200, DEFAULT_BLOCK);
     restMock.onGet(BLOCKS_LIMIT_ORDER_URL).reply(200, MOST_RECENT_BLOCK);
   });
 
@@ -124,6 +126,25 @@ describe('@ethGetStorageAt eth_getStorageAt spec', async function () {
         CONTRACT_ADDRESS_1,
         defaultDetailedContractResults.state_changes[0].slot,
         numberTo0x(BLOCK_NUMBER),
+      );
+      confirmResult(result);
+
+      // verify slot value
+      expect(result).equal(defaultDetailedContractResults.state_changes[0].value_written);
+    });
+
+    it('eth_getStorageAt with match with block hash', async function () {
+      // mirror node request mocks
+      restMock
+        .onGet(
+          `contracts/${CONTRACT_ADDRESS_1}/state?timestamp=${DEFAULT_BLOCK.timestamp.to}&slot=0x0000000000000000000000000000000000000000000000000000000000000101&limit=100&order=desc`,
+        )
+        .reply(200, DEFAULT_CURRENT_CONTRACT_STATE);
+
+      const result = await ethImpl.getStorageAt(
+        CONTRACT_ADDRESS_1,
+        defaultDetailedContractResults.state_changes[0].slot,
+        BLOCK_HASH,
       );
       confirmResult(result);
 

--- a/packages/server/src/validator/methods.ts
+++ b/packages/server/src/validator/methods.ts
@@ -127,7 +127,7 @@ export const METHODS = {
       type: 'hex',
     },
     2: {
-      type: 'blockNumber',
+      type: 'blockNumber|blockHash',
     },
   },
   eth_getTransactionByBlockHashAndIndex: {

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -1830,7 +1830,7 @@ describe('RPC Server', async function () {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}, value: 123`,
+            `Invalid parameter 2: ${Validator.INVALID_BLOCK_HASH_TAG_NUMBER} 123`,
           );
         }
       });
@@ -1849,7 +1849,26 @@ describe('RPC Server', async function () {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 2: ${Validator.BLOCK_NUMBER_ERROR}, value: newest`,
+            `Invalid parameter 2: ${Validator.INVALID_BLOCK_HASH_TAG_NUMBER} newest`,
+          );
+        }
+      });
+
+      it('validates parameter 2 is valid block tag', async function () {
+        try {
+          await this.testClient.post('/', {
+            id: '2',
+            jsonrpc: '2.0',
+            method: RelayCalls.ETH_ENDPOINTS.ETH_GET_STORAGE_AT,
+            params: ['0x0000000000000000000000000000000000000001', '0x1', 'newest'],
+          });
+
+          Assertions.expectedError();
+        } catch (error) {
+          BaseTest.invalidParamError(
+            error.response,
+            Validator.ERROR_CODE,
+            `Invalid parameter 2: ${Validator.INVALID_BLOCK_HASH_TAG_NUMBER} newest`,
           );
         }
       });
@@ -2045,7 +2064,6 @@ describe('RPC Server', async function () {
 
           Assertions.expectedError();
         } catch (error) {
-          console.log(error.response.data);
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
This pull request introduces a modification to the relay validator, enabling it to accommodate block hashes within the context of the getStorageAt endpoint. The primary focus of this update is to align the functionality with the underlying logic, which inherently supports block hashes.
Additionally, new tests were added, including adjustments to existing tests to ensure consistency.

**Related issue(s)**:

Fixes #2107

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
