### PR TITLE
fix: added support for legacy pre EIP 155 transactions with no chainID (chainId=0x0)

### DIFF
--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -100,7 +100,7 @@ export class Precheck {
   chainId(tx: Transaction, requestId?: string) {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     const txChainId = prepend0x(Number(tx.chainId).toString(16));
-    const passes = txChainId === this.chain;
+    const passes = txChainId === '0x0' || txChainId === this.chain;
     if (!passes) {
       this.logger.trace(
         `${requestIdPrefix} Failed chainId precheck for sendRawTransaction(transaction=%s, chainId=%s)`,

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -100,7 +100,7 @@ export class Precheck {
   chainId(tx: Transaction, requestId?: string) {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     const txChainId = prepend0x(Number(tx.chainId).toString(16));
-    const passes = txChainId === '0x0' || txChainId === this.chain;
+    const passes = this.isLegacyUnprotectedEtx(tx) || txChainId === this.chain;
     if (!passes) {
       this.logger.trace(
         `${requestIdPrefix} Failed chainId precheck for sendRawTransaction(transaction=%s, chainId=%s)`,
@@ -109,6 +109,17 @@ export class Precheck {
       );
       throw predefined.UNSUPPORTED_CHAIN_ID(txChainId, this.chain);
     }
+  }
+
+  /**
+   * Checks if the transaction is an (unprotected) pre-EIP155 transaction.
+   * Conditions include chainId being 0x0 and the signature's v value being either 27 or 28.
+   * @param tx the Ethereum transaction
+   */
+  isLegacyUnprotectedEtx(tx: Transaction): boolean {
+    const chainId = tx.chainId;
+    const vValue = tx.signature?.v;
+    return chainId === BigInt(0) && (vValue === 27 || vValue === 28);
   }
 
   /**

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -42,8 +42,11 @@ describe('Precheck', async function () {
     '0x02f87482012a0485a7a358200085a7a3582000832dc6c09400000000000000000000000000000000000003f78502540be40080c001a006f4cd8e6f84b76a05a5c1542a08682c928108ef7163d9c1bf1f3b636b1cd1fba032097cbf2dda17a2dcc40f62c97964d9d930cdce2e8a9df9a8ba023cda28e4ad';
   const parsedTxWithMatchingChainId = ethers.Transaction.from(txWithMatchingChainId);
   const parsedTxGasPrice = 1440000000000;
-  const txWithNonMatchingChainId =
+  const txWithChainId0x0 =
     '0xf86a0385a7a3582000832dc6c09400000000000000000000000000000000000003f78502540be400801ca06750e92db52fa708e27f94f27e0cfb7f5800f9b657180bb2e94c1520cfb1fb6da01bec6045068b6db38b55017bb8b50166699384bc1791fd8331febab0cf629a2a';
+  const parsedtxWithChainId0x0 = ethers.Transaction.from(txWithChainId0x0);
+  const txWithNonMatchingChainId =
+    '0xf86c8085a54f4c3c00832dc6c094000000000000000000000000000000000000042f8502540be40080820306a0fe71ab0077a58d112eecc7f95b9a7563ffdc14a45440cc1b2c698dbb1a687abea063ba3725ae54118f45999f5b53b38ba67b61f2365965784a81b9b47f37b78c10';
   const parsedTxWithNonMatchingChainId = ethers.Transaction.from(txWithNonMatchingChainId);
   const txWithValueMoreThanOneTinyBar =
     '0xf8628080809449858d4445908c12fcf70251d3f4682e8c9c381085174876e800801ba015ec73d3e329c7f5c0228be39bf30758f974d69468847dd507082c89ec453fe2a04124cc1dd6ac07417e7cdbe04cb99d698bddc6ce4d04054dd8978dec3493f3d2';
@@ -133,6 +136,14 @@ describe('Precheck', async function () {
       }
     });
 
+    it('should pass when chainId=0x0', async function () {
+      try {
+        precheck.chainId(parsedtxWithChainId0x0);
+      } catch (e: any) {
+        expect(e).to.not.exist;
+      }
+    });
+
     it('should not pass for non-matching chainId', async function () {
       try {
         precheck.chainId(parsedTxWithNonMatchingChainId);
@@ -140,7 +151,7 @@ describe('Precheck', async function () {
       } catch (e: any) {
         expect(e).to.exist;
         expect(e.code).to.eq(-32000);
-        expect(e.message).to.eq('ChainId (0x0) not supported. The correct chainId is 0x12a');
+        expect(e.message).to.eq('ChainId (0x171) not supported. The correct chainId is 0x12a');
       }
     });
   });

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -154,6 +154,15 @@ describe('Precheck', async function () {
         expect(e.message).to.eq('ChainId (0x171) not supported. The correct chainId is 0x12a');
       }
     });
+
+    it('Should check if a transaction is an unprotected pre-EIP155 transaction', function () {
+      try {
+        expect(precheck.isLegacyUnprotectedEtx(parsedtxWithChainId0x0)).to.be.true;
+        expect(precheck.isLegacyUnprotectedEtx(parsedTxWithMatchingChainId)).to.be.false;
+      } catch (e: any) {
+        expect(e).to.not.exist;
+      }
+    });
   });
 
   describe('gasLimit', async function () {


### PR DESCRIPTION
**Description**:
This PR introduces a check method, `isLegacyUnprotectedEtx()`, within the `precheck` class and utilized it in `precheck.chainId()`, allows for compatibility with pre EIP 155 transactions (`chainId=0x0`, default `v = {27, 28}`). Additionally, the PR added new UT coverage for the update and resolves any related UT issues.

**Related issue(s)**:

Fixes #2201 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
