### PR TITLE
fix: HotFix for using mSet instead of Set for redis cache

### DIFF
--- a/packages/relay/src/lib/clients/cache/ICacheClient.ts
+++ b/packages/relay/src/lib/clients/cache/ICacheClient.ts
@@ -23,4 +23,5 @@ export interface ICacheClient {
   set(key: string, value: any, callingMethod: string, ttl?: number, requestIdPrefix?: string): void;
   delete(key: string, callingMethod: string, requestIdPrefix?: string): void;
   clear(): void;
+  multiSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): void;
 }

--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -130,6 +130,21 @@ export class LocalLRUCache implements ICacheClient {
   }
 
   /**
+   * Stores multiple key-value pairs in the cache.
+   *
+   * @param keyValuePairs - An object where each property is a key and its value is the value to be cached.
+   * @param callingMethod - The name of the calling method.
+   * @param requestIdPrefix - Optional request ID prefix for logging.
+   * @returns {Promise<void>} A Promise that resolves when the values are cached.
+   */
+  public multiSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): void {
+    // Iterate over each entry in the keyValuePairs object
+    for (const [key, value] of Object.entries(keyValuePairs)) {
+      this.set(key, value, callingMethod, undefined, requestIdPrefix);
+    }
+  }
+
+  /**
    * Deletes a cached value associated with the given key.
    * Logs the deletion of the cache entry.
    * @param {string} key - The key associated with the cached value to delete.

--- a/packages/relay/src/lib/clients/cache/redisCache.ts
+++ b/packages/relay/src/lib/clients/cache/redisCache.ts
@@ -138,6 +138,29 @@ export class RedisCache implements ICacheClient {
   }
 
   /**
+   * Stores multiple key-value pairs in the cache.
+   *
+   * @param keyValuePairs - An object where each property is a key and its value is the value to be cached.
+   * @param callingMethod - The name of the calling method.
+   * @param requestIdPrefix - Optional request ID prefix for logging.
+   * @returns {Promise<void>} A Promise that resolves when the values are cached.
+   */
+  async multiSet(keyValuePairs: Record<string, any>, callingMethod: string, requestIdPrefix?: string): Promise<void> {
+    // Serialize values
+    const serializedKeyValuePairs: Record<string, string> = {};
+    for (const [key, value] of Object.entries(keyValuePairs)) {
+      serializedKeyValuePairs[key] = JSON.stringify(value);
+    }
+
+    // Perform mSet operation
+    await this.client.mSet(serializedKeyValuePairs);
+
+    // Log the operation
+    const entriesLength = Object.keys(keyValuePairs).length;
+    this.logger.trace(`${requestIdPrefix} caching multiple keys via ${callingMethod}, total keys: ${entriesLength}`);
+  }
+
+  /**
    * Deletes a value from the cache.
    *
    * @param {string} key - The cache key.

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2095,6 +2095,8 @@ export class EthImpl implements Eth {
     requestIdPrefix?: string,
   ): void {
     let filteredLogs: Log[];
+    const keyValuePairs: Record<string, any> = {}; // Object to accumulate cache entries
+
     if (showDetails) {
       filteredLogs = logs.filter(
         (log) => !transactionArray.some((transaction) => transaction.hash === log.transactionHash),
@@ -2104,14 +2106,7 @@ export class EthImpl implements Eth {
         transactionArray.push(transaction);
 
         const cacheKey = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${log.transactionHash}`;
-        this.cacheService.set(
-          cacheKey,
-          log,
-          EthImpl.ethGetBlockByHash,
-          this.syntheticLogCacheTtl,
-          requestIdPrefix,
-          true,
-        );
+        keyValuePairs[cacheKey] = log;
       });
     } else {
       filteredLogs = logs.filter((log) => !transactionArray.includes(log.transactionHash));
@@ -2119,19 +2114,16 @@ export class EthImpl implements Eth {
         transactionArray.push(log.transactionHash);
 
         const cacheKey = `${constants.CACHE_KEY.SYNTHETIC_LOG_TRANSACTION_HASH}${log.transactionHash}`;
-        this.cacheService.set(
-          cacheKey,
-          log,
-          EthImpl.ethGetBlockByHash,
-          this.syntheticLogCacheTtl,
-          requestIdPrefix,
-          true,
-        );
+        keyValuePairs[cacheKey] = log;
       });
 
       this.logger.trace(
         `${requestIdPrefix} ${filteredLogs.length} Synthetic transaction hashes will be added in the block response`,
       );
+    }
+    // cache the whole array using mSet
+    if (Object.keys(keyValuePairs).length > 0) {
+      this.cacheService.multiSet(keyValuePairs, EthImpl.ethGetBlockByHash, requestIdPrefix, true);
     }
   }
 

--- a/packages/relay/tests/lib/services/cacheService/cacheService.spec.ts
+++ b/packages/relay/tests/lib/services/cacheService/cacheService.spec.ts
@@ -76,6 +76,20 @@ describe('CacheService Test Suite', async function () {
 
       expect(cachedValue).eq(value);
     });
+
+    it('should be able to set using multiSet and get them separately', async function () {
+      const entries: Record<string, any> = {};
+      entries['key1'] = 'value1';
+      entries['key2'] = 'value2';
+      entries['key3'] = 'value3';
+
+      cacheService.multiSet(entries, callingMethod, undefined, true);
+
+      for (const [key, value] of Object.entries(entries)) {
+        const valueFromCache = cacheService.getSharedWithFallback(key, callingMethod, undefined);
+        expect(valueFromCache).eq(value);
+      }
+    });
   });
 
   describe('Shared Cache Test Suite', async function () {
@@ -136,6 +150,20 @@ describe('CacheService Test Suite', async function () {
       const cachedValue = await cacheService.getSharedWithFallback(key, callingMethod, undefined);
 
       expect(cachedValue).eq(value);
+    });
+
+    it('should be able to set using multiSet and get them separately using internal cache', async function () {
+      const entries: Record<string, any> = {};
+      entries['key1'] = 'value1';
+      entries['key2'] = 'value2';
+      entries['key3'] = 'value3';
+
+      cacheService.multiSet(entries, callingMethod, undefined, false);
+
+      for (const [key, value] of Object.entries(entries)) {
+        const valueFromCache = cacheService.getSharedWithFallback(key, callingMethod, undefined);
+        expect(valueFromCache).eq(value);
+      }
     });
   });
 });


### PR DESCRIPTION
**Description**:
Cherry-Pick of HotFix https://github.com/hashgraph/hedera-json-rpc-relay/pull/2197

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
