### PR TITLE
fix: resolved evm addresses for `from` and `to` addresses in returned transactions

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2004,8 +2004,18 @@ export class EthImpl implements Eth {
       throw predefined.MAX_BLOCK_SIZE(blockResponse.count);
     }
 
+    // prepare transactionArray
+    let transactionArray: any[] = [];
+    for (const contractResult of contractResults) {
+      contractResult.from = await this.resolveEvmAddress(contractResult.from, requestIdPrefix, [
+        constants.TYPE_ACCOUNT,
+      ]);
+      contractResult.to = await this.resolveEvmAddress(contractResult.to, requestIdPrefix);
+
+      transactionArray.push(showDetails ? formatContractResult(contractResult) : contractResult.hash);
+    }
+
     const blockHash = toHash32(blockResponse.hash);
-    const transactionArray = contractResults.map((cr) => (showDetails ? formatContractResult(cr) : cr.hash));
     // Gating feature in case of unexpected behavior with other apps.
     if (this.shouldPopulateSyntheticContractResults) {
       this.filterAndPopulateSyntheticContractResults(showDetails, logs, transactionArray, requestIdPrefix);

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -376,6 +376,14 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             await mirrorNode.get(`/contracts/${res.contract_id}/results/${res.timestamp}`, requestId),
           );
         }
+
+        // resolve EVM address for `from` and `to`
+        for (const mirrorTx of mirrorTransactions) {
+          const fromAccountInfo = await mirrorNode.get(`/accounts/${mirrorTx.from}`);
+          const toAccountInfo = await mirrorNode.get(`/accounts/${mirrorTx.to}`);
+          mirrorTx.from = fromAccountInfo.evm_address;
+          mirrorTx.to = toAccountInfo.evm_address;
+        }
       });
 
       it('should execute "eth_getBlockByHash", hydrated transactions = false', async function () {

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -65,7 +65,15 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
     const fromAccountInfo = await mirrorNode.get(`/accounts/${tx.from}`);
     const toAccountInfo = await mirrorNode.get(`/accounts/${tx.to}`);
 
-    return { from: fromAccountInfo.evm_address, to: toAccountInfo.evm_address };
+    if (fromAccountInfo) {
+      tx.from = fromAccountInfo.evm_address ?? tx.from;
+    }
+
+    if (toAccountInfo) {
+      tx.to = toAccountInfo.evm_address ?? tx.to;
+    }
+
+    return { from: tx.from, to: tx.to };
   };
 
   describe('RPC Server Acceptance Tests', function () {


### PR DESCRIPTION
**Description**:
- resolved long zero addresses to EVM addresses for the following RPC endpoints:
   - `eth_getTransactionByBlockHashAndIndex`
   - `eth_getTransactionByBlockNumberAndIndex `
   - `eth_getBlockByHash`
   - `eth_getBlockByNumber`

- fixed unit tests where necessary


**Related issue(s)**:

Fixes #2128 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
