### PR TITLE
fix: fixed setting WS_NEW_HEADS_ENABLED true as default logic (#2360)

### DIFF
--- a/packages/ws-server/src/controllers/eth_subscribe.ts
+++ b/packages/ws-server/src/controllers/eth_subscribe.ts
@@ -73,11 +73,18 @@ const handleEthSubscribeNewHeads = (
   event: string,
   relay: Relay,
   logger: any,
+  connectionIdPrefix: string,
+  requestIdPrefix: string,
 ): { response: any; subscriptionId: any } => {
-  const wsNewHeadsEnabled = process.env.WS_NEW_HEADS_ENABLED ? Boolean(Number(process.env.WS_NEW_HEADS_ENABLED)) : true;
-  if (wsNewHeadsEnabled) {
+  const wsNewHeadsEnabled =
+    typeof process.env.WS_NEW_HEADS_ENABLED !== 'undefined' ? process.env.WS_NEW_HEADS_ENABLED : 'true';
+
+  if (wsNewHeadsEnabled === 'true') {
     ({ response, subscriptionId } = subscribeToNewHeads(filters, response, subscriptionId, ctx, event, relay, logger));
   } else {
+    logger.warn(
+      `${connectionIdPrefix} ${requestIdPrefix}: Unsupported JSON-RPC method due to the value of environment variable WS_NEW_HEADS_ENABLED`,
+    );
     response = jsonResp(request.id, predefined.UNSUPPORTED_METHOD, undefined);
   }
   return { response, subscriptionId };
@@ -145,6 +152,7 @@ export const handleEthSubsribe = async ({
   mirrorNodeClient,
   limiter,
   logger,
+  connectionIdPrefix,
 }): Promise<any> => {
   const event = params[0];
   const filters = params[1];
@@ -176,6 +184,8 @@ export const handleEthSubsribe = async ({
         event,
         relay,
         logger,
+        connectionIdPrefix,
+        requestIdPrefix,
       ));
       break;
     case constants.SUBSCRIBE_EVENTS.NEW_PENDING_TRANSACTIONS:

--- a/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
@@ -189,7 +189,6 @@ describe('@release @web-socket eth_subscribe newHeads', async function () {
 
   describe('Subscriptions for newHeads', async function () {
     it('should subscribe to newHeads, include transactions true, and receive a valid JSON RPC response', (done) => {
-      process.env.WS_NEW_HEADS_ENABLED = 'true';
       const webSocket = new WebSocket(WS_RELAY_URL);
       const subscriptionId = 1;
       webSocket.on('open', function open() {
@@ -219,7 +218,6 @@ describe('@release @web-socket eth_subscribe newHeads', async function () {
     });
 
     it('should subscribe to newHeads, without the "include transactions", and receive a valid JSON RPC response', (done) => {
-      process.env.WS_NEW_HEADS_ENABLED = 'true';
       const webSocket = new WebSocket(WS_RELAY_URL);
       const subscriptionId = 1;
       webSocket.on('open', function open() {
@@ -249,7 +247,6 @@ describe('@release @web-socket eth_subscribe newHeads', async function () {
     });
 
     it('should subscribe to newHeads, with "include transactions false", and receive a valid JSON RPC response', (done) => {
-      process.env.WS_NEW_HEADS_ENABLED = 'true';
       const webSocket = new WebSocket(WS_RELAY_URL);
       const subscriptionId = 1;
       webSocket.on('open', function open() {


### PR DESCRIPTION
**Description**:
- fixed setting WS_NEW_HEADS_ENABLED true as default logic 
- added a warning log if WS_NEW_HEADS_ENABLED is "false"

**Related issue(s)**:

Fixes #2360 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
