### PR TITLE
docs: improve openrpc limit docs for `eth_getLogs`

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -402,7 +402,7 @@
         {
             "name": "eth_getLogs",
             "summary": "Returns an array of all logs matching a given filter object.",
-            "description": "The block range filter, _i.e._, `fromBlock` and `toBlock` arguments, cannot be larger than `ETH_GET_LOGS_BLOCK_RANGE_LIMIT` (defaults to `1000`). However, when `address` represents a single address, either a `string` or an array with a single element, this restriction is lifted.\n\nWhen the logs for an individual address exceeds the Mirror Node page limit `MIRROR_NODE_CONTRACT_RESULTS_LOGS_PG_MAX` (defaults to `200`) an error `-32011` _Mirror Node pagination count range too large_ is returned.",
+            "description": "The block range filter, _i.e._, `fromBlock` and `toBlock` arguments, cannot be larger than `ETH_GET_LOGS_BLOCK_RANGE_LIMIT` (defaults to `1000`). However, when `address` represents a single address, either a `string` or an array with a single element, this restriction is lifted.\n\nWhen the logs for an individual address exceeds `MIRROR_NODE_CONTRACT_RESULTS_LOGS_PG_MAX * MIRROR_NODE_LIMIT_PARAM` (defaults to `20k`) an error `-32011` _Mirror Node pagination count range too large_ is returned. These settings are the Mirror Node page limit (defaults to `200`) and Mirror Node entries per page (defaults to `100`) respectively.",
             "params": [
                 {
                     "name": "Filter",


### PR DESCRIPTION
**Description**:

This PR includes more details on how the `eth_getLogs` behaves when a single address argument is used.

Fixes #2326.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
