### PR TITLE
feat: added  parameter check on block param for getcode()

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -250,11 +250,12 @@ export const predefined = {
       code: -32000,
       message: `Exceeded max transactions that can be returned in a block: ${count}`,
     }),
-  UNKNOWN_BLOCK: new JsonRpcError({
-    name: 'Unknown block',
-    code: -39012,
-    message: 'Unknown block',
-  }),
+  UNKNOWN_BLOCK: (msg?: string | null) =>
+    new JsonRpcError({
+      name: 'Unknown block',
+      code: -39012,
+      message: msg || 'Unknown block',
+    }),
   INVALID_BLOCK_RANGE: new JsonRpcError({
     name: 'Invalid block range',
     code: -39013,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1015,8 +1015,7 @@ export class EthImpl implements Eth {
    */
   async getCode(address: string, blockNumber: string | null, requestIdPrefix?: string) {
     if (!EthImpl.isBlockParamValid(blockNumber)) {
-      throw predefined.INVALID_PARAMETER(
-        1, // param index
+      throw predefined.UNKNOWN_BLOCK(
         `The value passed is not a valid blockHash/blockNumber/blockTag value: ${blockNumber}`,
       );
     }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1323,7 +1323,7 @@ export class EthImpl implements Eth {
         nonceCount = await this.getAccountNonceForHistoricBlock(address, blockNumOrTag, requestIdPrefix);
       } else {
         // return a '-39001: Unknown block' error per api-spec
-        throw predefined.UNKNOWN_BLOCK;
+        throw predefined.UNKNOWN_BLOCK();
       }
     } else {
       // if no block consideration, get latest ethereumNonce from mirror node if account or from consensus node is contract until HIP 729 is implemented
@@ -2208,7 +2208,7 @@ export class EthImpl implements Eth {
     // get block timestamp for blockNum
     const block = await this.mirrorNodeClient.getBlock(blockNumOrHash, requestIdPrefix); // consider caching error responses
     if (block == null) {
-      throw predefined.UNKNOWN_BLOCK;
+      throw predefined.UNKNOWN_BLOCK();
     }
 
     // get the latest 2 ethereum transactions for the account
@@ -2275,7 +2275,7 @@ export class EthImpl implements Eth {
     const isParamBlockNum = typeof blockNumOrHash === 'number' ? true : false;
 
     if (isParamBlockNum && blockNumOrHash < 0) {
-      throw predefined.UNKNOWN_BLOCK;
+      throw predefined.UNKNOWN_BLOCK();
     }
 
     if (!isParamBlockNum) {
@@ -2287,7 +2287,7 @@ export class EthImpl implements Eth {
     // check if on latest block, if so get latest ethereumNonce from mirror node account API
     const blockResponse = await this.mirrorNodeClient.getLatestBlock(requestIdPrefix); // consider caching error responses
     if (blockResponse == null || blockResponse.blocks.length === 0) {
-      throw predefined.UNKNOWN_BLOCK;
+      throw predefined.UNKNOWN_BLOCK();
     }
 
     if (blockResponse.blocks[0].number - blockNum <= this.maxBlockRange) {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1014,6 +1014,13 @@ export class EthImpl implements Eth {
    * @param blockNumber
    */
   async getCode(address: string, blockNumber: string | null, requestIdPrefix?: string) {
+    if (!EthImpl.isBlockParamValid(blockNumber)) {
+      throw predefined.INVALID_PARAMETER(
+        1, // param index
+        `The value passed is not a valid blockHash/blockNumber/blockTag value: ${blockNumber}`,
+      );
+    }
+
     this.logger.trace(`${requestIdPrefix} getCode(address=${address}, blockNumber=${blockNumber})`);
 
     // check for static precompile cases first before consulting nodes
@@ -1943,17 +1950,25 @@ export class EthImpl implements Eth {
     return input.startsWith(EthImpl.emptyHex) ? input.substring(2) : input;
   }
 
-  private static blockTagIsEarliest = (tag) => {
+  private static isBlockTagEarliest = (tag: string) => {
     return tag === EthImpl.blockEarliest;
   };
 
-  private static blockTagIsFinalized = (tag) => {
+  private static isBlockTagFinalized = (tag: string) => {
     return (
       tag === EthImpl.blockFinalized ||
       tag === EthImpl.blockLatest ||
       tag === EthImpl.blockPending ||
       tag === EthImpl.blockSafe
     );
+  };
+
+  private static isBlockNumValid = (num: string) => {
+    return /^0[xX]([1-9A-Fa-f]+[0-9A-Fa-f]{0,13}|0)$/.test(num) && Number.MAX_SAFE_INTEGER >= Number(num);
+  };
+
+  private static isBlockParamValid = (tag: string | null) => {
+    return tag == null || this.isBlockTagEarliest(tag) || this.isBlockTagFinalized(tag) || this.isBlockNumValid(tag);
   };
 
   private static isBlockHash = (blockHash) => {

--- a/packages/relay/tests/lib/eth/eth_getCode.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getCode.spec.ts
@@ -37,6 +37,7 @@ import {
   NO_TRANSACTIONS,
 } from './eth-config';
 import { generateEthTestEnv } from './eth-helpers';
+import { JsonRpcError, predefined } from '../../../src';
 
 dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 use(chaiAsPromised);
@@ -48,6 +49,8 @@ let currentMaxBlockRange: number;
 describe('@ethGetCode using MirrorNode', async function () {
   this.timeout(10000);
   let { restMock, hapiServiceInstance, ethImpl, cacheService } = generateEthTestEnv();
+  let validBlockParam = [null, 'earliest', 'latest', 'pending', 'finalized', 'safe', '0x0', '0x369ABF'];
+  let invalidBlockParam = ['hedera', 'ethereum', '0xhbar', '0x369ABF369ABF369ABF369ABF'];
 
   this.beforeEach(() => {
     // reset cache and restMock
@@ -126,6 +129,33 @@ describe('@ethGetCode using MirrorNode', async function () {
 
       const res = await ethImpl.getCode(EthImpl.iHTSAddress, null);
       expect(res).to.equal(EthImpl.invalidEVMInstruction);
+    });
+
+    validBlockParam.forEach((blockParam) => {
+      it(`should pass the validate param check with blockParam=${blockParam} and return the bytecode`, async () => {
+        const res = await ethImpl.getCode(CONTRACT_ADDRESS_1, blockParam);
+        expect(res).to.equal(MIRROR_NODE_DEPLOYED_BYTECODE);
+      });
+    });
+
+    invalidBlockParam.forEach((blockParam) => {
+      it(`should throw INVALID_PARAMETER JsonRpcError with invalid blockParam=${blockParam}`, async () => {
+        try {
+          await ethImpl.getCode(EthImpl.iHTSAddress, blockParam);
+          expect(true).to.eq(false);
+        } catch (error) {
+          const expectedError = predefined.INVALID_PARAMETER(
+            1,
+            `The value passed is not a valid blockHash/blockNumber/blockTag value: ${blockParam}`,
+          );
+
+          expect(error).to.exist;
+          expect(error instanceof JsonRpcError);
+          expect(error.code).to.eq(expectedError.code);
+          expect(error.name).to.eq(expectedError.name);
+          expect(error.message).to.eq(expectedError.message);
+        }
+      });
     });
   });
 });

--- a/packages/relay/tests/lib/eth/eth_getCode.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getCode.spec.ts
@@ -144,8 +144,7 @@ describe('@ethGetCode using MirrorNode', async function () {
           await ethImpl.getCode(EthImpl.iHTSAddress, blockParam);
           expect(true).to.eq(false);
         } catch (error) {
-          const expectedError = predefined.INVALID_PARAMETER(
-            1,
+          const expectedError = predefined.UNKNOWN_BLOCK(
             `The value passed is not a valid blockHash/blockNumber/blockTag value: ${blockParam}`,
           );
 

--- a/packages/relay/tests/lib/eth/eth_getTransactionCount.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionCount.spec.ts
@@ -209,7 +209,7 @@ describe('@ethGetTransactionCount eth_getTransactionCount spec', async function 
 
     const args = [MOCK_ACCOUNT_ADDR, blockNumberHex];
 
-    await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
+    await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK(), ethImpl.getTransactionCount, true, ethImpl, args);
   });
 
   it('should throw error for account historical numerical block tag with error on latest block', async () => {
@@ -218,7 +218,7 @@ describe('@ethGetTransactionCount eth_getTransactionCount spec', async function 
 
     const args = [MOCK_ACCOUNT_ADDR, blockNumberHex];
 
-    await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
+    await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK(), ethImpl.getTransactionCount, true, ethImpl, args);
   });
 
   it('should return valid nonce for historical numerical block close to latest', async () => {
@@ -300,13 +300,13 @@ describe('@ethGetTransactionCount eth_getTransactionCount spec', async function 
   it('should throw for -1 invalid block tag', async () => {
     const args = [MOCK_ACCOUNT_ADDR, '-1'];
 
-    await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
+    await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK(), ethImpl.getTransactionCount, true, ethImpl, args);
   });
 
   it('should throw for invalid block tag', async () => {
     const args = [MOCK_ACCOUNT_ADDR, 'notablock'];
 
-    await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK, ethImpl.getTransactionCount, true, ethImpl, args);
+    await RelayAssertions.assertRejection(predefined.UNKNOWN_BLOCK(), ethImpl.getTransactionCount, true, ethImpl, args);
   });
 
   it('should return 0x1 for pre-hip-729 contracts with nonce=null', async () => {


### PR DESCRIPTION
**Description**:
The `blockParam` parameter for the `getCode()` method is currently validated exclusively by the [validateParam()](https://github.com/hashgraph/hedera-json-rpc-relay/blob/main/packages/server/src/validator/utils.ts#L4) method at the server-level. However, it is necessary to extend this validation to the relay-level as well.

This PR adds a parameter validation step for the `blockParam` parameter in the `getCode()` method. It also includes UTs to ensure coverage of the new validation check.

**Related issue(s)**:

Fixes #2130

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
