### PR TITLE
ci: removed networkTag for API Batch 1 and Websocket Batch 2 CI tasks (#2402)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -17,7 +17,6 @@ jobs:
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: api_batch1
-      networkTag: 0.49.1
 
   api_batch_2:
     name: API Batch 2
@@ -86,7 +85,6 @@ jobs:
     with:
       testfilter: ws_batch2
       test_ws_server: true
-      networkTag: 0.49.1
 
   websocket-batch-3:
     name: Websocket Batch 3


### PR DESCRIPTION
**Description**:
This PR takes down the `networkTag:0.49.1` for API Batch 1 and Websocket Batch 2 CI tasks because the hedera-local is now updated to a version that supports deterministic deployment transaction.

**Related issue(s)**:

Fixes #2402

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
