### PR TITLE
fix: cherry-pick #2140 reverting node:18.18.2-bullseye-slim to unblock release process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.19.1-bullseye-slim
+FROM node:18.18.2-bullseye-slim
 
 # Setup
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
**Description**:
Cherry pick 2140

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
