### PR TITLE
feat: added deleteFile() method to delete files from the network

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -726,9 +726,7 @@ export class SDKClient {
       // Create fileDeleteTx
       const fileDeleteTx = await new FileDeleteTransaction()
         .setFileId(fileId)
-        .setMaxTransactionFee(
-          Hbar.fromTinybars(Math.floor((await this.getTinyBarGasFee('FileDelete')) * constants.BLOCK_GAS_LIMIT)),
-        )
+        .setMaxTransactionFee(new Hbar(2))
         .freezeWith(client);
 
       // execute fileDeleteTx

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -749,13 +749,14 @@ export class SDKClient {
       // ensure the file is deleted
       const receipt = deleteFileRecord.receipt;
       const fileInfo = await new FileInfoQuery().setFileId(fileId).execute(client);
+
       if (receipt.status === Status.Success && fileInfo.isDeleted) {
         this.logger.trace(`${requestIdPrefix} Deleted file with fileId: ${fileId}`);
       } else {
-        throw new SDKClientError({}, `${requestIdPrefix} Fail to delete file with fileId: ${fileId} `);
+        this.logger.warn(`${requestIdPrefix} Fail to delete file with fileId: ${fileId} `);
       }
     } catch (error: any) {
-      throw new SDKClientError(error, `${requestIdPrefix} ${error['message']} `);
+      this.logger.warn(`${requestIdPrefix} ${error['message']} `);
     }
   };
 }

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -201,6 +201,11 @@ describe('SdkClient', async function () {
       const ethereumTransactionData: EthereumTransactionData = EthereumTransactionData.fromBytes(transactionBuffer);
       const fileId = await sdkClient.createFile(ethereumTransactionData.callData, client, requestId, callerName, '');
 
+      const fileInfoPreDelete = await new FileInfoQuery().setFileId(fileId).execute(client);
+      expect(fileInfoPreDelete.fileId).to.deep.eq(fileId);
+      expect(fileInfoPreDelete.isDeleted).to.be.false;
+      expect(fileInfoPreDelete.size.toNumber()).to.not.eq(0);
+
       // delete a file
       await sdkClient.deleteFile(client, fileId, requestId, callerName, '');
       const fileInfoPostDelete = await new FileInfoQuery().setFileId(fileId).execute(client);

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -37,6 +37,9 @@ import {
   FileId,
   EthereumTransactionData,
   FileInfoQuery,
+  FileInfo,
+  FileDeleteTransaction,
+  TransactionRecord,
 } from '@hashgraph/sdk';
 const logger = pino();
 import constants from '../../src/lib/constants';
@@ -45,6 +48,7 @@ import { SDKClient } from '../../src/lib/clients';
 import { CacheService } from '../../src/lib/services/cacheService/cacheService';
 import { MAX_GAS_LIMIT_HEX } from './eth/eth-config';
 import { getRequestId, signTransaction } from '../helpers';
+import { TransactionReceipt } from 'ethers';
 
 describe('SdkClient', async function () {
   this.timeout(20000);
@@ -205,18 +209,16 @@ describe('SdkClient', async function () {
       expect(fileInfoPostDelete.size.toNumber()).to.eq(0);
     });
 
-    it('should throw an exception when delete file with invalid fileId', async () => {
+    it('should print a `warn` log when delete file with invalid fileId', async () => {
       // random fileId
       const fileId = new FileId(0, 0, 369);
 
-      try {
-        // delete a file
-        await sdkClient.deleteFile(client, fileId, requestId, callerName, '');
-        expect(true).to.eq(false);
-      } catch (error: any) {
-        expect(error).to.exist;
-        expect(error.status).to.eq(Status.EntityNotAllowedToDelete);
-      }
+      // spy on warn logs
+      const warnLoggerStub = sinon.stub(sdkClient.logger, 'warn');
+
+      // delete a file
+      await sdkClient.deleteFile(client, fileId, requestId, callerName, '');
+      expect(warnLoggerStub.calledWithMatch('ENTITY_NOT_ALLOWED_TO_DELETE')).to.be.true;
     });
   });
 });

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -26,12 +26,25 @@ import { Registry } from 'prom-client';
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 const registry = new Registry();
 import pino from 'pino';
-import { AccountId, Client, ContractCallQuery, PrivateKey, TransactionId, Hbar, Status } from '@hashgraph/sdk';
+import {
+  AccountId,
+  Client,
+  ContractCallQuery,
+  PrivateKey,
+  TransactionId,
+  Hbar,
+  Status,
+  FileId,
+  EthereumTransactionData,
+  FileInfoQuery,
+} from '@hashgraph/sdk';
 const logger = pino();
 import constants from '../../src/lib/constants';
 import HbarLimit from '../../src/lib/hbarlimiter';
 import { SDKClient } from '../../src/lib/clients';
 import { CacheService } from '../../src/lib/services/cacheService/cacheService';
+import { MAX_GAS_LIMIT_HEX } from './eth/eth-config';
+import { getRequestId, signTransaction } from '../helpers';
 
 describe('SdkClient', async function () {
   this.timeout(20000);
@@ -155,6 +168,55 @@ describe('SdkClient', async function () {
       sinon.assert.calledOnce(getFeeScheduleStub);
       sinon.assert.calledOnce(getExchangeRateStub);
       sinon.assert.calledOnce(convertGasPriceToTinyBarsStub);
+    });
+  });
+
+  describe('deleteFile', () => {
+    // states
+    const gasPrice = '0xad78ebc5ac620000';
+    const callerName = 'eth_sendRawTransaction';
+    const requestId = getRequestId();
+    const transaction = {
+      type: 1,
+      value: 0,
+      chainId: 0x12a,
+      gasPrice,
+      gasLimit: MAX_GAS_LIMIT_HEX,
+      data: '0x' + '00'.repeat(5121), // large contract
+    };
+
+    before(() => {
+      // mock captureMetrics
+      sinon.stub(sdkClient, 'captureMetrics').callsFake(() => {});
+    });
+
+    it('should execute deleteFile', async () => {
+      // prepare fileId
+      const signedTx = await signTransaction(transaction);
+      const transactionBuffer = Buffer.from(signedTx.substring(2), 'hex');
+      const ethereumTransactionData: EthereumTransactionData = EthereumTransactionData.fromBytes(transactionBuffer);
+      const fileId = await sdkClient.createFile(ethereumTransactionData.callData, client, requestId, callerName, '');
+
+      // delete a file
+      await sdkClient.deleteFile(client, fileId, requestId, callerName, '');
+      const fileInfoPostDelete = await new FileInfoQuery().setFileId(fileId).execute(client);
+      expect(fileInfoPostDelete.fileId).to.deep.eq(fileId);
+      expect(fileInfoPostDelete.isDeleted).to.be.true;
+      expect(fileInfoPostDelete.size.toNumber()).to.eq(0);
+    });
+
+    it('should throw an exception when delete file with invalid fileId', async () => {
+      // random fileId
+      const fileId = new FileId(0, 0, 369);
+
+      try {
+        // delete a file
+        await sdkClient.deleteFile(client, fileId, requestId, callerName, '');
+        expect(true).to.eq(false);
+      } catch (error: any) {
+        expect(error).to.exist;
+        expect(error.status).to.eq(Status.EntityNotAllowedToDelete);
+      }
     });
   });
 });


### PR DESCRIPTION
**Description**:
This PR adds a private function,`deleteFile()` within the `sdkClient` class. This function attempts to remove the `fileId` file that is generated during `CONTRACT_CREATE` transactions if the contract's bytecode is greater than 5KBs. `deleteFile()` is included in the `finally` block of the `sdkClient.executeTransaction()` function. This ensures that the created file is deleted regardless of whether the transaction succeeds or fails.

This PR also adds new UT coverage for `deleteFile()`

Fixes #2190

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
