### PR TITLE
fix: trimmed preceding zeros for gas value (#2174)

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -181,6 +181,10 @@ const prepend0x = (input: string): string => {
   return input.startsWith(EMPTY_HEX) ? input : EMPTY_HEX + input;
 };
 
+const trimPrecedingZeros = (input: string) => {
+  return parseInt(input, 16).toString(16);
+};
+
 const numberTo0x = (input: number | BigNumber | bigint): string => {
   return EMPTY_HEX + input.toString(16);
 };
@@ -251,6 +255,7 @@ export {
   toNullableBigNumber,
   toNullIfEmptyHex,
   generateRandomHex,
+  trimPrecedingZeros,
   weibarHexToTinyBarInt,
   stringToHex,
   toHexString,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -575,7 +575,7 @@ export class EthImpl implements Eth {
         requestIdPrefix,
       );
 
-      if (contractCallResponse && contractCallResponse.result) {
+      if (contractCallResponse?.result) {
         gas = prepend0x(trimPrecedingZeros(contractCallResponse.result));
       }
     } catch (e: any) {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -39,6 +39,7 @@ import {
   toHash32,
   toNullableBigNumber,
   weibarHexToTinyBarInt,
+  trimPrecedingZeros,
 } from '../formatters';
 import crypto from 'crypto';
 import HAPIService from './services/hapiService/hapiService';
@@ -573,8 +574,9 @@ export class EthImpl implements Eth {
         },
         requestIdPrefix,
       );
-      if (contractCallResponse?.result) {
-        gas = prepend0x(contractCallResponse.result);
+
+      if (contractCallResponse && contractCallResponse.result) {
+        gas = prepend0x(trimPrecedingZeros(contractCallResponse.result));
       }
     } catch (e: any) {
       this.logger.error(

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -265,14 +265,19 @@ describe('Formatters', () => {
 
   describe('trimPrecedingZeros', () => {
     it('should trim all the unnecessary preceding 0s in a hex value', () => {
+      expect(trimPrecedingZeros('0x0000000034')).to.eq('34');
+      expect(trimPrecedingZeros('0x0000039000')).to.eq('39000');
       expect('0x' + trimPrecedingZeros('0x00000000603')).to.eq('0x603');
       expect('0x' + trimPrecedingZeros('0x00000300042')).to.eq('0x300042');
       expect('0x' + trimPrecedingZeros('0x00012000000')).to.eq('0x12000000');
+      expect('0x0' + trimPrecedingZeros('0x0000000025')).to.eq('0x025');
+      expect('0x00' + trimPrecedingZeros('0x000006100')).to.eq('0x006100');
     });
 
     it('should return NaN if inputs are invalid number', () => {
-      expect(trimPrecedingZeros('Hedera')).to.eq('NaN');
+      expect(trimPrecedingZeros('')).to.eq('NaN');
       expect(trimPrecedingZeros('Relay')).to.eq('NaN');
+      expect(trimPrecedingZeros('Hedera')).to.eq('NaN');
     });
   });
 

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -35,6 +35,7 @@ import {
   toNullIfEmptyHex,
   weibarHexToTinyBarInt,
   isValidEthereumAddress,
+  trimPrecedingZeros,
 } from '../../src/formatters';
 import constants from '../../src/lib/constants';
 import { BigNumber as BN } from 'bignumber.js';
@@ -259,6 +260,19 @@ describe('Formatters', () => {
     });
     it('should not add prefix if the string is already prefixed', () => {
       expect(prepend0x('0x5644')).to.equal('0x5644');
+    });
+  });
+
+  describe('trimPrecedingZeros', () => {
+    it('should trim all the unnecessary preceding 0s in a hex value', () => {
+      expect('0x' + trimPrecedingZeros('0x00000000603')).to.eq('0x603');
+      expect('0x' + trimPrecedingZeros('0x00000300042')).to.eq('0x300042');
+      expect('0x' + trimPrecedingZeros('0x00012000000')).to.eq('0x12000000');
+    });
+
+    it('should return NaN if inputs are invalid number', () => {
+      expect(trimPrecedingZeros('Hedera')).to.eq('NaN');
+      expect(trimPrecedingZeros('Relay')).to.eq('NaN');
     });
   });
 

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -267,15 +267,15 @@ describe('Formatters', () => {
     it('should trim all the unnecessary preceding 0s in a hex value', () => {
       expect(trimPrecedingZeros('0x0000000034')).to.eq('34');
       expect(trimPrecedingZeros('0x0000039000')).to.eq('39000');
+      expect('0x' + trimPrecedingZeros('0x0')).to.eq('0x0');
       expect('0x' + trimPrecedingZeros('0x00000000603')).to.eq('0x603');
       expect('0x' + trimPrecedingZeros('0x00000300042')).to.eq('0x300042');
       expect('0x' + trimPrecedingZeros('0x00012000000')).to.eq('0x12000000');
-      expect('0x0' + trimPrecedingZeros('0x0000000025')).to.eq('0x025');
-      expect('0x00' + trimPrecedingZeros('0x000006100')).to.eq('0x006100');
     });
 
     it('should return NaN if inputs are invalid number', () => {
       expect(trimPrecedingZeros('')).to.eq('NaN');
+      expect(trimPrecedingZeros('0x')).to.eq('NaN');
       expect(trimPrecedingZeros('Relay')).to.eq('NaN');
       expect(trimPrecedingZeros('Hedera')).to.eq('NaN');
     });

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -63,7 +63,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
   const ONE_WEIBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 18)));
 
   const BASIC_CONTRACT_PING_CALL_DATA = '0x5c36b186';
-  const PING_CALL_ESTIMATED_GAS = '0x0000000000006122';
+  const PING_CALL_ESTIMATED_GAS = '0x6122';
   const EXCHANGE_RATE_FILE_ID = '0.0.112';
   const EXCHANGE_RATE_FILE_CONTENT_DEFAULT = '0a1008b0ea0110f9bb1b1a0608f0cccf9306121008b0ea0110e9c81a1a060880e9cf9306';
   const FEE_SCHEDULE_FILE_ID = '0.0.111';


### PR DESCRIPTION
**Description**:
- added a quick helper method to convert the long zero gas value to a decimal value and revert it back to a hexadecimal value. This ensures that the gas value remains intact during the trimming process.
- fixed corresponded unit test

**Related issue(s)**:

Fixes #2174

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
