### PR TITLE
fix: increase actions/checkout version to v4

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -3,6 +3,7 @@ name: Release Integration Environment
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   OWNER: hashgraph
@@ -28,6 +29,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
 
       - name: Build and push images
         uses: docker/build-push-action@v2

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
 
       - name: Build and push images
         uses: docker/build-push-action@v2


### PR DESCRIPTION
**Description**:
Currently the release production GH workflow is stuck at `Set up Docker Buildx` due to a network error, that might be caused due to the node fetch version.

This might or not fix the issue.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
