### PR TITLE
feat: integrated eth_sendRawTransaction to websocket server

### DIFF
--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -167,6 +167,7 @@ export default {
     ETH_SUBSCRIBE: 'eth_subscribe',
     ETH_UNSUBSCRIBE: 'eth_unsubscribe',
     ETH_CHAIN_ID: 'eth_chainId',
+    ETH_SEND_RAW_TRANSACTION: 'eth_sendRawTransaction',
   },
 
   SUBSCRIBE_EVENTS: {

--- a/packages/relay/src/lib/poller.ts
+++ b/packages/relay/src/lib/poller.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/relay/tests/lib/eth/eth_call.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_call.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/server/tests/acceptance/ws/sendRawTransaction.spec.ts
+++ b/packages/server/tests/acceptance/ws/sendRawTransaction.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/server/tests/acceptance/ws/sendRawTransaction.spec.ts
+++ b/packages/server/tests/acceptance/ws/sendRawTransaction.spec.ts
@@ -27,7 +27,7 @@ import { AliasAccount } from '../../clients/servicesClient';
 import { numberTo0x } from '@hashgraph/json-rpc-relay/src/formatters';
 import { ONE_TINYBAR_IN_WEI_HEX } from '@hashgraph/json-rpc-relay/tests/lib/eth/eth-config';
 
-describe('@web-socket eth_sendRawTransaction', async function () {
+describe('@release @web-socket eth_sendRawTransaction', async function () {
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const METHOD_NAME = 'eth_sendRawTransaction';
   const CHAIN_ID = process.env.CHAIN_ID || '0x12a';

--- a/packages/server/tests/acceptance/ws/sendRawTransaction.spec.ts
+++ b/packages/server/tests/acceptance/ws/sendRawTransaction.spec.ts
@@ -1,0 +1,115 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// external resources
+import { expect } from 'chai';
+import { ethers, WebSocketProvider } from 'ethers';
+import RelayClient from '../../clients/relayClient';
+import MirrorClient from '../../clients/mirrorClient';
+import { AliasAccount } from '../../clients/servicesClient';
+import { numberTo0x } from '@hashgraph/json-rpc-relay/src/formatters';
+import { ONE_TINYBAR_IN_WEI_HEX } from '@hashgraph/json-rpc-relay/tests/lib/eth/eth-config';
+
+describe('@web-socket eth_sendRawTransaction', async function () {
+  const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
+  const METHOD_NAME = 'eth_sendRawTransaction';
+  const CHAIN_ID = process.env.CHAIN_ID || '0x12a';
+  const INVALID_PARAMS = [['hedera', 'hbar'], [], ['websocket', 'rpc', 'invalid']];
+  const INVALID_TX_HASH = ['0xhbar', '0xHedera', '', 66, 'abc', true, false, 39];
+
+  let accounts: AliasAccount[] = [];
+  let mirrorNodeServer: MirrorClient, requestId: string, relayClient: RelayClient, wsProvider: WebSocketProvider;
+
+  before(async () => {
+    // @ts-ignore
+    const { servicesNode, mirrorNode, relay } = global;
+
+    mirrorNodeServer = mirrorNode;
+    relayClient = relay;
+
+    accounts[0] = await servicesNode.createAliasAccount(100, relay.provider, requestId);
+    accounts[1] = await servicesNode.createAliasAccount(5, relay.provider, requestId);
+  });
+
+  beforeEach(async () => {
+    wsProvider = new ethers.WebSocketProvider(WS_RELAY_URL);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  });
+
+  afterEach(async () => {
+    if (wsProvider) {
+      await wsProvider.destroy();
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  });
+
+  for (const params of INVALID_PARAMS) {
+    it(`Should throw predefined.INVALID_PARAMETERS if the request's params variable is invalid (params.length !== 1). params=[${params}]`, async () => {
+      try {
+        await wsProvider.send(METHOD_NAME, params);
+        expect(true).to.eq(false);
+      } catch (error) {
+        expect(error.error).to.exist;
+        expect(error.error.code).to.eq(-32602);
+        expect(error.error.name).to.eq('Invalid parameters');
+        expect(error.error.message).to.eq('Invalid params');
+      }
+    });
+  }
+
+  for (const txHash of INVALID_TX_HASH) {
+    it(`Should handle invalid data correctly. txHash = ${txHash}`, async () => {
+      try {
+        await wsProvider.send(METHOD_NAME, [txHash]);
+        expect(true).to.eq(false);
+      } catch (error) {
+        expect(error.error.code).to.eq(-32603);
+
+        if (txHash === '') {
+          expect(error.error.message).to.contain('Error invoking RPC: Passed hex an empty string');
+        } else if (typeof txHash !== 'string') {
+          expect(error.error.message).to.contain('Error invoking RPC: hex.startsWith is not a function');
+        } else {
+          expect(error.error.message).to.contain('Error invoking RPC: invalid BytesLike value');
+        }
+      }
+    });
+  }
+
+  it('Should handle valid data correctly', async () => {
+    const tx = {
+      value: ONE_TINYBAR_IN_WEI_HEX,
+      gasLimit: numberTo0x(30000),
+      chainId: Number(CHAIN_ID),
+      to: accounts[1].address,
+      nonce: await relayClient.getAccountNonce(accounts[0].address, requestId),
+      maxFeePerGas: await relayClient.gasPrice(requestId),
+    };
+
+    const signedTx = await accounts[0].wallet.signTransaction(tx);
+    const txHash = await wsProvider.send(METHOD_NAME, [signedTx]);
+
+    const txReceipt = await mirrorNodeServer.get(`/contracts/results/${txHash}`);
+    const fromAccountInfo = await mirrorNodeServer.get(`/accounts/${txReceipt.from}`);
+
+    expect(txReceipt.to).to.eq(accounts[1].address);
+    expect(fromAccountInfo.evm_address).to.eq(accounts[0].address);
+  });
+});

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/server/tests/acceptance/ws/subscribe.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribe.spec.ts
@@ -69,7 +69,7 @@ const createLogs = async (contract: ethers.Contract, requestId) => {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 };
 
-describe('@web-socket Acceptance Tests', async function () {
+describe('@release @web-socket Acceptance Tests', async function () {
   this.timeout(240 * 1000); // 240 seconds
   const CHAIN_ID = process.env.CHAIN_ID || 0;
   let server;

--- a/packages/server/tests/acceptance/ws/subscribeNewHeads.spec.ts
+++ b/packages/server/tests/acceptance/ws/subscribeNewHeads.spec.ts
@@ -119,7 +119,7 @@ function verifyResponse(response: any, done: Mocha.Done, webSocket: any, include
   }
 }
 
-describe('@web-socket Acceptance Tests', async function () {
+describe('@release @web-socket Acceptance Tests', async function () {
   this.timeout(240 * 1000); // 240 seconds
   const accounts: AliasAccount[] = [];
   const CHAIN_ID = process.env.CHAIN_ID || 0;

--- a/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
+++ b/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
+++ b/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
@@ -31,6 +31,7 @@ import jsonResp from '@hashgraph/json-rpc-server/dist/koaJsonRpc/lib/RpcResponse
  * @param {any} logger - The logger object for logging messages and events.
  * @param {Relay} relay - The relay object for interacting with the Hedera network.
  * @param {any} request - The request object received from the client.
+ * @param {string} method - The name of the method.
  * @param {string} socketIdPrefix - The prefix for the socket ID.
  * @param {string} requestIdPrefix - The prefix for the request ID.
  * @param {string} connectionIdPrefix - The prefix for the connection ID.
@@ -43,18 +44,18 @@ export const handleEthSendRawTransaction = async (
   logger: any,
   relay: Relay,
   request: any,
+  method: string,
   socketIdPrefix: string,
   requestIdPrefix: string,
   connectionIdPrefix: string,
 ) => {
   const SIGNED_TX = params[0];
-  const METHOD_NAME = 'eth_sendRawTransaction';
-  const TAG = JSON.stringify({ method: METHOD_NAME, signedTx: SIGNED_TX });
+  const TAG = JSON.stringify({ method, signedTx: SIGNED_TX });
 
   if (params.length !== 1) {
     const ERR_MSG = 'INVALID PARAMETERS';
     logger.error(`${connectionIdPrefix} ${requestIdPrefix} ${socketIdPrefix}: Invalid parameters ${params}`);
-    sendToClient(ctx.websocket, METHOD_NAME, ERR_MSG, TAG, logger, socketIdPrefix, requestIdPrefix, connectionIdPrefix);
+    sendToClient(ctx.websocket, method, ERR_MSG, TAG, logger, socketIdPrefix, requestIdPrefix, connectionIdPrefix);
     throw predefined.INVALID_PARAMETERS;
   }
 
@@ -65,7 +66,7 @@ export const handleEthSendRawTransaction = async (
   try {
     const txRes = await relay.eth().sendRawTransaction(SIGNED_TX, requestIdPrefix);
     if (txRes) {
-      sendToClient(ctx.websocket, METHOD_NAME, txRes, TAG, logger, socketIdPrefix, requestIdPrefix, connectionIdPrefix);
+      sendToClient(ctx.websocket, method, txRes, TAG, logger, socketIdPrefix, requestIdPrefix, connectionIdPrefix);
     } else {
       logger.error(
         `${connectionIdPrefix} ${requestIdPrefix} ${socketIdPrefix}: Fail to retrieve result for tag=${TAG}`,
@@ -76,7 +77,7 @@ export const handleEthSendRawTransaction = async (
   } catch (error: any) {
     sendToClient(
       ctx.websocket,
-      METHOD_NAME,
+      method,
       JSON.stringify(error.message || error),
       TAG,
       logger,

--- a/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
+++ b/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
@@ -1,0 +1,90 @@
+/* -
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { sendToClient } from '../utils/utils';
+import { Relay } from '@hashgraph/json-rpc-relay';
+import { predefined } from '@hashgraph/json-rpc-relay';
+import jsonResp from '@hashgraph/json-rpc-server/dist/koaJsonRpc/lib/RpcResponse';
+
+/**
+ * Handles the "eth_sendRawTransaction" method request by submitting a raw transaction to the Websocket server.
+ * Validates the parameters, submits the transaction, and sends the txHash response back to the client.
+ * @param {any} ctx - The context object containing information about the WebSocket connection.
+ * @param {any} params - The parameters of the method request, expecting a single parameter: the signed transaction.
+ * @param {any} logger - The logger object for logging messages and events.
+ * @param {Relay} relay - The relay object for interacting with the Hedera network.
+ * @param {any} request - The request object received from the client.
+ * @param {string} socketIdPrefix - The prefix for the socket ID.
+ * @param {string} requestIdPrefix - The prefix for the request ID.
+ * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @returns {Promise<any>} Returns a promise that resolves with the JSON-RPC response to the client.
+ * @throws {JsonRpcError} Throws a JsonRpcError if there is an issue with the parameters or an internal error occurs.
+ */
+export const handleEthSendRawTransaction = async (
+  ctx: any,
+  params: any,
+  logger: any,
+  relay: Relay,
+  request: any,
+  socketIdPrefix: string,
+  requestIdPrefix: string,
+  connectionIdPrefix: string,
+) => {
+  const SIGNED_TX = params[0];
+  const METHOD_NAME = 'eth_sendRawTransaction';
+  const TAG = JSON.stringify({ method: METHOD_NAME, signedTx: SIGNED_TX });
+
+  if (params.length !== 1) {
+    const ERR_MSG = 'INVALID PARAMETERS';
+    logger.error(`${connectionIdPrefix} ${requestIdPrefix} ${socketIdPrefix}: Invalid parameters ${params}`);
+    sendToClient(ctx.websocket, METHOD_NAME, ERR_MSG, TAG, logger, socketIdPrefix, requestIdPrefix, connectionIdPrefix);
+    throw predefined.INVALID_PARAMETERS;
+  }
+
+  logger.info(
+    `${connectionIdPrefix} ${requestIdPrefix} ${socketIdPrefix}: Submitting raw transaction with signedTx=${SIGNED_TX} for tag=${TAG}`,
+  );
+
+  try {
+    const txRes = await relay.eth().sendRawTransaction(SIGNED_TX, requestIdPrefix);
+    if (txRes) {
+      sendToClient(ctx.websocket, METHOD_NAME, txRes, TAG, logger, socketIdPrefix, requestIdPrefix, connectionIdPrefix);
+    } else {
+      logger.error(
+        `${connectionIdPrefix} ${requestIdPrefix} ${socketIdPrefix}: Fail to retrieve result for tag=${TAG}`,
+      );
+    }
+
+    return jsonResp(request.id, null, txRes);
+  } catch (error: any) {
+    sendToClient(
+      ctx.websocket,
+      METHOD_NAME,
+      JSON.stringify(error.message || error),
+      TAG,
+      logger,
+      socketIdPrefix,
+      requestIdPrefix,
+      connectionIdPrefix,
+    );
+
+    throw predefined.INTERNAL_ERROR(JSON.stringify(error.message || error));
+  }
+};

--- a/packages/ws-server/src/controllers/eth_subscribe.ts
+++ b/packages/ws-server/src/controllers/eth_subscribe.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/controllers/eth_unscribe.ts
+++ b/packages/ws-server/src/controllers/eth_unscribe.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/controllers/index.ts
+++ b/packages/ws-server/src/controllers/index.ts
@@ -20,5 +20,6 @@
 
 import { handleEthSubsribe } from './eth_subscribe';
 import { handleEthUnsubscribe } from './eth_unscribe';
+import { handleEthSendRawTransaction } from './eth_sendRawTransaction';
 
-export { handleEthUnsubscribe, handleEthSubsribe };
+export { handleEthUnsubscribe, handleEthSubsribe, handleEthSendRawTransaction };

--- a/packages/ws-server/src/controllers/index.ts
+++ b/packages/ws-server/src/controllers/index.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/utils/constants.ts
+++ b/packages/ws-server/src/utils/constants.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/utils/constants.ts
+++ b/packages/ws-server/src/utils/constants.ts
@@ -53,4 +53,10 @@ export const WS_CONSTANTS = {
       help: 'Relay websocket total connection ttl limits enforced',
     },
   },
+  METHODS: {
+    ETH_SUBSCRIBE: 'eth_subscribe',
+    ETH_UNSUBSCRIBE: 'eth_unsubscribe',
+    ETH_CHAIN_ID: 'eth_chainId',
+    ETH_SEND_RAW_TRANSACTION: 'eth_sendRawTransaction',
+  },
 };

--- a/packages/ws-server/src/utils/counters.ts
+++ b/packages/ws-server/src/utils/counters.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/utils/counters.ts
+++ b/packages/ws-server/src/utils/counters.ts
@@ -18,21 +18,21 @@
  *
  */
 
-import { WS_CONSTANTS } from './constants';
 import { Counter, Registry } from 'prom-client';
 
 /**
  * Generates a Prometheus Counter metric for tracking WebSocket method calls.
  * Removes any existing metric with the same name from the provided registry before creating the new metric.
  * @param {Registry} register - The Prometheus Registry where the metric will be registered.
+ * @param {any} counterInfo - Information of the counter.
  * @returns {Counter} Returns a new Counter metric instance.
  */
-export const generateMethodsCounter = (register: Registry) => {
-  register.removeSingleMetric(WS_CONSTANTS.methodsCounter.name);
+export const generateMethodsCounter = (register: Registry, counterInfo: any): Counter => {
+  register.removeSingleMetric(counterInfo.name);
   return new Counter({
-    name: WS_CONSTANTS.methodsCounter.name,
-    help: WS_CONSTANTS.methodsCounter.help,
-    labelNames: WS_CONSTANTS.methodsCounter.labelNames,
+    name: counterInfo.name,
+    help: counterInfo.help,
+    labelNames: counterInfo.labelNames,
     registers: [register],
   });
 };
@@ -41,14 +41,15 @@ export const generateMethodsCounter = (register: Registry) => {
  * Generates a Prometheus Counter metric for tracking WebSocket method calls by IP address.
  * Removes any existing metric with the same name from the provided registry before creating the new metric.
  * @param {Registry} register - The Prometheus Registry where the metric will be registered.
+ * @param {any} counterInfo - Information of the counter.
  * @returns {Counter} Returns a new Counter metric instance.
  */
-export const generateMethodsCounterById = (register: Registry) => {
-  register.removeSingleMetric(WS_CONSTANTS.methodsCounterByIp.name);
+export const generateMethodsCounterById = (register: Registry, counterInfo: any): Counter => {
+  register.removeSingleMetric(counterInfo.name);
   return new Counter({
-    name: WS_CONSTANTS.methodsCounterByIp.name,
-    help: WS_CONSTANTS.methodsCounterByIp.help,
-    labelNames: WS_CONSTANTS.methodsCounterByIp.labelNames,
+    name: counterInfo.name,
+    help: counterInfo.help,
+    labelNames: counterInfo.labelNames,
     registers: [register],
   });
 };

--- a/packages/ws-server/src/utils/formatters.ts
+++ b/packages/ws-server/src/utils/formatters.ts
@@ -19,10 +19,11 @@
  */
 
 /**
- * Formats a connection ID message for logging purposes.
- * @param {string | undefined} connectionId - The connection ID to be formatted.
- * @returns {string} Returns a formatted connection ID message if a connection ID is provided, otherwise an empty string.
+ * Formats an ID message for logging purposes.
+ * @param {string } title - The title of the ID to be formatted.
+ * @param {string | undefined} id - The ID to be formatted.
+ * @returns {string} Returns a formatted ID message if an ID is provided, otherwise an empty string.
  */
-export const formatConnectionIdMessage = (connectionId?: string): string => {
-  return connectionId ? `[Connection ID: ${connectionId}]` : '';
+export const formatIdMessage = (title: string, id?: string): string => {
+  return id ? `[${title}: ${id}]` : '';
 };

--- a/packages/ws-server/src/utils/formatters.ts
+++ b/packages/ws-server/src/utils/formatters.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/utils/utils.ts
+++ b/packages/ws-server/src/utils/utils.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/utils/utils.ts
+++ b/packages/ws-server/src/utils/utils.ts
@@ -41,3 +41,39 @@ export const handleConnectionClose = async (ctx: any, relay: Relay, limiter: Con
 export const getMultipleAddressesEnabled = (): boolean => {
   return process.env.WS_MULTIPLE_ADDRESSES_ENABLED === 'true';
 };
+
+/**
+ * Sends a JSON-RPC response message to the client WebSocket connection.
+ * Resets the TTL timer for inactivity on the client connection.
+ * @param {any} connection - The WebSocket connection object.
+ * @param {string} method - The JSON-RPC method associated with the response.
+ * @param {any} data - The data to be included in the response.
+ * @param {string} tag - A tag used for logging and identifying the message.
+ * @param {any} logger - The logger object for logging messages and events.
+ * @param {string} socketIdPrefix - The prefix for the socket ID.
+ * @param {string} requestIdPrefix - The prefix for the request ID.
+ * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ */
+export const sendToClient = (
+  connection: any,
+  method: string,
+  data: any,
+  tag: string,
+  logger: any,
+  socketIdPrefix: string,
+  requestIdPrefix: string,
+  connectionIdPrefix: string,
+) => {
+  logger.info(
+    `${connectionIdPrefix} ${requestIdPrefix} ${socketIdPrefix}: Sending data from tag: ${tag} to connectionId: ${connection.id}, data: ${data}`,
+  );
+
+  connection.send(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      method,
+      result: data,
+    }),
+  );
+  connection.limiter.resetInactivityTTLTimer(connection);
+};

--- a/packages/ws-server/src/utils/validators.ts
+++ b/packages/ws-server/src/utils/validators.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -31,11 +31,10 @@ import { handleConnectionClose } from './utils/utils';
 import ConnectionLimiter from './utils/connectionLimiter';
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
 import KoaJsonRpc from '@hashgraph/json-rpc-server/dist/koaJsonRpc';
-import { handleEthSubsribe, handleEthUnsubscribe } from './controllers';
 import jsonResp from '@hashgraph/json-rpc-server/dist/koaJsonRpc/lib/RpcResponse';
-import { handleEthSendRawTransaction } from './controllers/eth_sendRawTransaction';
 import { generateMethodsCounter, generateMethodsCounterById } from './utils/counters';
 import { type Relay, RelayImpl, predefined, JsonRpcError } from '@hashgraph/json-rpc-relay';
+import { handleEthSendRawTransaction, handleEthSubsribe, handleEthUnsubscribe } from './controllers';
 
 const register = new Registry();
 const pingInterval = Number(process.env.WS_PING_INTERVAL || 1000);


### PR DESCRIPTION
**Description**:
This PR adds support and test coverage for `eth_sendRawTransaction(signedTransaction)` endpoint to the websocket server.  

This PR also slightly modify utils functions in ws-server package to better suit the new API


**Related issue(s)**:

Fixes #2282

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
