### PR TITLE
feat: remove block range limit in `eth_getLogs` when filtering with a single address

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -402,7 +402,7 @@
         {
             "name": "eth_getLogs",
             "summary": "Returns an array of all logs matching a given filter object.",
-            "description": "The block range filter, _i.e._, `fromBlock` and `toBlock` arguments, cannot be larger than `ETH_GET_LOGS_BLOCK_RANGE_LIMIT` (defaults to `1000`). However, when `address` represents a single address, either a `string` or an array with a single element, this restriction is lifted.",
+            "description": "The block range filter, _i.e._, `fromBlock` and `toBlock` arguments, cannot be larger than `ETH_GET_LOGS_BLOCK_RANGE_LIMIT` (defaults to `1000`). However, when `address` represents a single address, either a `string` or an array with a single element, this restriction is lifted.\n\nWhen the logs for an individual address exceeds the Mirror Node page limit `MIRROR_NODE_CONTRACT_RESULTS_LOGS_PG_MAX` (defaults to `200`) an error `-32011` _Mirror Node pagination count range too large_ is returned.",
             "params": [
                 {
                     "name": "Filter",

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -401,7 +401,8 @@
         },
         {
             "name": "eth_getLogs",
-            "summary": "Returns an array of all logs matching filter with given id.",
+            "summary": "Returns an array of all logs matching a given filter object.",
+            "description": "The block range filter, _i.e._, `fromBlock` and `toBlock` arguments, cannot be larger than `ETH_GET_LOGS_BLOCK_RANGE_LIMIT` (defaults to `1000`). However, when `address` represents a single address, either a `string` or an array with a single element, this restriction is lifted.",
             "params": [
                 {
                     "name": "Filter",

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -89,7 +89,7 @@ export interface Eth {
     blockHash: string | null,
     fromBlock: string | null,
     toBlock: string | null,
-    address: string | null,
+    address: string | string[] | null,
     topics: any[] | null,
     requestId?: string,
   ): Promise<Log[]>;

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2287,7 +2287,7 @@ export class EthImpl implements Eth {
     blockHash: string | null,
     fromBlock: string | 'latest',
     toBlock: string | 'latest',
-    address: string | [string] | null,
+    address: string | string[] | null,
     topics: any[] | null,
     requestIdPrefix?: string,
   ): Promise<Log[]> {

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -268,7 +268,7 @@ export class CommonService implements ICommonService {
     }
   }
 
-  public async getLogsByAddress(address: string | [string], params: any, requestIdPrefix) {
+  public async getLogsByAddress(address: string | string[], params: any, requestIdPrefix) {
     const addresses = Array.isArray(address) ? address : [address];
     const logPromises = addresses.map((addr) =>
       this.mirrorNodeClient.getContractResultsLogsByAddress(addr, params, undefined, requestIdPrefix),
@@ -283,7 +283,7 @@ export class CommonService implements ICommonService {
     return logs;
   }
 
-  public async getLogsWithParams(address: string | [string] | null, params, requestIdPrefix?: string): Promise<Log[]> {
+  public async getLogsWithParams(address: string | string[] | null, params, requestIdPrefix?: string): Promise<Log[]> {
     const EMPTY_RESPONSE = [];
 
     let logResults;
@@ -321,7 +321,7 @@ export class CommonService implements ICommonService {
     blockHash: string | null,
     fromBlock: string | 'latest',
     toBlock: string | 'latest',
-    address: string | [string] | null,
+    address: string | string[] | null,
     topics: any[] | null,
     requestIdPrefix?: string,
   ): Promise<Log[]> {

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -74,6 +74,10 @@ export class CommonService implements ICommonService {
     'ETH_BLOCK_NUMBER_CACHE_TTL_MS_DEFAULT',
   );
 
+  private getLogsBlockRangeLimit() {
+    return parseNumericEnvVar('ETH_GET_LOGS_BLOCK_RANGE_LIMIT', 'DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT');
+  }
+
   constructor(mirrorNodeClient: MirrorNodeClient, logger: Logger, cacheService: CacheService) {
     this.mirrorNodeClient = mirrorNodeClient;
     this.logger = logger;
@@ -139,10 +143,9 @@ export class CommonService implements ICommonService {
         return false;
       }
 
-      const blockRangeLimit =
-        process.env.TEST === 'true'
-          ? constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT
-          : Number(process.env.ETH_GET_LOGS_BLOCK_RANGE_LIMIT);
+      const blockRangeLimit = this.getLogsBlockRangeLimit();
+      // Increasing it to more then one address may degrade mirror node performance
+      // when addresses contains many log events.
       const isSingleAddress = Array.isArray(address)
         ? address.length === 1
         : typeof address === 'string' && address !== '';

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -143,8 +143,10 @@ export class CommonService implements ICommonService {
         process.env.TEST === 'true'
           ? constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT
           : Number(process.env.ETH_GET_LOGS_BLOCK_RANGE_LIMIT);
-      const isSingleAddress = Array.isArray(address) ? address.length === 1 : address !== '';
-      if (!isSingleAddress || toBlockNum - fromBlockNum > blockRangeLimit) {
+      const isSingleAddress = Array.isArray(address)
+        ? address.length === 1
+        : typeof address === 'string' && address !== '';
+      if (!isSingleAddress && toBlockNum - fromBlockNum > blockRangeLimit) {
         throw predefined.RANGE_TOO_LARGE(blockRangeLimit);
       }
     }

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -99,12 +99,8 @@ export class CommonService implements ICommonService {
     fromBlock: string,
     toBlock: string,
     requestIdPrefix?: string,
+    address?: string | string[] | null,
   ) {
-    const blockRangeLimit =
-      process.env.TEST === 'true'
-        ? constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT
-        : Number(process.env.ETH_GET_LOGS_BLOCK_RANGE_LIMIT);
-
     if (this.blockTagIsLatestOrPending(toBlock)) {
       toBlock = CommonService.blockLatest;
     }
@@ -141,7 +137,14 @@ export class CommonService implements ICommonService {
 
       if (fromBlockNum > toBlockNum) {
         return false;
-      } else if (toBlockNum - fromBlockNum > blockRangeLimit) {
+      }
+
+      const blockRangeLimit =
+        process.env.TEST === 'true'
+          ? constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT
+          : Number(process.env.ETH_GET_LOGS_BLOCK_RANGE_LIMIT);
+      const isSingleAddress = Array.isArray(address) ? address.length === 1 : address !== '';
+      if (!isSingleAddress || toBlockNum - fromBlockNum > blockRangeLimit) {
         throw predefined.RANGE_TOO_LARGE(blockRangeLimit);
       }
     }
@@ -332,7 +335,9 @@ export class CommonService implements ICommonService {
       if (!(await this.validateBlockHashAndAddTimestampToParams(params, blockHash, requestIdPrefix))) {
         return EMPTY_RESPONSE;
       }
-    } else if (!(await this.validateBlockRangeAndAddTimestampToParams(params, fromBlock, toBlock, requestIdPrefix))) {
+    } else if (
+      !(await this.validateBlockRangeAndAddTimestampToParams(params, fromBlock, toBlock, requestIdPrefix, address))
+    ) {
       return EMPTY_RESPONSE;
     }
 

--- a/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
@@ -282,7 +282,7 @@ describe('@ethGetLogs using MirrorNode', async function () {
   });
 
   [CONTRACT_ADDRESS_1, [CONTRACT_ADDRESS_1]].forEach((address) => {
-    it(`single address filter \`${JSON.stringify(address)}\` and large block range`, async function () {
+    it(`should filter logs by \`${JSON.stringify(address)}\` with a large block range`, async function () {
       const filteredLogs = {
         logs: [DEFAULT_LOGS.logs[0], DEFAULT_LOGS.logs[1], DEFAULT_LOGS.logs[2]],
       };
@@ -479,7 +479,7 @@ describe('@ethGetLogs using MirrorNode', async function () {
   });
 
   [null, [], [CONTRACT_ADDRESS_1, CONTRACT_ADDRESS_2]].forEach((address) => {
-    it(`when block range is too large with address \`${JSON.stringify(address)}\``, async function () {
+    it(`should fail when block range is too large for address(es) \`${JSON.stringify(address)}\``, async function () {
       const fromBlock = {
         ...DEFAULT_BLOCK,
         number: 1,

--- a/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
@@ -282,7 +282,6 @@ describe('@ethGetLogs using MirrorNode', async function () {
   });
 
   [CONTRACT_ADDRESS_1, [CONTRACT_ADDRESS_1]].forEach((address) => {
-    console.log(address);
     it(`single address filter \`${JSON.stringify(address)}\` and large block range`, async function () {
       const filteredLogs = {
         logs: [DEFAULT_LOGS.logs[0], DEFAULT_LOGS.logs[1], DEFAULT_LOGS.logs[2]],

--- a/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
@@ -281,6 +281,46 @@ describe('@ethGetLogs using MirrorNode', async function () {
     expectLogData3(result[2]);
   });
 
+  [CONTRACT_ADDRESS_1, [CONTRACT_ADDRESS_1]].forEach((address) => {
+    console.log(address);
+    it(`single address filter \`${JSON.stringify(address)}\` and large block range`, async function () {
+      const filteredLogs = {
+        logs: [DEFAULT_LOGS.logs[0], DEFAULT_LOGS.logs[1], DEFAULT_LOGS.logs[2]],
+      };
+      restMock.onGet(CONTRACTS_LOGS_WITH_FILTER).reply(200, filteredLogs);
+      for (const log of filteredLogs.logs) {
+        restMock.onGet(`contracts/${log.address}`).reply(200, DEFAULT_CONTRACT);
+      }
+
+      const fromBlock = {
+        ...DEFAULT_BLOCK,
+        number: 1,
+      };
+      const toBlock = {
+        ...DEFAULT_BLOCK,
+        number: 1003,
+      };
+
+      const blockBeyondMaximumRange = {
+        ...DEFAULT_BLOCK,
+        number: 1007,
+      };
+
+      restMock.onGet(BLOCKS_LIMIT_ORDER_URL).reply(200, { blocks: [blockBeyondMaximumRange] });
+      restMock.onGet('blocks/1').reply(200, fromBlock);
+      restMock.onGet('blocks/1003').reply(200, toBlock);
+
+      const result = await ethImpl.getLogs(null, '0x1', '0x3eb', address, null);
+
+      expect(result).to.exist;
+
+      expect(result.length).to.eq(3);
+      expectLogData1(result[0]);
+      expectLogData2(result[1]);
+      expectLogData3(result[2]);
+    });
+  });
+
   it('multiple addresses filter', async function () {
     const filteredLogsAddress1 = {
       logs: [DEFAULT_LOGS.logs[0], DEFAULT_LOGS.logs[1], DEFAULT_LOGS.logs[2]],
@@ -439,27 +479,29 @@ describe('@ethGetLogs using MirrorNode', async function () {
     expectLogData1(result[0]);
   });
 
-  it('when block range is too large', async function () {
-    const fromBlock = {
-      ...DEFAULT_BLOCK,
-      number: 1,
-    };
-    const toBlock = {
-      ...DEFAULT_BLOCK,
-      number: 1003,
-    };
+  [null, [], [CONTRACT_ADDRESS_1, CONTRACT_ADDRESS_2]].forEach((address) => {
+    it(`when block range is too large with address \`${JSON.stringify(address)}\``, async function () {
+      const fromBlock = {
+        ...DEFAULT_BLOCK,
+        number: 1,
+      };
+      const toBlock = {
+        ...DEFAULT_BLOCK,
+        number: 1003,
+      };
 
-    const blockBeyondMaximumRange = {
-      ...DEFAULT_BLOCK,
-      number: 1007,
-    };
+      const blockBeyondMaximumRange = {
+        ...DEFAULT_BLOCK,
+        number: 1007,
+      };
 
-    restMock.onGet(BLOCKS_LIMIT_ORDER_URL).reply(200, { blocks: [blockBeyondMaximumRange] });
-    restMock.onGet('blocks/1').reply(200, fromBlock);
-    restMock.onGet('blocks/1003').reply(200, toBlock);
+      restMock.onGet(BLOCKS_LIMIT_ORDER_URL).reply(200, { blocks: [blockBeyondMaximumRange] });
+      restMock.onGet('blocks/1').reply(200, fromBlock);
+      restMock.onGet('blocks/1003').reply(200, toBlock);
 
-    await ethGetLogsFailing(ethImpl, [null, '0x1', '0x3eb', null, null], (error) => {
-      expect(error.message).to.equal('Exceeded maximum block range: 1000');
+      await ethGetLogsFailing(ethImpl, [null, '0x1', '0x3eb', address, null], (error) => {
+        expect(error.message).to.equal('Exceeded maximum block range: 1000');
+      });
     });
   });
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -268,21 +268,27 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       });
 
       it('should be able to use `address` param with a large block range', async () => {
-        //when we pass only address, it defaults to the latest block
-        const logs = await relay.call(
-          RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS,
-          [
-            {
-              fromBlock: numberTo0x(latestBlock - constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT - 10),
-              address: contractAddress,
-            },
-          ],
-          requestId,
-        );
-        expect(logs.length).to.be.greaterThan(0);
+        const blockRangeLimit = constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT;
+        constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT = 10;
+        try {
+          //when we pass only address, it defaults to the latest block
+          const logs = await relay.call(
+            RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS,
+            [
+              {
+                fromBlock: numberTo0x(latestBlock - constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT - 1),
+                address: contractAddress,
+              },
+            ],
+            requestId,
+          );
+          expect(logs.length).to.be.greaterThan(0);
 
-        for (const i in logs) {
-          expect(logs[i].address).to.equal(contractAddress);
+          for (const i in logs) {
+            expect(logs[i].address).to.equal(contractAddress);
+          }
+        } finally {
+          constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT = blockRangeLimit;
         }
       });
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -267,6 +267,25 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         }
       });
 
+      it('should be able to use `address` param with a large block range', async () => {
+        //when we pass only address, it defaults to the latest block
+        const logs = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS,
+          [
+            {
+              fromBlock: numberTo0x(latestBlock - constants.DEFAULT_ETH_GET_LOGS_BLOCK_RANGE_LIMIT - 10),
+              address: contractAddress,
+            },
+          ],
+          requestId,
+        );
+        expect(logs.length).to.be.greaterThan(0);
+
+        for (const i in logs) {
+          expect(logs[i].address).to.equal(contractAddress);
+        }
+      });
+
       it('should be able to use `address` param with multiple addresses', async () => {
         const logs = await relay.call(
           RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS,


### PR DESCRIPTION
**Description**:

This PR removes the block range limit, _e.g._, 1000, when the filter in the `eth_getLogs` contains a single address (the optional `address` param might be either a string or an addresses array).

This change allows consumers to query all the log entries of the given address. For now, we permit only a single address, but in the future we might relax this constraint as well.

The block range validation is also used in `eth_newFilter`, but it should not be affected by this change.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #2175 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

It also fixes function type signatures, _i.e., use `string[]` instead of `[string]`.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
