### PR TITLE
chore: update hashgraph/sdk to 2.43.0 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9251,7 +9251,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -9614,7 +9613,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -20319,7 +20317,7 @@
       "version": "0.45.0-SNAPSHOT",
       "dependencies": {
         "@ethersproject/asm": "^5.7.0",
-        "@hashgraph/sdk": "2.42.0",
+        "@hashgraph/sdk": "2.43.0",
         "@keyvhq/core": "^1.6.9",
         "axios": "^1.4.0",
         "axios-retry": "^3.5.1",
@@ -20349,9 +20347,9 @@
       }
     },
     "packages/relay/node_modules/@hashgraph/proto": {
-      "version": "2.14.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.4.tgz",
-      "integrity": "sha512-DCmK9CivuVpdDuay1VcYt++Zhms55uu8JZgJI6fBtJuv/WkMuYLNtmnihKcQ39Ykmm8SV6iL6trTziTINHV44g==",
+      "version": "2.14.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.5.tgz",
+      "integrity": "sha512-UrIbLdctpD//Ua99Z4PnknbR8220nc1Pzv0nkDJ1emZE9EAi7YOOry2Dw660azQHWfVw/HhqECPdiKrTIZ2b+Q==",
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "^7.2.5"
@@ -20361,9 +20359,9 @@
       }
     },
     "packages/relay/node_modules/@hashgraph/sdk": {
-      "version": "2.42.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.42.0.tgz",
-      "integrity": "sha512-47E08ZHGRKoZCmJJhbcaFWcAWNPpJfs5F0SvqocDNFHs616+zrAwFDPXqWLtGx3JhyeCZClgpDYvJX7CVBFCtA==",
+      "version": "2.43.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.43.0.tgz",
+      "integrity": "sha512-3MOZDL8Tm+Ciu+e402R9mSPfAUaiv8GCY+G6prUDOJzkNubRGm7gNxpeMlmHDZepc+EOkuq+kOq3QvB+2IvgWQ==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -20371,7 +20369,7 @@
         "@ethersproject/rlp": "^5.7.0",
         "@grpc/grpc-js": "1.8.2",
         "@hashgraph/cryptography": "1.4.8-beta.5",
-        "@hashgraph/proto": "2.14.0-beta.4",
+        "@hashgraph/proto": "2.14.0-beta.5",
         "axios": "^1.6.4",
         "bignumber.js": "^9.1.1",
         "bn.js": "^5.1.1",
@@ -20650,7 +20648,7 @@
       },
       "devDependencies": {
         "@hashgraph/hedera-local": "^2.15.1",
-        "@hashgraph/sdk": "^2.38.0",
+        "@hashgraph/sdk": "2.43.0",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -20667,6 +20665,103 @@
         "ts-mocha": "^9.0.2",
         "ts-node": "^10.8.1",
         "typescript": "^4.5.5"
+      }
+    },
+    "packages/server/node_modules/@hashgraph/proto": {
+      "version": "2.14.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.5.tgz",
+      "integrity": "sha512-UrIbLdctpD//Ua99Z4PnknbR8220nc1Pzv0nkDJ1emZE9EAi7YOOry2Dw660azQHWfVw/HhqECPdiKrTIZ2b+Q==",
+      "dev": true,
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "^7.2.5"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "packages/server/node_modules/@hashgraph/sdk": {
+      "version": "2.43.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.43.0.tgz",
+      "integrity": "sha512-3MOZDL8Tm+Ciu+e402R9mSPfAUaiv8GCY+G6prUDOJzkNubRGm7gNxpeMlmHDZepc+EOkuq+kOq3QvB+2IvgWQ==",
+      "dev": true,
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@grpc/grpc-js": "1.8.2",
+        "@hashgraph/cryptography": "1.4.8-beta.5",
+        "@hashgraph/proto": "2.14.0-beta.5",
+        "axios": "^1.6.4",
+        "bignumber.js": "^9.1.1",
+        "bn.js": "^5.1.1",
+        "crypto-js": "^4.2.0",
+        "js-base64": "^3.7.4",
+        "long": "^4.0.0",
+        "pino": "^8.14.1",
+        "pino-pretty": "^10.0.0",
+        "protobufjs": "^7.2.5",
+        "rfc4648": "^1.5.3",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "expo": "^49.0.16"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "packages/server/node_modules/@hashgraph/sdk/node_modules/pino": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.19.0.tgz",
+      "integrity": "sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==",
+      "dev": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "v1.1.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "packages/server/node_modules/@hashgraph/sdk/node_modules/pino-pretty": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+      "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+      "dev": true,
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
       }
     },
     "packages/server/node_modules/@noble/curves": {
@@ -20692,6 +20787,15 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
       "dev": true
+    },
+    "packages/server/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
     },
     "packages/server/node_modules/ethers": {
       "version": "6.11.1",
@@ -20726,6 +20830,119 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
       "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
       "dev": true
+    },
+    "packages/server/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/server/node_modules/pino-abstract-transport": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "packages/server/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "dev": true
+    },
+    "packages/server/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "dev": true
+    },
+    "packages/server/node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "packages/server/node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "dev": true
+    },
+    "packages/server/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/server/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "packages/server/node_modules/sonic-boom": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
+      "integrity": "sha512-ybz6OYOUjoQQCQ/i4LU8kaToD8ACtYP+Cj5qd2AO36bwbdewxWJ3ArmJ2cr6AvxlL2o0PqnCcPGUgkILbfkaCA==",
+      "dev": true,
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "packages/server/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "packages/server/node_modules/thread-stream": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
+      "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+      "dev": true,
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "packages/server/node_modules/tslib": {
       "version": "2.4.0",
@@ -20776,7 +20993,7 @@
       },
       "devDependencies": {
         "@hashgraph/hedera-local": "^2.15.1",
-        "@hashgraph/sdk": "2.38.0",
+        "@hashgraph/sdk": "2.43.0",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -20794,48 +21011,10 @@
         "typescript": "^4.5.5"
       }
     },
