### PR TITLE
fix: moved deleteFile() logic to the eth_sendRawTransaction level (#2418)

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -19,7 +19,7 @@
  */
 
 import { Eth } from '../index';
-import { Hbar, PrecheckStatusError } from '@hashgraph/sdk';
+import { FileId, Hbar, PrecheckStatusError } from '@hashgraph/sdk';
 import { Logger } from 'pino';
 import { Block, Transaction, Log, Transaction1559 } from './model';
 import { MirrorNodeClient } from './clients';
@@ -1411,10 +1411,10 @@ export class EthImpl implements Eth {
 
     const parsedTx = await this.parseRawTxAndPrecheck(transaction, requestIdPrefix);
     const transactionBuffer = Buffer.from(EthImpl.prune0x(transaction), 'hex');
-
+    let fileId: FileId | null = null;
     let txSubmitted = false;
     try {
-      const contractExecuteResponse = await this.sendRawTransactionWithRetry(
+      const sendRawTransactionResult = await this.sendRawTransactionWithRetry(
         async () =>
           await this.hapiService
             .getSDKClient()
@@ -1431,10 +1431,12 @@ export class EthImpl implements Eth {
           },
         },
       );
+
       txSubmitted = true;
+      fileId = sendRawTransactionResult!.fileId;
 
       // Wait for the record from the execution.
-      const txId = contractExecuteResponse!.transactionId.toString();
+      const txId = sendRawTransactionResult!.txResponse.transactionId.toString();
       const formattedId = formatTransactionIdWithoutQueryParams(txId);
 
       // handle formattedId being null
@@ -1442,13 +1444,14 @@ export class EthImpl implements Eth {
         throw predefined.INTERNAL_ERROR(`Invalid transactionID: ${txId}`);
       }
 
-      const record = await this.mirrorNodeClient.repeatedRequest(
+      const contractResult = await this.mirrorNodeClient.repeatedRequest(
         this.mirrorNodeClient.getContractResult.name,
         [formattedId],
         this.MirrorNodeGetContractResultRetries,
         requestIdPrefix,
       );
-      if (!record) {
+
+      if (!contractResult) {
         this.logger.warn(`${requestIdPrefix} No record retrieved`);
         const tx = await this.mirrorNodeClient.getTransactionById(txId, 0, requestIdPrefix);
 
@@ -1467,16 +1470,26 @@ export class EthImpl implements Eth {
         throw predefined.INTERNAL_ERROR(`No matching record found for transaction id ${txId}`);
       }
 
-      if (record.hash == null) {
+      if (contractResult.hash == null) {
         this.logger.error(
           `${requestIdPrefix} The ethereumHash can never be null for an ethereum transaction, and yet it was!!`,
         );
         throw predefined.INTERNAL_ERROR();
       }
 
-      return record.hash;
+      return contractResult.hash;
     } catch (e: any) {
       return this.sendRawTransactionErrorHandler(e, transaction, transactionBuffer, txSubmitted, requestIdPrefix);
+    } finally {
+      /**
+       *  For transactions of type CONTRACT_CREATE, if the contract's bytecode (calldata) exceeds 5120 bytes, HFS is employed to temporarily store the bytecode on the network.
+       *  After transaction execution, whether successful or not, any entity associated with the 'fileId' should be removed from the Hedera network.
+       */
+      if (fileId) {
+        this.hapiService
+          .getSDKClient()
+          .deleteFile(fileId, requestIdPrefix, EthImpl.ethSendRawTransaction, fileId.toString());
+      }
     }
   }
 

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -125,7 +125,10 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       restMock.onGet(`transactions/${transactionId}?nonce=0`).reply(200, null);
 
       sdkClientStub.submitEthereumTransaction.returns({
-        transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        txResponse: {
+          transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        },
+        fileId: null,
       });
 
       const response = (await ethImpl.sendRawTransaction(signed, getRequestId())) as JsonRpcError;
@@ -140,7 +143,10 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
 
       sdkClientStub.submitEthereumTransaction.returns({
-        transactionId: '',
+        txResponse: {
+          transactionId: '',
+        },
+        fileId: null,
       });
 
       const response = (await ethImpl.sendRawTransaction(signed, getRequestId())) as JsonRpcError;
@@ -153,7 +159,10 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
 
       sdkClientStub.submitEthereumTransaction.returns({
-        transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        txResponse: {
+          transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        },
+        fileId: null,
       });
       const signed = await signTransaction(transaction);
 
@@ -165,7 +174,10 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
 
       sdkClientStub.submitEthereumTransaction.returns({
-        transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        txResponse: {
+          transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        },
+        fileId: null,
       });
 
       const signed = await signTransaction(transaction);
@@ -181,7 +193,10 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       sdkClientStub.submitEthereumTransaction.onCall(0).throws(new SDKClientError({ status: 21 }, 'timeout exceeded'));
 
       sdkClientStub.submitEthereumTransaction.onCall(1).returns({
-        transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        txResponse: {
+          transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        },
+        fileId: null,
       });
 
       const signed = await signTransaction(transaction);


### PR DESCRIPTION
**Description**:
This PR moves the deleteFile() logic from `hapiService.getSDKClient().executeTransaction()` to `eth_sendRawTransaction`
 level to make sure that the consensus node actually finish executing the raw transaction before deleting the created file.

Current E2E test for deleteFile() also works with new logic, so no update has been done.

**Related issue(s)**:

Fixes #2418

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
