### PR TITLE
fix: add support for `eth_call` Historical Blocks

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -63,7 +63,7 @@ export interface Net {
 export interface Eth {
   blockNumber(requestId?: string): Promise<string>;
 
-  call(call: any, blockParam: string | null, requestId?: string): Promise<string | JsonRpcError>;
+  call(call: any, blockParam: string | object | null, requestId?: string): Promise<string | JsonRpcError>;
 
   coinbase(requestId?: string): JsonRpcError;
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -366,9 +366,9 @@ export class MirrorNodeClient {
     return this.request(path, pathLabel, 'GET', null, requestIdPrefix, retries);
   }
 
-  async post(path: string, data: any, pathLabel: string, requestIdPrefix?: string): Promise<any> {
+  async post(path: string, data: any, pathLabel: string, requestIdPrefix?: string, retries?: number): Promise<any> {
     if (!data) data = {};
-    return this.request(path, pathLabel, 'POST', data, requestIdPrefix);
+    return this.request(path, pathLabel, 'POST', data, requestIdPrefix, retries);
   }
 
   handleError(
@@ -979,6 +979,7 @@ export class MirrorNodeClient {
       callData,
       MirrorNodeClient.CONTRACT_CALL_ENDPOINT,
       requestIdPrefix,
+      1, // historical blocks might need 1 retry due to possible timeout from mirror node
     );
   }
 

--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -282,4 +282,10 @@ export const predefined = {
       code: -32203,
       message: `Batch request amount ${amount} exceeds max ${max}`,
     }),
+  INVALID_ARGUMENTS: (message: string) =>
+    new JsonRpcError({
+      name: 'Invalid argument',
+      code: -32000,
+      message: `Invalid arguments: ${message}`,
+    }),
 };


### PR DESCRIPTION
**Description**:
Adding support for eth_call historical blocks, also for receiving a blockHash in the format: { "blockHash": "<blockHash>" } or BlockNumber in the format: { "blockNumber": "0x0" }

Also allow 1 retry to mirror node, due to possible 504 or timeout when querying historical blocks

**Related issue(s)**:

Fixes #2119 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
