### PR TITLE
feat: added param validator to WS server (#2311)

### DIFF
--- a/packages/server/tests/acceptance/ws/blockNumber.spec.ts
+++ b/packages/server/tests/acceptance/ws/blockNumber.spec.ts
@@ -50,15 +50,13 @@ describe('@release @web-socket eth_blockNumber', async function () {
   });
 
   for (const params of INVALID_PARAMS) {
-    it(`Should throw predefined.INVALID_PARAMETERS if the request's params variable is invalid (params.length !== 0). params=[${params}]`, async () => {
+    it(`Should throw predefined.INVALID_PARAMETERS if the request's params variable is invalid. params=[${params}]`, async () => {
       try {
         await wsProvider.send(METHOD_NAME, params);
         expect(true).to.eq(false);
       } catch (error) {
         expect(error.error).to.exist;
         expect(error.error.code).to.eq(-32602);
-        expect(error.error.name).to.eq('Invalid parameters');
-        expect(error.error.message).to.eq('Invalid params');
       }
     });
   }

--- a/packages/server/tests/acceptance/ws/call.spec.ts
+++ b/packages/server/tests/acceptance/ws/call.spec.ts
@@ -28,19 +28,18 @@ import { AliasAccount } from '../../clients/servicesClient';
 describe('@release @web-socket eth_call', async function () {
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const METHOD_NAME = 'eth_call';
+  const FAKE_TX_HASH = `0x${'00'.repeat(20)}`;
   const INVALID_PARAMS = [
     ["{ to: '0xabcdef', data: '0x1a2b3c4d' }", 36, ''],
     ['{}', false, '0x0'],
+    [{ to: FAKE_TX_HASH, data: '' }, 'latest'],
+    [{ to: FAKE_TX_HASH, data: 36 }, 'latest'],
   ];
 
-  const INVALID_TX_INFO_A = [
+  const INVALID_TX_INFO = [
     [{ to: 123, data: '0x18160ddd' }, 'latest'],
     [{ to: '0x', data: '0x18160ddd' }, 'latest'],
     [{ to: '0xabcdef', data: '0x18160ddd' }, 'latest'],
-  ];
-  const INVALID_TX_INFO_B = [
-    [{ to: '0x88019982753D059db392934Ba3AA07e5228C485B', data: '' }, 'latest'],
-    [{ to: '0x88019982753D059db392934Ba3AA07e5228C485B', data: '0x1816' }, 'latest'],
   ];
 
   const TOKEN_NAME = Utils.randomString(10);
@@ -104,13 +103,11 @@ describe('@release @web-socket eth_call', async function () {
       } catch (error) {
         expect(error.info).to.exist;
         expect(error.info.error.code).to.eq(-32602);
-        expect(error.info.error.name).to.eq('Invalid parameters');
-        expect(error.info.error.message).to.eq('Invalid params');
       }
     });
   }
 
-  for (const params of INVALID_TX_INFO_A) {
+  for (const params of INVALID_TX_INFO) {
     it(`Should handle invalid TX_INFO A. params=[${JSON.stringify(params)}]`, async () => {
       try {
         await wsProvider.send(METHOD_NAME, [...params]);
@@ -121,13 +118,6 @@ describe('@release @web-socket eth_call', async function () {
         expect(error.code).to.eq('INVALID_ARGUMENT');
         expect(error.shortMessage).to.eq('invalid address');
       }
-    });
-  }
-
-  for (const params of INVALID_TX_INFO_B) {
-    it(`Should handle invalid TX_INFO B. params=[${JSON.stringify(params)}]`, async () => {
-      const res = await wsProvider.send(METHOD_NAME, [...params]);
-      expect(res).to.eq('0x');
     });
   }
 

--- a/packages/server/tests/acceptance/ws/getBalance.spec.ts
+++ b/packages/server/tests/acceptance/ws/getBalance.spec.ts
@@ -27,18 +27,16 @@ import { AliasAccount } from '../../clients/servicesClient';
 describe('@release @web-socket eth_getBalance', async function () {
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const METHOD_NAME = 'eth_getBalance';
+  const FAKE_TX_HASH = `0x${'00'.repeat(32)}`;
   const INVALID_PARAMS = [
     [],
-    ['0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69'],
-    ['0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69', '0xhbar', 36],
-    ['0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69', true, 39],
     [false],
-  ];
-
-  const INVALID_PARAM_VALUE = [
-    ['0xhedera', 'latest'],
+    [FAKE_TX_HASH],
     ['0xhbar', 'latest'],
-    ['0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69', '0xhedera'],
+    ['0xhedera', 'latest'],
+    [FAKE_TX_HASH, true, 39],
+    [FAKE_TX_HASH, '0xhedera'],
+    [FAKE_TX_HASH, '0xhbar', 36],
   ];
 
   let relayClient: RelayClient, wsProvider: WebSocketProvider, requestId: string;
@@ -69,26 +67,6 @@ describe('@release @web-socket eth_getBalance', async function () {
       } catch (error) {
         expect(error.error).to.exist;
         expect(error.error.code).to.eq(-32602);
-        expect(error.error.name).to.eq('Invalid parameters');
-        expect(error.error.message).to.eq('Invalid params');
-      }
-    });
-  }
-
-  for (const params of INVALID_PARAM_VALUE) {
-    it(`Should handle invalid param value. params=[${params}]`, async () => {
-      try {
-        await wsProvider.send(METHOD_NAME, [...params]);
-        expect(true).to.eq(false);
-      } catch (error) {
-        expect(error.error.code).to.eq(-32603);
-        expect(error.error.name).to.eq('Internal error');
-        expect(error.error.message).to.satisfy((msg: string) => {
-          return (
-            msg === 'Error invoking RPC: "Error invoking RPC: Invalid parameter: idOrAliasOrEvmAddress"' ||
-            msg === 'Error invoking RPC: "Error invoking RPC: Invalid parameter: hashOrNumber"'
-          );
-        });
       }
     });
   }

--- a/packages/server/tests/acceptance/ws/getBlockByHash.spec.ts
+++ b/packages/server/tests/acceptance/ws/getBlockByHash.spec.ts
@@ -26,16 +26,14 @@ import RelayClient from '../../clients/relayClient';
 describe('@release @web-socket eth_getBlockByHash', async function () {
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const METHOD_NAME = 'eth_getBlockByHash';
+  const FAKE_TX_HASH = `0x${'00'.repeat(32)}`;
   const INVALID_PARAMS = [
     [],
-    ['0x469652152b68e142a9639848e0f37786681a8b5fbdaecb9459f80fcb2fe4722b'],
-    ['0x469652152b68e142a9639848e0f37786681a8b5fbdaecb9459f80fcb2fe4722b', '0xhbar'],
-    ['0x469652152b68e142a9639848e0f37786681a8b5fbdaecb9459f80fcb2fe4722b', '54'],
-    ['0x469652152b68e142a9639848e0f37786681a8b5fbdaecb9459f80fcb2fe4722b', true, 39],
-    [false],
-  ];
-
-  const INVALID_BLOCK_PARAM = [
+    [FAKE_TX_HASH],
+    [FAKE_TX_HASH, '0xhbar'],
+    [FAKE_TX_HASH, '54'],
+    [FAKE_TX_HASH, true, 39],
+    [FAKE_TX_HASH, false, 39],
     ['0xhedera', true],
     ['0xhbar', false],
   ];
@@ -67,21 +65,6 @@ describe('@release @web-socket eth_getBlockByHash', async function () {
       } catch (error) {
         expect(error.error).to.exist;
         expect(error.error.code).to.eq(-32602);
-        expect(error.error.name).to.eq('Invalid parameters');
-        expect(error.error.message).to.eq('Invalid params');
-      }
-    });
-  }
-
-  for (const params of INVALID_BLOCK_PARAM) {
-    it(`Should handle invalid block hash. params=[${params}]`, async () => {
-      try {
-        await wsProvider.send(METHOD_NAME, [...params]);
-        expect(true).to.eq(false);
-      } catch (error) {
-        expect(error.error.code).to.eq(-32602);
-        expect(error.error.name).to.eq('Invalid parameters');
-        expect(error.error.message).to.eq('Invalid params');
       }
     });
   }

--- a/packages/server/tests/acceptance/ws/getBlockByNumber.spec.ts
+++ b/packages/server/tests/acceptance/ws/getBlockByNumber.spec.ts
@@ -26,11 +26,15 @@ import RelayClient from '../../clients/relayClient';
 describe('@release @web-socket eth_getBlockByNumber', async function () {
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const METHOD_NAME = 'eth_getBlockByNumber';
-  const INVALID_PARAMS = [[], ['0x36'], ['0x36', '0xhbar'], ['0x36', '54'], ['0x36', true, 39], [false]];
-
-  const INVALID_BLOCK_PARAM = [
+  const INVALID_PARAMS = [
+    [],
+    ['0x36'],
+    ['0x36', '0xhbar'],
+    ['0x36', '54'],
+    ['0x36', 'true', 39],
     ['0xhedera', true],
     ['0xhbar', false],
+    ['0xnetwork', false],
   ];
 
   let relayClient: RelayClient, wsProvider: WebSocketProvider;
@@ -59,21 +63,6 @@ describe('@release @web-socket eth_getBlockByNumber', async function () {
       } catch (error) {
         expect(error.error).to.exist;
         expect(error.error.code).to.eq(-32602);
-        expect(error.error.name).to.eq('Invalid parameters');
-        expect(error.error.message).to.eq('Invalid params');
-      }
-    });
-  }
-
-  for (const params of INVALID_BLOCK_PARAM) {
-    it(`Should handle invalid block tag. params=[${params}]`, async () => {
-      try {
-        await wsProvider.send(METHOD_NAME, [...params]);
-        expect(true).to.eq(false);
-      } catch (error) {
-        expect(error.error.code).to.eq(-32603);
-        expect(error.error.name).to.eq('Internal error');
-        expect(error.error.message).to.eq('Error invoking RPC: "Error invoking RPC: Invalid parameter: hashOrNumber"');
       }
     });
   }

--- a/packages/server/tests/acceptance/ws/getLogs.spec.ts
+++ b/packages/server/tests/acceptance/ws/getLogs.spec.ts
@@ -26,24 +26,31 @@ import { AliasAccount } from '../../clients/servicesClient';
 describe('@release @web-socket eth_getLogs', async function () {
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const METHOD_NAME = 'eth_getLogs';
-  const INVALID_PARAMS = [[{}, ''], [], [{}, '0xhbar', false]];
-
-  const INVALID_FILTERS = [
-    {
-      address: '0xhedera',
-      fromBlock: 'latest',
-      toBlock: 'latest',
-    },
-    {
-      address: '0x637a6A8e5A69C087c24983B05261F63f64ED7e9b',
-      fromBlock: '0xhedera',
-      toBlock: 'latest',
-    },
-    {
-      address: '0x637a6A8e5A69C087c24983B05261F63f64ED7e9b',
-      fromBlock: 'latest',
-      toBlock: '0xhedera',
-    },
+  const INVALID_PARAMS = [
+    [{}, ''],
+    [],
+    [{}, '0xhbar', false],
+    [
+      {
+        address: '0xhedera',
+        fromBlock: 'latest',
+        toBlock: 'latest',
+      },
+    ],
+    [
+      {
+        address: '0x637a6A8e5A69C087c24983B05261F63f64ED7e9b',
+        fromBlock: '0xhedera',
+        toBlock: 'latest',
+      },
+    ],
+    [
+      {
+        address: '0x637a6A8e5A69C087c24983B05261F63f64ED7e9b',
+        fromBlock: 'latest',
+        toBlock: '0xhedera',
+      },
+    ],
   ];
 
   let accounts: AliasAccount[] = [];
@@ -68,28 +75,13 @@ describe('@release @web-socket eth_getLogs', async function () {
   });
 
   for (const params of INVALID_PARAMS) {
-    it(`Should throw predefined.INVALID_PARAMETERS if the request's params variable is invalid (params.length !== 1). params=[${params}]`, async () => {
+    it(`Should throw predefined.INVALID_PARAMETERS if the request's params variable is invalid. params=[${params}]`, async () => {
       try {
         await wsProvider.send(METHOD_NAME, params);
         expect(true).to.eq(false);
       } catch (error) {
         expect(error.error).to.exist;
         expect(error.error.code).to.eq(-32602);
-        expect(error.error.name).to.eq('Invalid parameters');
-        expect(error.error.message).to.eq('Invalid params');
-      }
-    });
-  }
-
-  for (const filter of INVALID_FILTERS) {
-    it(`Should handle invalid data correctly. filter = ${JSON.stringify(filter)}`, async () => {
-      try {
-        await wsProvider.send(METHOD_NAME, [filter]);
-        expect(true).to.eq(false);
-      } catch (error) {
-        expect(error.error.code).to.eq(-32603);
-        expect(error.error.name).to.eq(`Internal error`);
-        expect(error.error.message).to.contain('Error invoking RPC:');
       }
     });
   }

--- a/packages/server/tests/acceptance/ws/getStorageAt.spec.ts
+++ b/packages/server/tests/acceptance/ws/getStorageAt.spec.ts
@@ -26,18 +26,16 @@ import { AliasAccount } from '../../clients/servicesClient';
 describe('@release @web-socket eth_getStorageAt', async function () {
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const METHOD_NAME = 'eth_getStorageAt';
+  const FAKE_TX_HASH = `0x${'00'.repeat(32)}`;
   const INVALID_PARAMS = [
     [],
-    ['0xfFC7d3ff264c838aD75167e64d043794bf1BD52e'],
-    ['0xfFC7d3ff264c838aD75167e64d043794bf1BD52e', '0x0', 'latest', '0xhedera'],
-  ];
-
-  const INVALID_VALUES = [
     ['', ''],
-    ['0xfFC7d3ff264c838aD75167e64d043794bf1BD52e', ''],
     ['', '0x0'],
-    ['0xfFC7d3ff264c838aD75167e64d043794bf1BD52e', 36, 'latest'],
-    ['0xfFC7d3ff264c838aD75167e64d043794bf1BD52e', '0xhbar', 'latest'],
+    [FAKE_TX_HASH],
+    [FAKE_TX_HASH, ''],
+    [FAKE_TX_HASH, 36, 'latest'],
+    [FAKE_TX_HASH, '0xhbar', 'latest'],
+    [FAKE_TX_HASH, '0x0', 'latest', '0xhedera'],
   ];
 
   let accounts: AliasAccount[] = [];
@@ -71,22 +69,6 @@ describe('@release @web-socket eth_getStorageAt', async function () {
       } catch (error) {
         expect(error.error).to.exist;
         expect(error.error.code).to.eq(-32602);
-        expect(error.error.name).to.eq('Invalid parameters');
-        expect(error.error.message).to.eq('Invalid params');
-      }
-    });
-  }
-
-  for (const params of INVALID_VALUES) {
-    it(`Should handle invalid value. params=[${JSON.stringify(params)}]`, async () => {
-      try {
-        await wsProvider.send(METHOD_NAME, [...params]);
-        expect(true).to.eq(false);
-      } catch (error) {
-        expect(error.error).to.exist;
-        expect(error.error.code).to.eq(-32603);
-        expect(error.error.name).to.eq('Internal error');
-        expect(error.error.message).to.contain('Error invoking RPC');
       }
     });
   }

--- a/packages/server/tests/acceptance/ws/getTransactionByHash.spec.ts
+++ b/packages/server/tests/acceptance/ws/getTransactionByHash.spec.ts
@@ -31,8 +31,20 @@ describe('@release @web-socket eth_getTransactionByHash', async function () {
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const METHOD_NAME = 'eth_getTransactionByHash';
   const CHAIN_ID = process.env.CHAIN_ID || '0x12a';
-  const INVALID_PARAMS = [['hedera', 'hbar'], [], ['websocket', 'rpc', 'invalid']];
-  const INVALID_TX_HASH = ['0xhbar', '0xHedera', '', 66, 'abc', true, false, 39];
+  const FAKE_TX_HASH = `0x${'00'.repeat(32)}`;
+  const INVALID_PARAMS = [
+    [],
+    [''],
+    [66],
+    [39],
+    [true],
+    ['abc'],
+    ['0xhbar'],
+    ['txHash'],
+    ['0xHedera'],
+    [FAKE_TX_HASH, 'hbar'],
+    [FAKE_TX_HASH, 'rpc', 'invalid'],
+  ];
 
   let accounts: AliasAccount[] = [];
   let mirrorNodeServer: MirrorClient, requestId: string, relayClient: RelayClient, wsProvider: WebSocketProvider;
@@ -46,6 +58,7 @@ describe('@release @web-socket eth_getTransactionByHash', async function () {
 
     accounts[0] = await servicesNode.createAliasAccount(100, relay.provider, requestId);
     accounts[1] = await servicesNode.createAliasAccount(5, relay.provider, requestId);
+    await new Promise((r) => setTimeout(r, 1000)); // wait for accounts to propagate
   });
 
   beforeEach(async () => {
@@ -59,34 +72,13 @@ describe('@release @web-socket eth_getTransactionByHash', async function () {
   });
 
   for (const params of INVALID_PARAMS) {
-    it(`Should throw predefined.INVALID_PARAMETERS if the request's params variable is invalid (params.length !== 1). params=[${params}]`, async () => {
+    it(`Should throw predefined.INVALID_PARAMETERS if the request's params variable is invalid. params=[${params}]`, async () => {
       try {
         await wsProvider.send(METHOD_NAME, params);
         expect(true).to.eq(false);
       } catch (error) {
         expect(error.error).to.exist;
         expect(error.error.code).to.eq(-32602);
-        expect(error.error.name).to.eq('Invalid parameters');
-        expect(error.error.message).to.eq('Invalid params');
-      }
-    });
-  }
-
-  for (const txHash of INVALID_TX_HASH) {
-    it(`Should handle invalid data correctly. txHash = ${txHash}`, async () => {
-      try {
-        const res = await wsProvider.send(METHOD_NAME, [txHash]);
-        if (txHash === '') {
-          expect(res).to.be.null;
-        } else {
-          expect(true).to.eq(false);
-        }
-      } catch (error) {
-        expect(error.error.code).to.eq(-32603);
-        expect(error.error.name).to.eq(`Internal error`);
-        expect(error.error.message).to.eq(
-          'Error invoking RPC: "Invalid Transaction id. Please use \\"shard.realm.num-sss-nnn\\" format where sss are seconds and nnn are nanoseconds"',
-        );
       }
     });
   }

--- a/packages/server/tests/acceptance/ws/getTransactionCount.spec.ts
+++ b/packages/server/tests/acceptance/ws/getTransactionCount.spec.ts
@@ -19,18 +19,18 @@
  */
 
 // external resources
-import { expect } from 'chai';
-import { Contract, ethers, JsonRpcProvider, WebSocketProvider } from 'ethers';
-import { AliasAccount } from '../../clients/servicesClient';
 import WebSocket from 'ws';
-import basicContractJson from '../../contracts/Basic.json';
-import { numberTo0x } from '@hashgraph/json-rpc-relay/src/formatters';
+import { expect } from 'chai';
 import { Utils } from '../../helpers/utils';
 import Assertions from '../../helpers/assertions';
-const CHAIN_ID = process.env.CHAIN_ID || 0;
-const ONE_TINYBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 10)));
+import basicContractJson from '../../contracts/Basic.json';
+import { AliasAccount } from '../../clients/servicesClient';
+import { numberTo0x } from '@hashgraph/json-rpc-relay/src/formatters';
+import { Contract, ethers, JsonRpcProvider, WebSocketProvider } from 'ethers';
 
 describe('@release @web-socket eth_getTransactionCount', async function () {
+  const CHAIN_ID = process.env.CHAIN_ID || 0;
+  const ONE_TINYBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 10)));
   const RELAY_URL = `${process.env.RELAY_ENDPOINT}`;
   const WS_RELAY_URL = `${process.env.WS_RELAY_URL}`;
   const defaultGasPrice = numberTo0x(Assertions.defaultGasPrice);

--- a/packages/ws-server/src/controllers/eth_blockNumber.ts
+++ b/packages/ws-server/src/controllers/eth_blockNumber.ts
@@ -18,32 +18,35 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_blockNumber" method request by retrieving the current block number from the Hedera network.
  * Validates the parameters, retrieves the current block number using the relay object, and sends the response back to the client.
  * @param {any} ctx - The context object containing information about the WebSocket connection.
  * @param {any[]} params - The parameters of the method request, expecting no parameters.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting a block param (block number or block tag) and a boolean flag indicating whether to include detailed information.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthBlockNumber = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthBlockNumber = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   if (params.length !== 0) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_call.ts
+++ b/packages/ws-server/src/controllers/eth_call.ts
@@ -18,34 +18,33 @@
  *
  */
 
-import { Relay } from '@hashgraph/json-rpc-relay';
 import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
 
 /**
  * Handles the "eth_call" method request by executing a call operation against a contract on the Hedera network.
  * Validates the parameters, executes the call operation using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting transaction information and a block parameter.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
- * @returns {Promise<void>} Returns a promise that resolves after processing the request.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting transaction information and a block parameter.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthCall = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthCall = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   const TX_INFO = params[0];
   const BLOCK_PARAM = params[1];
   const TAG = JSON.stringify({ method, txInfo: TX_INFO, block: BLOCK_PARAM });

--- a/packages/ws-server/src/controllers/eth_estimateGas.ts
+++ b/packages/ws-server/src/controllers/eth_estimateGas.ts
@@ -18,32 +18,34 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { predefined, Relay } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_estimateGas" method request by estimating the gas needed to execute a transaction.
  * Validates the parameters, retrieves the gas estimation using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting a transaction object.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
+ * @returns {Promise<void>} Returns a promise that resolves after processing the request.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthEstimateGas = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthEstimateGas = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   if (params.length !== 1) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_gasPrice.ts
+++ b/packages/ws-server/src/controllers/eth_gasPrice.ts
@@ -18,32 +18,33 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_gasPrice" method request by retrieving the current gas price from the Hedera network.
  * Validates the parameters, retrieves the current gas price using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting no parameters.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting no parameters.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGasPrice = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthGasPrice = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   if (params.length !== 0) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_getBalance.ts
+++ b/packages/ws-server/src/controllers/eth_getBalance.ts
@@ -18,39 +18,40 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_getBalance" method request by retrieving the balance of the specified address.
  * Validates the parameters, retrieves the balance using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting an address and a block parameter.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting an address and a block parameter.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetBalance = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
-  if (params.length !== 2) {
-    throw predefined.INVALID_PARAMETERS;
-  }
-
+export const handleEthGetBalance = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   const ADDRESS = params[0];
   const BLOCK_PARAM = params[1];
   const TAG = JSON.stringify({ method, address: ADDRESS, blockParam: BLOCK_PARAM });
+
+  if (params.length !== 2) {
+    throw predefined.INVALID_PARAMETERS;
+  }
 
   logger.info(`${connectionIdPrefix} ${requestIdPrefix}: Retrieving balance information for tag=${TAG}`);
 

--- a/packages/ws-server/src/controllers/eth_getBlockByHash.ts
+++ b/packages/ws-server/src/controllers/eth_getBlockByHash.ts
@@ -18,33 +18,34 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 import { validate32bytesHexaString } from '../utils/validators';
 
 /**
  * Handles the "eth_getBlockByHash" method request by retrieving block information using the specified block hash.
  * Validates the parameters, retrieves block information using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting a block hash and a boolean flag indicating whether to include detailed information.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting a block hash and a boolean flag indicating whether to include detailed information.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetBlockByHash = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthGetBlockByHash = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   const BLOCK_HASH = params[0];
   const SHOW_DETAILS = params[1];
   const TAG = JSON.stringify({ method, blockHash: BLOCK_HASH, showDetails: SHOW_DETAILS });

--- a/packages/ws-server/src/controllers/eth_getBlockByNumber.ts
+++ b/packages/ws-server/src/controllers/eth_getBlockByNumber.ts
@@ -18,32 +18,33 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_getBlockByNumber" method request by retrieving block information using the specified block param (block number or block tags).
  * Validates the parameters, retrieves block information using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting a block param (block number or block tag) and a boolean flag indicating whether to include detailed information.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting a block param (block number or block tag) and a boolean flag indicating whether to include detailed information.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetBlockByNumber = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthGetBlockByNumber = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   const BLOCK_PARAM = params[0];
   const SHOW_DETAILS = params[1];
   const TAG = JSON.stringify({ method, blockParam: BLOCK_PARAM, showDetails: SHOW_DETAILS });

--- a/packages/ws-server/src/controllers/eth_getCode.ts
+++ b/packages/ws-server/src/controllers/eth_getCode.ts
@@ -18,32 +18,33 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { predefined, Relay } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_getCode" method request by retrieving the code at a specific address on the Hedera network.
  * Validates the parameters, retrieves the contract code using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting an address and a block parameter.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting an address and a block tag.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetCode = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthGetCode = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   if (params.length !== 2) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_getLogs.ts
+++ b/packages/ws-server/src/controllers/eth_getLogs.ts
@@ -18,33 +18,33 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_getLogs" method request by retrieving logs that match the specified filter object.
  * Validates the parameters, retrieves the logs using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting a filter object.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
- * @returns {Promise<void>} Returns a promise that resolves after processing the request.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting a filter object.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetLogs = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-): Promise<any> => {
+export const handleEthGetLogs = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}): Promise<any> => {
   if (params.length !== 1) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_getStorageAt.ts
+++ b/packages/ws-server/src/controllers/eth_getStorageAt.ts
@@ -18,33 +18,33 @@
  *
  */
 
-import { Relay } from '@hashgraph/json-rpc-relay';
 import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
 
 /**
  * Handles the "eth_getStorageAt" method request by retrieving the value stored at a specific storage position in an Hedera account's storage.
  * Validates the parameters, retrieves the storage information using the relay object, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting an address, a position, and a block parameter.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting an address, a position, and a block parameter.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
  * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetStorageAt = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthGetStorageAt = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   if (params.length !== 2 && params.length !== 3) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_getTransactionByHash.ts
+++ b/packages/ws-server/src/controllers/eth_getTransactionByHash.ts
@@ -18,33 +18,33 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_getTransactionByHash" method request by retrieving transaction details from the Hedera network.
  * Validates the parameters, retrieves the transaction details, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting a single parameter: the transaction hash.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
- * @returns {Promise<any>} Returns a promise that resolves with the JSON-RPC response to the client.
- * @throws {JsonRpcError} Throws a JsonRpcError if there is an issue with the parameters or an internal error occurs.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting a transaction hash.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
+ * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetTransactionByHash = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-): Promise<any> => {
+export const handleEthGetTransactionByHash = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}): Promise<any> => {
   if (params.length !== 1) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_getTransactionCount.ts
+++ b/packages/ws-server/src/controllers/eth_getTransactionCount.ts
@@ -18,32 +18,32 @@
  *
  */
 
-import { Relay } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
 
 /**
  * Handles the "eth_getTransactionCount" method request by retrieving the transaction count of an address.
  * Validates the parameters, retrieves the transaction count from the relay, and returns the response to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting an address.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The method name being handled.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
- * @returns {Promise<any>} Returns a promise that resolves with the transaction count response.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting an address.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
+ * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetTransactionCount = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthGetTransactionCount = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   const ADDRESS = params[0];
   const TAG = JSON.stringify({ method, address: ADDRESS });
 

--- a/packages/ws-server/src/controllers/eth_getTransactionReceipt.ts
+++ b/packages/ws-server/src/controllers/eth_getTransactionReceipt.ts
@@ -18,33 +18,33 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_getTransactionReceipt" method request by retrieving transaction receipt details from the Hedera network.
  * Validates the parameters, retrieves the transaction receipt details, and sends the response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any[]} params - The parameters of the method request, expecting a single parameter: the transaction hash.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
- * @returns {Promise<any>} Returns a promise that resolves with the JSON-RPC response to the client.
- * @throws {JsonRpcError} Throws a JsonRpcError if there is an issue with the parameters or an internal error occurs.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting a single parameter: the transaction hash.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
+ * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthGetTransactionReceipt = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-): Promise<any> => {
+export const handleEthGetTransactionReceipt = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}): Promise<any> => {
   if (params.length !== 1) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
+++ b/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
@@ -18,33 +18,33 @@
  *
  */
 
+import { predefined } from '@hashgraph/json-rpc-relay';
 import { handleSendingRequestsToRelay } from './helpers';
-import { Relay, predefined } from '@hashgraph/json-rpc-relay';
 
 /**
  * Handles the "eth_sendRawTransaction" method request by submitting a raw transaction to the Websocket server.
  * Validates the parameters, submits the transaction, and sends the txHash response back to the client.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any} params - The parameters of the method request, expecting a single parameter: the signed transaction.
- * @param {any} logger - The logger object for logging messages and events.
- * @param {Relay} relay - The relay object for interacting with the Hedera network.
- * @param {any} request - The request object received from the client.
- * @param {string} method - The name of the method.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {string} connectionIdPrefix - The prefix for the connection ID.
- * @returns {Promise<any>} Returns a promise that resolves with the JSON-RPC response to the client.
- * @throws {JsonRpcError} Throws a JsonRpcError if there is an issue with the parameters or an internal error occurs.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting a signed transaction.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {any} args.request - The request object received from the client.
+ * @param {string} args.method - The JSON-RPC method associated with the request.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {string} args.connectionIdPrefix - The prefix for the connection ID.
+ * @throws {JsonRpcError} Throws a JsonRpcError if the method parameters are invalid or an internal error occurs.
  */
-export const handleEthSendRawTransaction = async (
-  ctx: any,
-  params: any,
-  logger: any,
-  relay: Relay,
-  request: any,
-  method: string,
-  requestIdPrefix: string,
-  connectionIdPrefix: string,
-) => {
+export const handleEthSendRawTransaction = async ({
+  ctx,
+  params,
+  logger,
+  relay,
+  request,
+  method,
+  requestIdPrefix,
+  connectionIdPrefix,
+}) => {
   if (params.length !== 1) {
     throw predefined.INVALID_PARAMETERS;
   }

--- a/packages/ws-server/src/controllers/eth_subscribe.ts
+++ b/packages/ws-server/src/controllers/eth_subscribe.ts
@@ -124,26 +124,27 @@ const handleEthSubscribeLogs = async (
 /**
  * Handles subscription requests for on-chain events.
  * Subscribes to the specified event type and returns the response.
- * @param {any} ctx - The context object containing information about the WebSocket connection.
- * @param {any} params - The parameters of the subscription request.
- * @param {string} requestIdPrefix - The prefix for the request ID.
- * @param {any} request - The request object received from the client.
- * @param {Relay} relay - The relay object used for managing WebSocket subscriptions.
- * @param {MirrorNodeClient} mirrorNodeClient - The client for interacting with the MirrorNode API.
- * @param {ConnectionLimiter} limiter - The limiter object used for rate limiting WebSocket connections.
- * @param {any} logger - The logger object used for logging subscription information.
- * @returns {Promise<any>} Returns a promise that resolves with the response to the subscription request.
+ * @param {object} args - An object containing the function parameters as properties.
+ * @param {any} args.ctx - The context object containing information about the WebSocket connection.
+ * @param {any[]} args.params - The parameters of the method request, expecting an event and filters.
+ * @param {string} args.requestIdPrefix - The prefix for the request ID.
+ * @param {any} args.request - The request object received from the client.
+ * @param {Relay} args.relay - The relay object for interacting with the Hedera network.
+ * @param {MirrorNodeClient} args.mirrorNodeClient - The mirror node client for handling subscriptions.
+ * @param {ConnectionLimiter} args.limiter - The limiter object for managing connection subscriptions.
+ * @param {any} args.logger - The logger object for logging messages and events.
+ * @returns {Promise<any>} Returns a promise that resolves with the subscription response.
  */
-export const handleEthSubsribe = async (
-  ctx: any,
-  params: any,
-  requestIdPrefix: string,
-  request: any,
-  relay: Relay,
-  mirrorNodeClient: MirrorNodeClient,
-  limiter: ConnectionLimiter,
-  logger: any,
-): Promise<any> => {
+export const handleEthSubsribe = async ({
+  ctx,
+  params,
+  requestIdPrefix,
+  request,
+  relay,
+  mirrorNodeClient,
+  limiter,
+  logger,
+}): Promise<any> => {
   const event = params[0];
   const filters = params[1];
   let response: any;

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -140,7 +140,7 @@ app.ws.use(async (ctx) => {
     methodsCounterByIp.labels(ctx.request.ip, method).inc();
 
     // Check if the subscription limit is exceeded for ETH_SUBSCRIBE method
-    let relayResponse, response;
+    let response;
     if (method === WS_CONSTANTS.METHODS.ETH_SUBSCRIBE && !limiter.validateSubscriptionLimit(ctx)) {
       response = jsonResp(request.id, predefined.MAX_SUBSCRIPTIONS, undefined);
       ctx.websocket.send(JSON.stringify(response));
@@ -149,18 +149,11 @@ app.ws.use(async (ctx) => {
 
     // method logics
     try {
+      const sharedParams = { ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix };
+
       switch (method) {
         case WS_CONSTANTS.METHODS.ETH_SUBSCRIBE:
-          response = await handleEthSubsribe(
-            ctx,
-            params,
-            requestIdPrefix,
-            request,
-            relay,
-            mirrorNodeClient,
-            limiter,
-            logger,
-          );
+          response = await handleEthSubsribe({ ...sharedParams, limiter, mirrorNodeClient });
           break;
         case WS_CONSTANTS.METHODS.ETH_UNSUBSCRIBE:
           response = handleEthUnsubscribe(ctx, params, request, relay, limiter);
@@ -169,95 +162,46 @@ app.ws.use(async (ctx) => {
           response = jsonResp(request.id, null, CHAIN_ID);
           break;
         case WS_CONSTANTS.METHODS.ETH_SEND_RAW_TRANSACTION:
-          await handleEthSendRawTransaction(
-            ctx,
-            params,
-            logger,
-            relay,
-            request,
-            method,
-            requestIdPrefix,
-            connectionIdPrefix,
-          );
+          await handleEthSendRawTransaction(sharedParams);
           break;
         case WS_CONSTANTS.METHODS.ETH_GET_CODE:
-          await handleEthGetCode(ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix);
-          // response = jsonResp(request.id, null, relayResponse.result);
+          await handleEthGetCode(sharedParams);
           break;
         case WS_CONSTANTS.METHODS.ETH_ESTIMATE_GAS:
-          await handleEthEstimateGas(ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix);
+          await handleEthEstimateGas(sharedParams);
           break;
         case WS_CONSTANTS.METHODS.ETH_GET_TRANSACTION_BY_HASH:
-          await handleEthGetTransactionByHash(
-            ctx,
-            params,
-            logger,
-            relay,
-            request,
-            method,
-            requestIdPrefix,
-            connectionIdPrefix,
-          );
+          await handleEthGetTransactionByHash(sharedParams);
           break;
         case WS_CONSTANTS.METHODS.ETH_GET_TRANSACTION_RECEIPT:
-          await handleEthGetTransactionReceipt(
-            ctx,
-            params,
-            logger,
-            relay,
-            request,
-            method,
-            requestIdPrefix,
-            connectionIdPrefix,
-          );
+          await handleEthGetTransactionReceipt(sharedParams);
           break;
         case WS_CONSTANTS.METHODS.ETH_GET_TRANSACTION_COUNT:
-          await handleEthGetTransactionCount(
-            ctx,
-            params,
-            logger,
-            relay,
-            request,
-            method,
-            requestIdPrefix,
-            connectionIdPrefix,
-          );
+          await handleEthGetTransactionCount(sharedParams);
           break;
         case WS_CONSTANTS.METHODS.ETH_GET_BLOCK_BY_HASH:
-          await handleEthGetBlockByHash(
-            ctx,
-            params,
-            logger,
-            relay,
-            request,
-            method,
-            requestIdPrefix,
-            connectionIdPrefix,
-          );
+          await handleEthGetBlockByHash(sharedParams);
           break;
         case WS_CONSTANTS.METHODS.ETH_GET_BLOCK_BY_NUMBER:
-          await handleEthGetBlockByNumber(
-            ctx,
-            params,
-            logger,
-            relay,
-            request,
-            method,
-            requestIdPrefix,
-            connectionIdPrefix,
-          );
+          await handleEthGetBlockByNumber(sharedParams);
+          break;
         case WS_CONSTANTS.METHODS.ETH_BLOCK_NUMBER:
-          await handleEthBlockNumber(ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix);
+          await handleEthBlockNumber(sharedParams);
+          break;
         case WS_CONSTANTS.METHODS.ETH_GAS_PRICE:
-          await handleEthGasPrice(ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix);
+          await handleEthGasPrice(sharedParams);
+          break;
         case WS_CONSTANTS.METHODS.ETH_GET_BALANCE:
-          await handleEthGetBalance(ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix);
+          await handleEthGetBalance(sharedParams);
+          break;
         case WS_CONSTANTS.METHODS.ETH_GET_STORAGE_AT:
-          await handleEthGetStorageAt(ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix);
+          await handleEthGetStorageAt(sharedParams);
+          break;
         case WS_CONSTANTS.METHODS.ETH_GET_LOGS:
-          await handleEthGetLogs(ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix);
+          await handleEthGetLogs(sharedParams);
+          break;
         case WS_CONSTANTS.METHODS.ETH_CALL:
-          await handleEthCall(ctx, params, logger, relay, request, method, requestIdPrefix, connectionIdPrefix);
+          await handleEthCall(sharedParams);
           break;
         default:
           response = jsonResp(request.id, DEFAULT_ERROR, null);


### PR DESCRIPTION
**Description**:
This PR add a validate solution which utilizes the param validator from relay-server package to validate params coming into WS server. Fix acceptance tests.

- This PR also group the common params used for the handlers into a `sharedParams` object so it can be used among the handlers

**Related issue(s)**:

Fixes #2311

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
