### PR TITLE
fix: Removing `name` field from RPC Error when returning Execution Revert on `eth_call`

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -23,10 +23,10 @@ import constants from '../../lib/constants';
 export class JsonRpcError {
   public code: number;
   public message: string;
-  public name: string;
+  public name?: string;
   public data?: string;
 
-  constructor(args: { name: string; code: number; message: string; data?: string }, requestId?: string) {
+  constructor(args: { name?: string; code: number; message: string; data?: string }, requestId?: string) {
     this.code = args.code;
     this.name = args.name;
     this.message = requestId ? `[${constants.REQUEST_ID_STRING}${requestId}] ` + args.message : args.message;
@@ -37,7 +37,6 @@ export class JsonRpcError {
 export const predefined = {
   CONTRACT_REVERT: (errorMessage?: string, data: string = '') =>
     new JsonRpcError({
-      name: 'Contract revert executed',
       code: -32008,
       message: `execution reverted: ${decodeErrorMessage(errorMessage)}`,
       data: data,

--- a/packages/relay/tests/lib/eth/eth_call.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_call.spec.ts
@@ -529,7 +529,7 @@ describe('@ethCall Eth Call spec', async function () {
 
       expect(result).to.exist;
       expect((result as JsonRpcError).code).to.equal(-32008);
-      expect((result as JsonRpcError).name).to.equal('Contract revert executed');
+      expect((result as JsonRpcError).name).to.undefined;
       expect((result as JsonRpcError).message).to.equal(`execution reverted: ${defaultErrorMessageText}`);
       expect((result as JsonRpcError).data).to.equal(defaultErrorMessageHex);
     });
@@ -723,7 +723,7 @@ describe('@ethCall Eth Call spec', async function () {
       const result = await ethImpl.call(callData, 'latest');
       expect(result).to.be.not.null;
       expect((result as JsonRpcError).code).to.eq(-32008);
-      expect((result as JsonRpcError).name).to.eq('Contract revert executed');
+      expect((result as JsonRpcError).name).to.undefined;
       expect((result as JsonRpcError).message).to.contain(mockData.contractReverted._status.messages[0].message);
     });
 
@@ -774,7 +774,7 @@ describe('@ethCall Eth Call spec', async function () {
       sinon.assert.notCalled(sdkClientStub.submitContractCallQueryWithRetry);
       expect(result).to.not.be.null;
       expect((result as JsonRpcError).code).to.eq(-32008);
-      expect((result as JsonRpcError).name).to.eq('Contract revert executed');
+      expect((result as JsonRpcError).name).to.undefined;
       expect((result as JsonRpcError).message).to.contain(mockData.contractReverted._status.messages[0].message);
     });
 
@@ -805,7 +805,7 @@ describe('@ethCall Eth Call spec', async function () {
 
       expect(result).to.exist;
       expect((result as JsonRpcError).code).to.eq(-32008);
-      expect((result as JsonRpcError).name).to.eq('Contract revert executed');
+      expect((result as JsonRpcError).name).to.undefined;
       expect((result as JsonRpcError).message).to.equal(`execution reverted: ${defaultErrorMessageText}`);
       expect((result as JsonRpcError).data).to.equal(defaultErrorMessageHex);
     });

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -27,7 +27,7 @@ import { Utils } from '../helpers/utils';
 // local resources
 import reverterContractJson from '../contracts/Reverter.json';
 import { EthImpl } from '../../../../packages/relay/src/lib/eth';
-import { predefined } from '../../../../packages/relay';
+import { JsonRpcError, predefined } from '../../../../packages/relay';
 import basicContractJson from '../contracts/Basic.json';
 import callerContractJson from '../contracts/Caller.json';
 import DeployerContractJson from '../contracts/Deployer.json';
@@ -567,7 +567,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       expect(response.data.error).to.exist;
       expect(response.data.error.code).to.be.equal(-32008);
       expect(response.data.error.message).to.contain('execution reverted: CONTRACT_REVERT_EXECUTED');
-      expect(response.data.error.name).to.be.equal('Contract revert executed');
+      expect((result as JsonRpcError).name).to.undefined;
     });
   });
 

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -567,7 +567,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       expect(response.data.error).to.exist;
       expect(response.data.error.code).to.be.equal(-32008);
       expect(response.data.error.message).to.contain('execution reverted: CONTRACT_REVERT_EXECUTED');
-      expect((result as JsonRpcError).name).to.undefined;
+      expect(response.data.error.name).to.undefined;
     });
   });
 

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -94,7 +94,7 @@ export default class RelayClient {
       );
       Assertions.expectedError();
     } catch (e: any) {
-      if (expectedRpcError.name === 'Contract revert executed') {
+      if (expectedRpcError.message.includes('execution reverted')) {
         if (e?.info) {
           Assertions.jsonRpcError(e.info.error, expectedRpcError);
         } else if (e?.error) {


### PR DESCRIPTION
**Description**:
Removing `name` field from RPC Error when returning `execution revert` error from `eth_call` due to not being compatible with thegraph node, since it does not maps to their RPC Error structure.


**Related issue(s)**:

Fixes #2330

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
