### PR TITLE
fix: HotFix for using mSet instead of Set for redis cache when storing synthetic transactions

### DIFF
--- a/packages/relay/src/lib/clients/cache/ICacheClient.ts
+++ b/packages/relay/src/lib/clients/cache/ICacheClient.ts
@@ -23,5 +23,5 @@ export interface ICacheClient {
   set(key: string, value: any, callingMethod: string, ttl?: number, requestIdPrefix?: string): void;
   delete(key: string, callingMethod: string, requestIdPrefix?: string): void;
   clear(): void;
-  mSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string, batchSize?: number): void;
+  multiSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): void;
 }

--- a/packages/relay/src/lib/clients/cache/ICacheClient.ts
+++ b/packages/relay/src/lib/clients/cache/ICacheClient.ts
@@ -23,4 +23,5 @@ export interface ICacheClient {
   set(key: string, value: any, callingMethod: string, ttl?: number, requestIdPrefix?: string): void;
   delete(key: string, callingMethod: string, requestIdPrefix?: string): void;
   clear(): void;
+  mSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string, batchSize?: number): void;
 }

--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -137,7 +137,7 @@ export class LocalLRUCache implements ICacheClient {
    * @param requestIdPrefix - Optional request ID prefix for logging.
    * @returns {Promise<void>} A Promise that resolves when the values are cached.
    */
-  public mSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): void {
+  public multiSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): void {
     // Iterate over each entry in the keyValuePairs object
     for (const [key, value] of Object.entries(keyValuePairs)) {
       this.set(key, value, callingMethod, undefined, requestIdPrefix);

--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -130,6 +130,21 @@ export class LocalLRUCache implements ICacheClient {
   }
 
   /**
+   * Stores multiple key-value pairs in the cache.
+   *
+   * @param keyValuePairs - An object where each property is a key and its value is the value to be cached.
+   * @param callingMethod - The name of the calling method.
+   * @param requestIdPrefix - Optional request ID prefix for logging.
+   * @returns {Promise<void>} A Promise that resolves when the values are cached.
+   */
+  public mSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): void {
+    // Iterate over each entry in the keyValuePairs object
+    for (const [key, value] of Object.entries(keyValuePairs)) {
+      this.set(key, value, callingMethod, undefined, requestIdPrefix);
+    }
+  }
+
+  /**
    * Deletes a cached value associated with the given key.
    * Logs the deletion of the cache entry.
    * @param {string} key - The key associated with the cached value to delete.

--- a/packages/relay/src/lib/clients/cache/redisCache.ts
+++ b/packages/relay/src/lib/clients/cache/redisCache.ts
@@ -138,6 +138,28 @@ export class RedisCache implements ICacheClient {
   }
 
   /**
+   * Stores multiple key-value pairs in the cache.
+   *
+   * @param keyValuePairs - An object where each property is a key and its value is the value to be cached.
+   * @param callingMethod - The name of the calling method.
+   * @param requestIdPrefix - Optional request ID prefix for logging.
+   * @returns {Promise<void>} A Promise that resolves when the values are cached.
+   */
+  async mSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): Promise<void> {
+    // Serialize values
+    const serializedKeyValuePairs: Record<string, string> = {};
+    for (const [key, value] of Object.entries(keyValuePairs)) {
+      serializedKeyValuePairs[key] = JSON.stringify(value);
+    }
+
+    // Perform mSet operation
+    await this.client.mSet(serializedKeyValuePairs);
+
+    // Log the operation
+    this.logger.trace(`${requestIdPrefix} caching multiple keys via ${callingMethod}`);
+  }
+
+  /**
    * Deletes a value from the cache.
    *
    * @param {string} key - The cache key.

--- a/packages/relay/src/lib/clients/cache/redisCache.ts
+++ b/packages/relay/src/lib/clients/cache/redisCache.ts
@@ -145,7 +145,7 @@ export class RedisCache implements ICacheClient {
    * @param requestIdPrefix - Optional request ID prefix for logging.
    * @returns {Promise<void>} A Promise that resolves when the values are cached.
    */
