### PR TITLE
fix: Re-enable tests.

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -126,7 +126,14 @@ const parseNumericEnvVar = (envVarName: string, fallbackConstantKey: string): nu
  */
 const weibarHexToTinyBarInt = (value: string): number | null => {
   if (value && value !== '0x') {
-    const tinybarValue = BigInt(value) / BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+    const weiBigInt = BigInt(value);
+    const coefBigInt = BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+    // Calculate the tinybar value
+    const tinybarValue = weiBigInt / coefBigInt;
+    // Check if there was a fractional part that got discarded
+    if (tinybarValue === BigInt(0) && weiBigInt > BigInt(0)) {
+      return 1; // Round up to the smallest unit of tinybar
+    }
     return Number(tinybarValue);
   }
   return null;

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2023 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,8 +167,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
       expect(parseInt(estimatedGas)).to.be.greaterThan(currentPrice * (1 - gasPriceDeviation));
     });
 
-    // Skip this test for now because of bug in mirror-node https://github.com/hashgraph/hedera-mirror-node/issues/6612 in Additional bug fixes
-    xit('@release should execute "eth_estimateGas" for existing account', async function () {
+    it('@release should execute "eth_estimateGas" for existing account', async function () {
       const res = await relay.call(
         RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS,
         [
@@ -179,12 +178,13 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
         ],
         requestId,
       );
+      const gasPriceDeviation = parseFloat((EthImpl.gasTxBaseCost * 0.2).toString());
       expect(res).to.contain('0x');
-      expect(res).to.equal(EthImpl.gasTxBaseCost);
+      expect(parseInt(res)).to.be.lessThan(Number(EthImpl.gasTxBaseCost) * (1 + gasPriceDeviation));
+      expect(parseInt(res)).to.be.greaterThan(Number(EthImpl.gasTxBaseCost) * (1 - gasPriceDeviation));
     });
 
-    // Skip this test for now because of bug in mirror-node https://github.com/hashgraph/hedera-mirror-node/issues/6612 in Additional bug fixes
-    xit('@release should execute "eth_estimateGas" hollow account creation', async function () {
+    it('@release should execute "eth_estimateGas" hollow account creation', async function () {
       const hollowAccount = ethers.Wallet.createRandom();
       const res = await relay.call(
         RelayCalls.ETH_ENDPOINTS.ETH_ESTIMATE_GAS,


### PR DESCRIPTION
Re-enabled tests released to `eth_estimateGas` and hollow accounts.

**Related issue(s)**:

Fixes #2384 

