### PR TITLE
chore: Revert SNYK #2298 on 0.46 branch 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.20.1-bullseye-slim
+FROM node:18.18.2-bullseye-slim
 
 # Setup
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
**Description**:
Revert "[Snyk] Security upgrade node from 18.18.2-bullseye-slim to 18.20.1-bullseye-slim"

Due to it is breaking the buildx process on CI.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
