### PR TITLE
fix: updated MIRROR_NODE_RETRY_DELAY to 1800ms (#2371)

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -87,7 +87,7 @@ export class MirrorNodeClient {
   private static ACCOUNT_TIMESTAMP_PROPERTY = 'timestamp';
   private static ACCOUNT_TRANSACTION_TYPE_PROPERTY = 'transactiontype';
   private static CONTRACT_RESULT_LOGS_PROPERTY = 'logs';
-  private readonly MIRROR_NODE_RETRY_DELAY = parseInt(process.env.MIRROR_NODE_RETRY_DELAY || '2000');
+  private readonly MIRROR_NODE_RETRY_DELAY = parseInt(process.env.MIRROR_NODE_RETRY_DELAY || '1800');
 
   static acceptedErrorStatusesResponsePerRequestPathMap: Map<string, Array<number>> = new Map([
     [MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT, [404]],

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -87,7 +87,7 @@ export class MirrorNodeClient {
   private static ACCOUNT_TIMESTAMP_PROPERTY = 'timestamp';
   private static ACCOUNT_TRANSACTION_TYPE_PROPERTY = 'transactiontype';
   private static CONTRACT_RESULT_LOGS_PROPERTY = 'logs';
-  private readonly MIRROR_NODE_RETRY_DELAY = parseInt(process.env.MIRROR_NODE_RETRY_DELAY || '250');
+  private readonly MIRROR_NODE_RETRY_DELAY = parseInt(process.env.MIRROR_NODE_RETRY_DELAY || '2000');
 
   static acceptedErrorStatusesResponsePerRequestPathMap: Map<string, Array<number>> = new Map([
     [MirrorNodeClient.GET_ACCOUNTS_BY_ID_ENDPOINT, [404]],


### PR DESCRIPTION
**Description**:
this PR updated the MIRROR_NODE_RETRY_DELAY to 1800ms to extend the delayed duration between repeated retries to the mirror node

Initially it was discussed to be 2000ms, but 2000ms seems a little bit long so eth_getLogs seems to skip blocks. In anoother way, instead of getting the logs in the consecutive block, with delay being 2000ms, eth_getLogs will jump to the second next block in the specified range. 

**Related issue(s)**:

Fixes #2371 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
