### PR TITLE
fix: allows nullable value for `transaction.to` (#2314) (#2319)

### DIFF
--- a/packages/server/src/validator/objectTypes.ts
+++ b/packages/server/src/validator/objectTypes.ts
@@ -43,7 +43,7 @@ export const OBJECTS_VALIDATIONS = {
     },
     to: {
       type: 'address',
-      nullable: false,
+      nullable: true,
     },
     gas: {
       type: 'hex',

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -230,6 +230,23 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
       expect(res).to.not.be.equal('0x0');
     });
 
+    it('should execute "eth_estimateGas" with `to` filed set to null (deployment transaction)', async function () {
+      const res = await relay.call(
+        RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS,
+        [
+          {
+            from: '0x114f60009ee6b84861c0cdae8829751e517bc4d7',
+            to: null,
+            value: `0x${'00'.repeat(5121)}`,
+          },
+        ],
+        requestId,
+      );
+      expect(res).to.contain('0x');
+      expect(res).to.not.be.equal('0x');
+      expect(res).to.not.be.equal('0x0');
+    });
+
     it('should not be able to execute "eth_estimateGas" with no transaction object', async function () {
       await relay.callFailing('eth_estimateGas', [], predefined.MISSING_REQUIRED_PARAMETER(0), requestId);
     });


### PR DESCRIPTION
fix: allow nullable value for `transaction.to` (#2314)

**Related issue(s)**:

Fixes #2314

