### PR TITLE
chore: bumped hedera-local to 2.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "root",
       "dependencies": {
-        "@hashgraph/hedera-local": "^2.22.0",
+        "@hashgraph/hedera-local": "^2.23.0",
         "@open-rpc/schema-utils-js": "^1.16.1",
         "@types/find-config": "^1.0.4",
         "@types/sinon": "^10.0.20",
@@ -2107,9 +2107,9 @@
       }
     },
     "node_modules/@hashgraph/hedera-local": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.22.0.tgz",
-      "integrity": "sha512-2wEiLdTMHe5ZmoJDkkKSBuOlOEscIJPycoe9rNkP9bOBGJfI8PiBUGA4Kv62QzqYawfyWZPoIPTgaoxsXbHp2w==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.23.0.tgz",
+      "integrity": "sha512-ifX08JKEXI1WagTJ9IZ62buiwioYEASHi+/sMgZ6ZNPdwDU9iuUSSQaNKHaQ/CqqJdIHgmU7nFmAwERGpTiYVA==",
       "dependencies": {
         "@hashgraph/sdk": "^2.43.0",
         "blessed": "^0.1.81",
@@ -23276,9 +23276,9 @@
       }
     },
     "@hashgraph/hedera-local": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.22.0.tgz",
-      "integrity": "sha512-2wEiLdTMHe5ZmoJDkkKSBuOlOEscIJPycoe9rNkP9bOBGJfI8PiBUGA4Kv62QzqYawfyWZPoIPTgaoxsXbHp2w==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.23.0.tgz",
+      "integrity": "sha512-ifX08JKEXI1WagTJ9IZ62buiwioYEASHi+/sMgZ6ZNPdwDU9iuUSSQaNKHaQ/CqqJdIHgmU7nFmAwERGpTiYVA==",
       "requires": {
         "@hashgraph/sdk": "^2.43.0",
         "blessed": "^0.1.81",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@hashgraph/hedera-local": "^2.22.0",
+    "@hashgraph/hedera-local": "^2.23.0",
     "@open-rpc/schema-utils-js": "^1.16.1",
     "@types/find-config": "^1.0.4",
     "@types/sinon": "^10.0.20",


### PR DESCRIPTION
**Description**:
This PR pumps hedera-local to the latest version 2.23.0. This will help unblock https://github.com/hashgraph/hedera-json-rpc-relay/issues/2402

**Related issue(s)**:

Fixes #2411 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
