### PR TITLE
fix: removed ping method in WS server

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,7 +116,6 @@ Unless you need to set a non-default value, it is recommended to only populate o
 | `WS_MULTIPLE_ADDRESSES_ENABLED` | "false"  | If enabled eth_subscribe will allow subscription to multiple contract address.                                                |
 | `WS_CACHE_TTL`                  | "20000"  | The time to live for cached entries.                                                                                          |
 | `WS_NEW_HEADS_ENABLED`.         | "true"   | Enables subscriptions for the latest blocks, `newHeads`.                                                                      |
-| `WS_PING_INTERVAL`              | "1000"   | Interval between ping messages. Set to `0` to disable pinger.                                                                 |
 
 ## Sample for connecting to Hedera Environments
 

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -73,8 +73,6 @@ const mirrorNodeClient = relay.mirrorClient();
 const limiter = new ConnectionLimiter(logger, register);
 const wsMetricRegistry = new WsMetricRegistry(register);
 
-const pingInterval = Number(process.env.WS_PING_INTERVAL || 1000);
-
 const app = websockify(new Koa());
 app.ws.use(async (ctx) => {
   // Increment the total opened connections
@@ -243,12 +241,6 @@ app.ws.use(async (ctx) => {
     // Update the connection duration histogram with the calculated duration
     wsMetricRegistry.getHistogram('messageDuration').labels(method).observe(msgDurationInMiliSeconds);
   });
-
-  if (pingInterval > 0) {
-    setInterval(async () => {
-      ctx.websocket.send(JSON.stringify(jsonResp(null, null, null)));
-    }, pingInterval);
-  }
 });
 
 const httpApp = new KoaJsonRpc(logger, register).getKoaApp();

--- a/packages/ws-server/tests/acceptance/estimateGas.spec.ts
+++ b/packages/ws-server/tests/acceptance/estimateGas.spec.ts
@@ -91,7 +91,7 @@ describe('@release @web-socket-batch-1 eth_estimateGas', async function () {
     expect(Number(estimatedGas)).to.be.greaterThan(currentPrice * (1 - gasPriceDeviation));
   });
 
-  it('should return the code through a websocket', async () => {
+  it('@release should execute "eth_estimateGas" for contract call, using a standard websocket', async () => {
     const tx = { to: basicContract.target, data: BASIC_CONTRACT_PING_CALL_DATA };
     const response = await WsTestHelper.sendRequestToStandardWebSocket(METHOD_NAME, [tx]);
     WsTestHelper.assertJsonRpcObject(response);

--- a/packages/ws-server/tests/acceptance/subscribe.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribe.spec.ts
@@ -142,20 +142,6 @@ describe('@release @web-socket-batch-3 eth_subscribe', async function () {
       expect(wsProvider.ready).to.eq(true);
     });
 
-    it('@release receives ping messages', async function () {
-      expect(wsProvider).to.exist;
-      expect(wsProvider.ready).to.eq(true);
-
-      let pings = 0;
-      wsProvider.websocket.on('message', (message) => {
-        pings++;
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 2500));
-
-      expect(pings).to.greaterThanOrEqual(2);
-    });
-
     it('@release Socket server responds to the eth_chainId event', async function () {
       const response = await wsProvider.send('eth_chainId', []);
       expect(response).to.eq(CHAIN_ID);

--- a/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
@@ -202,6 +202,7 @@ describe('@release @web-socket-batch-3 eth_subscribe newHeads', async function (
 
   describe('Subscriptions for newHeads', async function () {
     it('should subscribe to newHeads, include transactions true, and receive a valid JSON RPC response', (done) => {
+      process.env.WS_NEW_HEADS_ENABLED = 'true';
       const webSocket = new WebSocket(WS_RELAY_URL);
       const subscriptionId = 1;
       webSocket.on('open', function open() {
@@ -231,6 +232,7 @@ describe('@release @web-socket-batch-3 eth_subscribe newHeads', async function (
     });
 
     it('should subscribe to newHeads, without the "include transactions", and receive a valid JSON RPC response', (done) => {
+      process.env.WS_NEW_HEADS_ENABLED = 'true';
       const webSocket = new WebSocket(WS_RELAY_URL);
       const subscriptionId = 1;
       webSocket.on('open', function open() {
@@ -260,6 +262,7 @@ describe('@release @web-socket-batch-3 eth_subscribe newHeads', async function (
     });
 
     it('should subscribe to newHeads, with "include transactions false", and receive a valid JSON RPC response', (done) => {
+      process.env.WS_NEW_HEADS_ENABLED = 'true';
       const webSocket = new WebSocket(WS_RELAY_URL);
       const subscriptionId = 1;
       webSocket.on('open', function open() {


### PR DESCRIPTION
**Description**:
This PR removes the ping method in the WS server to stop the server from repeatitively sending null responses back to client

misc: renamed one of the test case which was incorrect

**Related issue(s)**:

Fixes #2359

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
