### PR TITLE
adding logs for eth_call size and gas

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1455,9 +1455,15 @@ export class EthImpl implements Eth {
    * @param blockParam
    */
   async call(call: any, blockParam: string | object | null, requestIdPrefix?: string): Promise<string | JsonRpcError> {
+    const callData = call.data ? call.data : call.value;
+    // log request
     this.logger.trace(
-      `${requestIdPrefix} call({to=${call.to}, from=${call.from}, value=${call.value}, gas=${call.gas}, ...}, blockParam=${blockParam})`,
+      `${requestIdPrefix} call({to=${call.to}, from=${call.from}, data=${callData}, gas=${call.gas}, ...}, blockParam=${blockParam})`,
     );
+    // log call data size and gas
+    const callDataSize = callData ? callData.length : 0;
+    this.logger.trace(`${requestIdPrefix} call data size: ${callDataSize}, gas: ${call.gas}`);
+    // metrics for selector
     if (call.data?.length >= constants.FUNCTION_SELECTOR_CHAR_LENGTH)
       this.ethExecutionsCounter
         .labels(EthImpl.ethCall, call.data.substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH))


### PR DESCRIPTION
**Description**:
adding logs for eth_call size and gas

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
This is how the logs look like:
```
[2024-02-23 00:21:55.278 +0000] TRACE (relay-eth/936 on Admins-Laptop.local): [Request ID: 42b67952-6968-4d1d-a566-a61e6986a0f7] call({to=0x5555555555555555555555555555555555555555, from=0xf66068b5f4b589b2e43b6b4b158851ef472610c6, data=0x5c36b186, gas=0x7530, ...}, blockParam=latest)
[2024-02-23 00:21:55.279 +0000] TRACE (relay-eth/936 on Admins-Laptop.local): [Request ID: 42b67952-6968-4d1d-a566-a61e6986a0f7] call data size: 10, gas: 0x7530

```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
