### PR TITLE
fix: update `build-push-action` to v5

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v5
         with:
+          network: host
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64, linux/arm64

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -34,7 +34,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Build and push images
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v5
         with:
+          network: host
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64, linux/arm64


### PR DESCRIPTION
**Description**:
increase build-push-action to v5 in order to use Node20, and solve the fetch issue

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