-    "packages/ws-server/node_modules/@hashgraph/cryptography": {
-      "version": "1.4.8-beta.4",
-      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.4.tgz",
-      "integrity": "sha512-43wpRuE6ML04dFNpNPHvEZTKlVT9+dOE7SxyQPMYunsFitJvlIDl1VvOXeOSGbVdsV+nDQQV7C9pZWRSV1e32g==",
-      "dev": true,
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "bignumber.js": "^9.1.1",
-        "bn.js": "^5.2.1",
-        "buffer": "^6.0.3",
-        "crypto-js": "^4.1.1",
-        "elliptic": "^6.5.4",
-        "js-base64": "^3.7.4",
-        "node-forge": "^1.3.1",
-        "spark-md5": "^3.0.2",
-        "tweetnacl": "^1.0.3",
-        "utf8": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "expo": "^45.0.3",
-        "expo-crypto": "^10.1.2",
-        "expo-random": "^12.1.2"
-      },
-      "peerDependenciesMeta": {
-        "expo": {
-          "optional": true
-        },
-        "expo-crypto": {
-          "optional": true
-        },
-        "expo-random": {
-          "optional": true
-        }
-      }
-    },
     "packages/ws-server/node_modules/@hashgraph/proto": {
-      "version": "2.14.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.2.tgz",
-      "integrity": "sha512-LuypRVyDc05podG/FoDlElgirAiBa8LuyKoAdOmZHUQOC3zNA7bFneTkZJR92Oxhnc56++QCLCOsRPjVLOYBcw==",
+      "version": "2.14.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.5.tgz",
+      "integrity": "sha512-UrIbLdctpD//Ua99Z4PnknbR8220nc1Pzv0nkDJ1emZE9EAi7YOOry2Dw660azQHWfVw/HhqECPdiKrTIZ2b+Q==",
       "dev": true,
       "dependencies": {
         "long": "^4.0.0",
@@ -20846,9 +21025,9 @@
       }
     },
     "packages/ws-server/node_modules/@hashgraph/sdk": {
-      "version": "2.38.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.38.0.tgz",
-      "integrity": "sha512-fe28I/xEAyaA1S8VrwR4oWGLonyjadD0sHyCbaO+9zPgpQXcM4wMeBZrbkia5riemY+adPHwrJ5FxASk3Rr3eg==",
+      "version": "2.43.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.43.0.tgz",
+      "integrity": "sha512-3MOZDL8Tm+Ciu+e402R9mSPfAUaiv8GCY+G6prUDOJzkNubRGm7gNxpeMlmHDZepc+EOkuq+kOq3QvB+2IvgWQ==",
       "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
@@ -20856,24 +21035,25 @@
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/rlp": "^5.7.0",
         "@grpc/grpc-js": "1.8.2",
-        "@hashgraph/cryptography": "1.4.8-beta.4",
-        "@hashgraph/proto": "2.14.0-beta.2",
-        "axios": "^1.3.1",
+        "@hashgraph/cryptography": "1.4.8-beta.5",
+        "@hashgraph/proto": "2.14.0-beta.5",
+        "axios": "^1.6.4",
         "bignumber.js": "^9.1.1",
         "bn.js": "^5.1.1",
-        "crypto-js": "^4.1.1",
+        "crypto-js": "^4.2.0",
         "js-base64": "^3.7.4",
         "long": "^4.0.0",
         "pino": "^8.14.1",
         "pino-pretty": "^10.0.0",
         "protobufjs": "^7.2.5",
+        "rfc4648": "^1.5.3",
         "utf8": "^3.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "expo": "^49.0.10"
+        "expo": "^49.0.16"
       },
       "peerDependenciesMeta": {
         "expo": {
@@ -22885,7 +23065,7 @@
       "version": "file:packages/relay",
       "requires": {
         "@ethersproject/asm": "^5.7.0",
-        "@hashgraph/sdk": "2.42.0",
+        "@hashgraph/sdk": "2.43.0",
         "@keyvhq/core": "^1.6.9",
         "@types/chai": "^4.3.0",
         "@types/mocha": "^9.1.0",
@@ -22913,18 +23093,18 @@
       },
       "dependencies": {
         "@hashgraph/proto": {
-          "version": "2.14.0-beta.4",
-          "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.4.tgz",
-          "integrity": "sha512-DCmK9CivuVpdDuay1VcYt++Zhms55uu8JZgJI6fBtJuv/WkMuYLNtmnihKcQ39Ykmm8SV6iL6trTziTINHV44g==",
+          "version": "2.14.0-beta.5",
+          "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.5.tgz",
+          "integrity": "sha512-UrIbLdctpD//Ua99Z4PnknbR8220nc1Pzv0nkDJ1emZE9EAi7YOOry2Dw660azQHWfVw/HhqECPdiKrTIZ2b+Q==",
           "requires": {
             "long": "^4.0.0",
             "protobufjs": "^7.2.5"
           }
         },
         "@hashgraph/sdk": {
-          "version": "2.42.0",
-          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.42.0.tgz",
-          "integrity": "sha512-47E08ZHGRKoZCmJJhbcaFWcAWNPpJfs5F0SvqocDNFHs616+zrAwFDPXqWLtGx3JhyeCZClgpDYvJX7CVBFCtA==",
+          "version": "2.43.0",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.43.0.tgz",
+          "integrity": "sha512-3MOZDL8Tm+Ciu+e402R9mSPfAUaiv8GCY+G6prUDOJzkNubRGm7gNxpeMlmHDZepc+EOkuq+kOq3QvB+2IvgWQ==",
           "requires": {
             "@ethersproject/abi": "^5.7.0",
             "@ethersproject/bignumber": "^5.7.0",
@@ -22932,7 +23112,7 @@
             "@ethersproject/rlp": "^5.7.0",
             "@grpc/grpc-js": "1.8.2",
             "@hashgraph/cryptography": "1.4.8-beta.5",
-            "@hashgraph/proto": "2.14.0-beta.4",
+            "@hashgraph/proto": "2.14.0-beta.5",
             "axios": "^1.6.4",
             "bignumber.js": "^9.1.1",
             "bn.js": "^5.1.1",
@@ -23137,7 +23317,7 @@
       "requires": {
         "@hashgraph/hedera-local": "^2.15.1",
         "@hashgraph/json-rpc-relay": "file:../relay",
-        "@hashgraph/sdk": "^2.38.0",
+        "@hashgraph/sdk": "2.43.0",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -23169,6 +23349,85 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "@hashgraph/proto": {
+          "version": "2.14.0-beta.5",
+          "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.5.tgz",
+          "integrity": "sha512-UrIbLdctpD//Ua99Z4PnknbR8220nc1Pzv0nkDJ1emZE9EAi7YOOry2Dw660azQHWfVw/HhqECPdiKrTIZ2b+Q==",
+          "dev": true,
+          "requires": {
+            "long": "^4.0.0",
+            "protobufjs": "^7.2.5"
+          }
+        },
+        "@hashgraph/sdk": {
+          "version": "2.43.0",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.43.0.tgz",
+          "integrity": "sha512-3MOZDL8Tm+Ciu+e402R9mSPfAUaiv8GCY+G6prUDOJzkNubRGm7gNxpeMlmHDZepc+EOkuq+kOq3QvB+2IvgWQ==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@grpc/grpc-js": "1.8.2",
+            "@hashgraph/cryptography": "1.4.8-beta.5",
+            "@hashgraph/proto": "2.14.0-beta.5",
+            "axios": "^1.6.4",
+            "bignumber.js": "^9.1.1",
+            "bn.js": "^5.1.1",
+            "crypto-js": "^4.2.0",
+            "js-base64": "^3.7.4",
+            "long": "^4.0.0",
+            "pino": "^8.14.1",
+            "pino-pretty": "^10.0.0",
+            "protobufjs": "^7.2.5",
+            "rfc4648": "^1.5.3",
+            "utf8": "^3.0.0"
+          },
+          "dependencies": {
+            "pino": {
+              "version": "8.19.0",
+              "resolved": "https://registry.npmjs.org/pino/-/pino-8.19.0.tgz",
+              "integrity": "sha512-oswmokxkav9bADfJ2ifrvfHUwad6MLp73Uat0IkQWY3iAw5xTRoznXbXksZs8oaOUMpmhVWD+PZogNzllWpJaA==",
+              "dev": true,
+              "requires": {
+                "atomic-sleep": "^1.0.0",
+                "fast-redact": "^3.1.1",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "v1.1.0",
+                "pino-std-serializers": "^6.0.0",
+                "process-warning": "^3.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^3.7.0",
+                "thread-stream": "^2.0.0"
+              }
+            },
+            "pino-pretty": {
+              "version": "10.3.1",
+              "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+              "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+              "dev": true,
+              "requires": {
+                "colorette": "^2.0.7",
+                "dateformat": "^4.6.3",
+                "fast-copy": "^3.0.0",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^5.0.0",
+                "joycon": "^3.1.1",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.0.0",
+                "pump": "^3.0.0",
+                "readable-stream": "^4.0.0",
+                "secure-json-parse": "^2.4.0",
+                "sonic-boom": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+              }
+            }
+          }
+        },
         "@noble/curves": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -23188,6 +23447,12 @@
           "version": "4.0.0-beta.5",
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
           "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+          "dev": true
+        },
+        "dateformat": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
           "dev": true
         },
         "ethers": {
@@ -23213,6 +23478,105 @@
             }
           }
         },
+        "on-exit-leak-free": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+          "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+          "dev": true
+        },
+        "pino-abstract-transport": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
+          "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^4.0.0",
+            "split2": "^4.0.0"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+          "dev": true
+        },
+        "process-warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+          "dev": true
+        },
+        "protobufjs": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+          "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+          "dev": true,
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          },
+          "dependencies": {
+            "long": {
+              "version": "5.2.3",
+              "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+              "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+              "dev": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        },
+        "real-require": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+          "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+          "dev": true
+        },
+        "sonic-boom": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.0.tgz",
+          "integrity": "sha512-ybz6OYOUjoQQCQ/i4LU8kaToD8ACtYP+Cj5qd2AO36bwbdewxWJ3ArmJ2cr6AvxlL2o0PqnCcPGUgkILbfkaCA==",
+          "dev": true,
+          "requires": {
+            "atomic-sleep": "^1.0.0"
+          }
+        },
+        "split2": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+          "dev": true
+        },
+        "thread-stream": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
+          "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+          "dev": true,
+          "requires": {
+            "real-require": "^0.2.0"
+          }
+        },
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -23234,7 +23598,7 @@
         "@hashgraph/hedera-local": "^2.15.1",
         "@hashgraph/json-rpc-relay": "file:../relay",
         "@hashgraph/json-rpc-server": "file:../server",