-  async mSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): Promise<void> {
+  async multiSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): Promise<void> {
     // Serialize values
     const serializedKeyValuePairs: Record<string, string> = {};
     for (const [key, value] of Object.entries(keyValuePairs)) {
@@ -156,7 +156,8 @@ export class RedisCache implements ICacheClient {
     await this.client.mSet(serializedKeyValuePairs);
 
     // Log the operation
-    this.logger.trace(`${requestIdPrefix} caching multiple keys via ${callingMethod}`);
+    const entriesLength = Object.keys(keyValuePairs).length;
+    this.logger.trace(`${requestIdPrefix} caching multiple keys via ${callingMethod}, total keys: ${entriesLength}`);
   }
 
   /**

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2079,7 +2079,7 @@ export class EthImpl implements Eth {
     }
     // cache the whole array using mSet
     if (Object.keys(keyValuePairs).length > 0) {
-      this.cacheService.mSet(keyValuePairs, EthImpl.ethGetBlockByHash, requestIdPrefix);
+      this.cacheService.multiSet(keyValuePairs, EthImpl.ethGetBlockByHash, requestIdPrefix, true);
     }
   }
 

--- a/packages/relay/src/lib/services/cacheService/cacheService.ts
+++ b/packages/relay/src/lib/services/cacheService/cacheService.ts
@@ -233,21 +233,19 @@ export class CacheService {
     if (shared && this.isSharedCacheEnabled) {
       try {
         this.cacheMethodsCounter.labels(callingMethod, CacheService.cacheTypes.REDIS, CacheService.methods.MSET).inc(1);
-        this.sharedCache.mSet(entries, callingMethod, requestIdPrefix);
+        this.sharedCache.multiSet(entries, callingMethod, requestIdPrefix);
       } catch (error) {
         const redisError = new RedisCacheError(error);
         this.logger.error(
           `${requestIdPrefix} Error occurred while setting the cache to Redis. Fallback to internal cache. Error is: ${redisError.fullError}`,
         );
-        // Fallback to internal cache for each failed key-value pair individually
-        for (const [key, value] of Object.entries(entries)) {
-          this.internalCache.set(key, value, callingMethod, undefined, requestIdPrefix);
-        }
+        // Fallback to internal cache
+        this.internalCache.multiSet(entries, callingMethod, requestIdPrefix);
       }
     } else {
       this.cacheMethodsCounter.labels(callingMethod, CacheService.cacheTypes.LRU, CacheService.methods.MSET).inc(1);
 
-      this.internalCache.mSet(entries, callingMethod, requestIdPrefix);
+      this.internalCache.multiSet(entries, callingMethod, requestIdPrefix);
     }
   }
 

--- a/packages/relay/src/lib/services/cacheService/cacheService.ts
+++ b/packages/relay/src/lib/services/cacheService/cacheService.ts
@@ -232,8 +232,8 @@ export class CacheService {
   ): void {
     if (shared && this.isSharedCacheEnabled) {
       try {
-        this.cacheMethodsCounter.labels(callingMethod, CacheService.cacheTypes.REDIS, CacheService.methods.MSET).inc(1);
         this.sharedCache.multiSet(entries, callingMethod, requestIdPrefix);
+        this.cacheMethodsCounter.labels(callingMethod, CacheService.cacheTypes.REDIS, CacheService.methods.MSET).inc(1);
       } catch (error) {
         const redisError = new RedisCacheError(error);
         this.logger.error(
@@ -241,11 +241,11 @@ export class CacheService {
         );
         // Fallback to internal cache
         this.internalCache.multiSet(entries, callingMethod, requestIdPrefix);
+        this.cacheMethodsCounter.labels(callingMethod, CacheService.cacheTypes.LRU, CacheService.methods.MSET).inc(1);
       }
     } else {
-      this.cacheMethodsCounter.labels(callingMethod, CacheService.cacheTypes.LRU, CacheService.methods.MSET).inc(1);
-
       this.internalCache.multiSet(entries, callingMethod, requestIdPrefix);
+      this.cacheMethodsCounter.labels(callingMethod, CacheService.cacheTypes.LRU, CacheService.methods.MSET).inc(1);
     }
   }
 

--- a/packages/relay/src/lib/services/cacheService/cacheService.ts
+++ b/packages/relay/src/lib/services/cacheService/cacheService.ts
@@ -224,11 +224,11 @@ export class CacheService {
    * @param {string} requestIdPrefix - A prefix to include in log messages (optional).
    * @param {boolean} shared - Whether to use the shared cache (optional, default: false).
    */
-  public mSet(
+  public multiSet(
     entries: Record<string, any>,
     callingMethod: string,
     requestIdPrefix?: string,
-    shared: boolean = false,
+    shared: boolean = true,
   ): void {
     if (shared && this.isSharedCacheEnabled) {
       try {

--- a/packages/relay/tests/lib/services/cacheService/cacheService.spec.ts
+++ b/packages/relay/tests/lib/services/cacheService/cacheService.spec.ts
@@ -76,6 +76,20 @@ describe('CacheService Test Suite', async function () {
 
       expect(cachedValue).eq(value);
     });
+
+    it('should be able to set using multiSet and get them separately', async function () {
+      const entries: Record<string, any> = {};
+      entries['key1'] = 'value1';
+      entries['key2'] = 'value2';
+      entries['key3'] = 'value3';
+
+      cacheService.multiSet(entries, callingMethod, undefined, true);
+
+      for (const [key, value] of Object.entries(entries)) {
+        const valueFromCache = cacheService.getSharedWithFallback(key, callingMethod, undefined);
+        expect(valueFromCache).eq(value);
+      }
+    });
   });
 
   describe('Shared Cache Test Suite', async function () {
@@ -136,6 +150,20 @@ describe('CacheService Test Suite', async function () {
       const cachedValue = await cacheService.getSharedWithFallback(key, callingMethod, undefined);
 
       expect(cachedValue).eq(value);
+    });
+
+    it('should be able to set using multiSet and get them separately using internal cache', async function () {
+      const entries: Record<string, any> = {};
+      entries['key1'] = 'value1';
+      entries['key2'] = 'value2';
+      entries['key3'] = 'value3';
+
+      cacheService.multiSet(entries, callingMethod, undefined, false);
+
+      for (const [key, value] of Object.entries(entries)) {
+        const valueFromCache = cacheService.getSharedWithFallback(key, callingMethod, undefined);
+        expect(valueFromCache).eq(value);
+      }
     });
   });
 });


### PR DESCRIPTION
**Description**:

- Added method interface `mSet` for ICacheClient
- Implemented method on both cache clients: Redis and Local
- Added method mSet to cache service
- Refactored method `filterAndPopulateSyntheticContractResults` to use mSet instead of set.

**Related issue(s)**:

Fixes # 


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
