### PR TITLE
test: broke websocket acceptancetest CI task into smaller separate batches (#2382)

### DIFF
--- a/.github/workflows/acceptance-public.yml
+++ b/.github/workflows/acceptance-public.yml
@@ -110,11 +110,31 @@ jobs:
       operator_id: ${{ inputs.operator_id }}
       operator_key: ${{ inputs.operator_key }}
 
-  websocket:
-    name: Websocket
+  websocket-batch-1:
+    name: Websocket Batch 1
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
-      testfilter: ws
+      testfilter: ws_batch1
+      test_ws_server: true
+      envfile: ${{ inputs.network }}Acceptance.env
+      operator_id: ${{ inputs.operator_id }}
+      operator_key: ${{ inputs.operator_key }}
+
+  websocket-batch-2:
+    name: Websocket Batch 2
+    uses: ./.github/workflows/acceptance-workflow.yml
+    with:
+      testfilter: ws_batch2
+      test_ws_server: true
+      envfile: ${{ inputs.network }}Acceptance.env
+      operator_id: ${{ inputs.operator_id }}
+      operator_key: ${{ inputs.operator_key }}
+
+  websocket-batch-3:
+    name: Websocket Batch 3
+    uses: ./.github/workflows/acceptance-workflow.yml
+    with:
+      testfilter: ws_batch3
       test_ws_server: true
       envfile: ${{ inputs.network }}Acceptance.env
       operator_id: ${{ inputs.operator_id }}
@@ -134,7 +154,9 @@ jobs:
       - tokenmanagement
       - htsprecompilev1
       - precompilecalls
-      - websocket
+      - websocket-batch-1
+      - websocket-batch-2
+      - websocket-batch-3
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -72,11 +72,25 @@ jobs:
     with:
       testfilter: precompile-calls
 
-  websocket:
-    name: Websocket
+  websocket-batch-1:
+    name: Websocket Batch 1
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
-      testfilter: ws
+      testfilter: ws_batch1
+      test_ws_server: true
+
+  websocket-batch-2:
+    name: Websocket Batch 2
+    uses: ./.github/workflows/acceptance-workflow.yml
+    with:
+      testfilter: ws_batch2
+      test_ws_server: true
+
+  websocket-batch-3:
+    name: Websocket Batch 3
+    uses: ./.github/workflows/acceptance-workflow.yml
+    with:
+      testfilter: ws_batch3
       test_ws_server: true
 
   cacheservice:
@@ -99,7 +113,9 @@ jobs:
       - tokenmanagement
       - htsprecompilev1
       - precompilecalls
-      - websocket
+      - websocket-batch-1
+      - websocket-batch-2
+      - websocket-batch-3
       - cacheservice
 
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "acceptancetest:htsprecompilev1": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@htsprecompilev1' --exit",
     "acceptancetest:release": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@release' --exit",
     "acceptancetest:ws": "ts-mocha packages/ws-server/tests/acceptance/index.spec.ts  -g '@web-socket' --exit",
+    "acceptancetest:ws_batch1": "ts-mocha packages/ws-server/tests/acceptance/index.spec.ts  -g '@web-socket-batch-1' --exit",
+    "acceptancetest:ws_batch2": "ts-mocha packages/ws-server/tests/acceptance/index.spec.ts  -g '@web-socket-batch-2' --exit",
+    "acceptancetest:ws_batch3": "ts-mocha packages/ws-server/tests/acceptance/index.spec.ts  -g '@web-socket-batch-3' --exit",
     "acceptancetest:ws_newheads": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@web-socket-newheads' --exit",
     "acceptancetest:precompile-calls": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@precompile-calls' --exit",
     "acceptancetest:cache-service": "ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@cache-service' --exit",
@@ -83,7 +86,7 @@
   },
   "overrides": {
     "protobufjs": "^7.2.4",
-    "semver": "^7.5.3"    
+    "semver": "^7.5.3"
   },
   "lint-staged": {
     "packages/**/src/**/*.ts": [

--- a/packages/ws-server/tests/acceptance/blockNumber.spec.ts
+++ b/packages/ws-server/tests/acceptance/blockNumber.spec.ts
@@ -23,7 +23,7 @@ import { expect } from 'chai';
 import { ethers, WebSocketProvider } from 'ethers';
 import { WsTestConstant, WsTestHelper } from '../helper';
 
-describe('@release @web-socket eth_blockNumber', async function () {
+describe('@release @web-socket-batch-1 eth_blockNumber', async function () {
   const METHOD_NAME = 'eth_blockNumber';
   const INVALID_PARAMS = [
     ['hedera', 'hbar'],

--- a/packages/ws-server/tests/acceptance/call.spec.ts
+++ b/packages/ws-server/tests/acceptance/call.spec.ts
@@ -26,7 +26,7 @@ import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 import ERC20MockJson from '@hashgraph/json-rpc-server/tests/contracts/ERC20Mock.json';
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 
-describe('@release @web-socket eth_call', async function () {
+describe('@release @web-socket-batch-1 eth_call', async function () {
   const METHOD_NAME = 'eth_call';
   const INVALID_PARAMS = [
     ['{}', false, '0x0'],

--- a/packages/ws-server/tests/acceptance/estimateGas.spec.ts
+++ b/packages/ws-server/tests/acceptance/estimateGas.spec.ts
@@ -21,13 +21,12 @@
 // external resources
 import { expect } from 'chai';
 import { Contract, ethers, WebSocketProvider } from 'ethers';
-// import { TransactionReceipt } from '@hashgraph/sdk';
 import { WsTestConstant, WsTestHelper } from '../helper';
 import basicContractJson from '@hashgraph/json-rpc-server/tests/contracts/Basic.json';
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 
-describe('@release @web-socket eth_estimateGas', async function () {
+describe('@release @web-socket-batch-1 eth_estimateGas', async function () {
   const METHOD_NAME = 'eth_estimateGas';
   const PING_CALL_ESTIMATED_GAS = '0x6122';
   const BASIC_CONTRACT_PING_CALL_DATA = '0x5c36b186';

--- a/packages/ws-server/tests/acceptance/gasPrice.spec.ts
+++ b/packages/ws-server/tests/acceptance/gasPrice.spec.ts
@@ -23,7 +23,7 @@ import { expect } from 'chai';
 import { ethers, WebSocketProvider } from 'ethers';
 import { WsTestConstant, WsTestHelper } from '../helper';
 
-describe('@release @web-socket eth_gasPrice', async function () {
+describe('@release @web-socket-batch-1 eth_gasPrice', async function () {
   const METHOD_NAME = 'eth_gasPrice';
   const INVALID_PARAMS = [
     ['hedera', 'hbar'],

--- a/packages/ws-server/tests/acceptance/getBalance.spec.ts
+++ b/packages/ws-server/tests/acceptance/getBalance.spec.ts
@@ -25,7 +25,7 @@ import { WsTestConstant, WsTestHelper } from '../helper';
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 
-describe('@release @web-socket eth_getBalance', async function () {
+describe('@release @web-socket-batch-1 eth_getBalance', async function () {
   const METHOD_NAME = 'eth_getBalance';
   const INVALID_PARAMS = [
     [],

--- a/packages/ws-server/tests/acceptance/getBlockByHash.spec.ts
+++ b/packages/ws-server/tests/acceptance/getBlockByHash.spec.ts
@@ -23,7 +23,7 @@ import { expect } from 'chai';
 import { ethers, WebSocketProvider } from 'ethers';
 import { WsTestConstant, WsTestHelper } from '../helper';
 
-describe('@release @web-socket eth_getBlockByHash', async function () {
+describe('@release @web-socket-batch-1 eth_getBlockByHash', async function () {
   const METHOD_NAME = 'eth_getBlockByHash';
   const INVALID_PARAMS = [
     [],

--- a/packages/ws-server/tests/acceptance/getBlockByNumber.spec.ts
+++ b/packages/ws-server/tests/acceptance/getBlockByNumber.spec.ts
@@ -23,7 +23,7 @@ import { expect } from 'chai';
 import { ethers, WebSocketProvider } from 'ethers';
 import { WsTestConstant, WsTestHelper } from '../helper';
 
-describe('@release @web-socket eth_getBlockByNumber', async function () {
+describe('@release @web-socket-batch-1 eth_getBlockByNumber', async function () {
   const METHOD_NAME = 'eth_getBlockByNumber';
   const INVALID_PARAMS = [
     [],

--- a/packages/ws-server/tests/acceptance/getCode.spec.ts
+++ b/packages/ws-server/tests/acceptance/getCode.spec.ts
@@ -26,7 +26,7 @@ import basicContractJson from '@hashgraph/json-rpc-server/tests/contracts/Basic.
 import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 
-describe('@release @web-socket eth_getCode', async function () {
+describe('@release @web-socket-batch-2 eth_getCode', async function () {
   const RELAY_URL = `${process.env.RELAY_ENDPOINT}`;
   const METHOD_NAME = 'eth_getCode';
 

--- a/packages/ws-server/tests/acceptance/getLogs.spec.ts
+++ b/packages/ws-server/tests/acceptance/getLogs.spec.ts
@@ -25,7 +25,7 @@ import { WsTestConstant, WsTestHelper } from '../helper';
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 
-describe('@release @web-socket eth_getLogs', async function () {
+describe('@release @web-socket-batch-2 eth_getLogs', async function () {
   const EXPECTED_VALUE = 7;
   const METHOD_NAME = 'eth_getLogs';
   const INVALID_PARAMS = [

--- a/packages/ws-server/tests/acceptance/getStorageAt.spec.ts
+++ b/packages/ws-server/tests/acceptance/getStorageAt.spec.ts
@@ -25,7 +25,7 @@ import { WsTestConstant, WsTestHelper } from '../helper';
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 
-describe('@release @web-socket eth_getStorageAt', async function () {
+describe('@release @web-socket-batch-2 eth_getStorageAt', async function () {
   const METHOD_NAME = 'eth_getStorageAt';
   const EXPECTED_VALUE = 7;
   const INVALID_PARAMS = [

--- a/packages/ws-server/tests/acceptance/getTransactionByHash.spec.ts
+++ b/packages/ws-server/tests/acceptance/getTransactionByHash.spec.ts
@@ -27,7 +27,7 @@ import { ONE_TINYBAR_IN_WEI_HEX } from '@hashgraph/json-rpc-relay/tests/lib/eth/
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 
-describe('@release @web-socket eth_getTransactionByHash', async function () {
+describe('@release @web-socket-batch-2 eth_getTransactionByHash', async function () {
   const METHOD_NAME = 'eth_getTransactionByHash';
   const CHAIN_ID = process.env.CHAIN_ID || '0x12a';
   const INVALID_PARAMS = [

--- a/packages/ws-server/tests/acceptance/getTransactionCount.spec.ts
+++ b/packages/ws-server/tests/acceptance/getTransactionCount.spec.ts
@@ -27,7 +27,7 @@ import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 import Assertions from '@hashgraph/json-rpc-server/tests/helpers/assertions';
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 
-describe('@release @web-socket eth_getTransactionCount', async function () {
+describe('@release @web-socket-batch-2 eth_getTransactionCount', async function () {
   const METHOD_NAME = 'eth_getTransactionCount';
   const CHAIN_ID = process.env.CHAIN_ID || '0x12a';
   const ONE_TINYBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 10)));

--- a/packages/ws-server/tests/acceptance/getTransactionReceipt.spec.ts
+++ b/packages/ws-server/tests/acceptance/getTransactionReceipt.spec.ts
@@ -27,7 +27,7 @@ import { ONE_TINYBAR_IN_WEI_HEX } from '@hashgraph/json-rpc-relay/tests/lib/eth/
 import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 
-describe('@release @web-socket eth_getTransactionReceipt', async function () {
+describe('@release @web-socket-batch-2 eth_getTransactionReceipt', async function () {
   const METHOD_NAME = 'eth_getTransactionReceipt';
   const CHAIN_ID = process.env.CHAIN_ID || '0x12a';
   const INVALID_PARAMS = [

--- a/packages/ws-server/tests/acceptance/sendRawTransaction.spec.ts
+++ b/packages/ws-server/tests/acceptance/sendRawTransaction.spec.ts
@@ -27,7 +27,7 @@ import { ONE_TINYBAR_IN_WEI_HEX } from '@hashgraph/json-rpc-relay/tests/lib/eth/
 import { AliasAccount } from '@hashgraph/json-rpc-server/tests/types/AliasAccount';
 import { Utils } from '@hashgraph/json-rpc-server/tests/helpers/utils';
 
-describe('@release @web-socket eth_sendRawTransaction', async function () {
+describe('@release @web-socket-batch-2 eth_sendRawTransaction', async function () {
   const METHOD_NAME = 'eth_sendRawTransaction';
   const CHAIN_ID = process.env.CHAIN_ID || '0x12a';
   const INVALID_PARAMS = [

--- a/packages/ws-server/tests/acceptance/subscribe.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribe.spec.ts
@@ -68,7 +68,7 @@ const createLogs = async (contract: ethers.Contract, requestId) => {
   await new Promise((resolve) => setTimeout(resolve, 2000));
 };
 
-describe('@release @web-socket eth_subscribe', async function () {
+describe('@release @web-socket-batch-3 eth_subscribe', async function () {
   this.timeout(240 * 1000); // 240 seconds
   const CHAIN_ID = process.env.CHAIN_ID || 0;
   let server;

--- a/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
@@ -90,7 +90,7 @@ function verifyResponse(response: any, done: Mocha.Done, webSocket: any, include
   }
 }
 
-describe('@release @web-socket eth_subscribe newHeads', async function () {
+describe('@release @web-socket-batch-3 eth_subscribe newHeads', async function () {
   this.timeout(240 * 1000); // 240 seconds
   const accounts: AliasAccount[] = [];
   const CHAIN_ID = process.env.CHAIN_ID || 0;


### PR DESCRIPTION
**Description**:
Currently there are 300+ total acceptance test cases in the WS server, and they all run within one CI task with one instance of localnode. Due to the enormous size of the CI task, the log wouldn't be able to show all the records, and without seeing the full log it's impossible to trace where the task fails. 

This PR attempts to break the one CI task into 3 smaller separate batches. 

**Related issue(s)**:

Fixes #2382

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
