### PR TITLE
fix: reverting node:18.18.2-bullseye-slim to unblock release process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.19.1-bullseye-slim
+FROM node:18.18.2-bullseye-slim
 
 # Setup
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
**Description**:
After the update to 18.19.1 version of node, the docker build process broke, both for production and integration release workflows.

This PR reverts that upgrade to unblock the release process.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

The release integration and also production release process broke due to the following auto update of node version:
https://github.com/hashgraph/hedera-json-rpc-relay/pull/2120


After reverting was able to get the pipeline to succed:
https://github.com/hashgraph/hedera-json-rpc-relay/actions/workflows/release-integration.yml

![image](https://github.com/hashgraph/hedera-json-rpc-relay/assets/123040664/4a3fa42a-1915-4fd7-940d-4d2ab0849b03)



**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