-        "@hashgraph/sdk": "2.38.0",
+        "@hashgraph/sdk": "2.43.0",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -23265,29 +23629,10 @@
         "typescript": "^4.5.5"
       },
       "dependencies": {
-        "@hashgraph/cryptography": {
-          "version": "1.4.8-beta.4",
-          "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.4.tgz",
-          "integrity": "sha512-43wpRuE6ML04dFNpNPHvEZTKlVT9+dOE7SxyQPMYunsFitJvlIDl1VvOXeOSGbVdsV+nDQQV7C9pZWRSV1e32g==",
-          "dev": true,
-          "requires": {
-            "asn1js": "^3.0.5",
-            "bignumber.js": "^9.1.1",
-            "bn.js": "^5.2.1",
-            "buffer": "^6.0.3",
-            "crypto-js": "^4.1.1",
-            "elliptic": "^6.5.4",
-            "js-base64": "^3.7.4",
-            "node-forge": "^1.3.1",
-            "spark-md5": "^3.0.2",
-            "tweetnacl": "^1.0.3",
-            "utf8": "^3.0.0"
-          }
-        },
         "@hashgraph/proto": {
-          "version": "2.14.0-beta.2",
-          "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.2.tgz",
-          "integrity": "sha512-LuypRVyDc05podG/FoDlElgirAiBa8LuyKoAdOmZHUQOC3zNA7bFneTkZJR92Oxhnc56++QCLCOsRPjVLOYBcw==",
+          "version": "2.14.0-beta.5",
+          "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.5.tgz",
+          "integrity": "sha512-UrIbLdctpD//Ua99Z4PnknbR8220nc1Pzv0nkDJ1emZE9EAi7YOOry2Dw660azQHWfVw/HhqECPdiKrTIZ2b+Q==",
           "dev": true,
           "requires": {
             "long": "^4.0.0",
@@ -23295,9 +23640,9 @@
           }
         },
         "@hashgraph/sdk": {
-          "version": "2.38.0",
-          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.38.0.tgz",
-          "integrity": "sha512-fe28I/xEAyaA1S8VrwR4oWGLonyjadD0sHyCbaO+9zPgpQXcM4wMeBZrbkia5riemY+adPHwrJ5FxASk3Rr3eg==",
+          "version": "2.43.0",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.43.0.tgz",
+          "integrity": "sha512-3MOZDL8Tm+Ciu+e402R9mSPfAUaiv8GCY+G6prUDOJzkNubRGm7gNxpeMlmHDZepc+EOkuq+kOq3QvB+2IvgWQ==",
           "dev": true,
           "requires": {
             "@ethersproject/abi": "^5.7.0",
@@ -23305,17 +23650,18 @@
             "@ethersproject/bytes": "^5.7.0",
             "@ethersproject/rlp": "^5.7.0",
             "@grpc/grpc-js": "1.8.2",
-            "@hashgraph/cryptography": "1.4.8-beta.4",
-            "@hashgraph/proto": "2.14.0-beta.2",
-            "axios": "^1.3.1",
+            "@hashgraph/cryptography": "1.4.8-beta.5",
+            "@hashgraph/proto": "2.14.0-beta.5",
+            "axios": "^1.6.4",
             "bignumber.js": "^9.1.1",
             "bn.js": "^5.1.1",
-            "crypto-js": "^4.1.1",
+            "crypto-js": "^4.2.0",
             "js-base64": "^3.7.4",
             "long": "^4.0.0",
             "pino": "^8.14.1",
             "pino-pretty": "^10.0.0",
             "protobufjs": "^7.2.5",
+            "rfc4648": "^1.5.3",
             "utf8": "^3.0.0"
           },
           "dependencies": {

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@ethersproject/asm": "^5.7.0",
-    "@hashgraph/sdk": "2.42.0",
+    "@hashgraph/sdk": "2.43.0",
     "@keyvhq/core": "^1.6.9",
     "axios": "^1.4.0",
     "axios-retry": "^3.5.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,12 +18,12 @@
     "mocha": "^9.2.2",
     "pino": "^7.11.0",
     "pino-pretty": "^7.6.1",
-    "uuid": "^3.3.2",
-    "pnpm": "^8.7.1"
+    "pnpm": "^8.7.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@hashgraph/hedera-local": "^2.15.1",
-    "@hashgraph/sdk": "^2.38.0",
+    "@hashgraph/sdk": "2.43.0",
     "@koa/cors": "^5.0.0",
     "@types/chai": "^4.3.0",
     "@types/cors": "^2.8.12",
@@ -35,11 +35,11 @@
     "axios-retry": "^3.5.1",
     "chai": "^4.3.6",
     "ethers": "^6.7.0",
+    "execution-apis": "git://github.com/ethereum/execution-apis.git#584905270d8ad665718058060267061ecfd79ca5",
     "shelljs": "^0.8.5",
     "ts-mocha": "^9.0.2",
     "ts-node": "^10.8.1",
-    "typescript": "^4.5.5",
-    "execution-apis": "git://github.com/ethereum/execution-apis.git#584905270d8ad665718058060267061ecfd79ca5"
+    "typescript": "^4.5.5"
   },
   "scripts": {
     "build": "pnpm clean && pnpm compile",

--- a/packages/ws-server/package.json
+++ b/packages/ws-server/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@hashgraph/hedera-local": "^2.15.1",
-    "@hashgraph/sdk": "2.38.0",
+    "@hashgraph/sdk": "2.43.0",
     "@koa/cors": "^5.0.0",
     "@types/chai": "^4.3.0",
     "@types/cors": "^2.8.12",


### PR DESCRIPTION
**Description**:
This PR updates the `@hashgraph/sdk` to 2.43. This includes an update to protobufs that supports `hedera-services` 0.48


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
