### PR TITLE
fix: Removed debugger settings.

### DIFF
--- a/packages/relay/tsconfig.json
+++ b/packages/relay/tsconfig.json
@@ -14,8 +14,7 @@
         "forceConsistentCasingInFileNames": true,
         "noImplicitAny": false,
         "declaration": true,
-        "strict": true,
-        "sourceMap": true
+        "strict": true
     },
     "include": [
         "src"

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -14,8 +14,7 @@
         "forceConsistentCasingInFileNames": true,
         "noImplicitAny": false,
         "declaration": true,
-        "strict": true,
-        "sourceMap": true
+        "strict": true
     },
     "include": [
         "src"


### PR DESCRIPTION

Fixes #2397 

Allowing `"sourceMap": true` to be deployed to production can have the following outcomes:

- Performance impact.  Although minimal, it can still result in data being transferred between client and server.
- More complicated deployment.  Managing and deploying source maps is an additional step in the deployment process
- Cleaner error reporting.  When the application uses error reporting tools.  Source maps may complicate the logging if they aren't integrated correctly with the tools.  

