### PR TITLE
fix: removed method attribute in WS response object

### DIFF
--- a/packages/ws-server/src/controllers/eth_blockNumber.ts
+++ b/packages/ws-server/src/controllers/eth_blockNumber.ts
@@ -61,7 +61,6 @@ export const handleEthBlockNumber = async ({
     relay,
     logger,
     request,
-    method,
     'blockNumber',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_call.ts
+++ b/packages/ws-server/src/controllers/eth_call.ts
@@ -62,7 +62,6 @@ export const handleEthCall = async ({
     relay,
     logger,
     request,
-    method,
     'call',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_estimateGas.ts
+++ b/packages/ws-server/src/controllers/eth_estimateGas.ts
@@ -62,7 +62,6 @@ export const handleEthEstimateGas = async ({
     relay,
     logger,
     request,
-    method,
     'estimateGas',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_gasPrice.ts
+++ b/packages/ws-server/src/controllers/eth_gasPrice.ts
@@ -59,7 +59,6 @@ export const handleEthGasPrice = async ({
     relay,
     logger,
     request,
-    method,
     'gasPrice',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getBalance.ts
+++ b/packages/ws-server/src/controllers/eth_getBalance.ts
@@ -62,7 +62,6 @@ export const handleEthGetBalance = async ({
     relay,
     logger,
     request,
-    method,
     'getBalance',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getBlockByHash.ts
+++ b/packages/ws-server/src/controllers/eth_getBlockByHash.ts
@@ -63,7 +63,6 @@ export const handleEthGetBlockByHash = async ({
     relay,
     logger,
     request,
-    method,
     'getBlockByHash',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getBlockByNumber.ts
+++ b/packages/ws-server/src/controllers/eth_getBlockByNumber.ts
@@ -62,7 +62,6 @@ export const handleEthGetBlockByNumber = async ({
     relay,
     logger,
     request,
-    method,
     'getBlockByNumber',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getCode.ts
+++ b/packages/ws-server/src/controllers/eth_getCode.ts
@@ -62,7 +62,6 @@ export const handleEthGetCode = async ({
     relay,
     logger,
     request,
-    method,
     'getCode',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getLogs.ts
+++ b/packages/ws-server/src/controllers/eth_getLogs.ts
@@ -71,7 +71,6 @@ export const handleEthGetLogs = async ({
     relay,
     logger,
     request,
-    method,
     'getLogs',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getStorageAt.ts
+++ b/packages/ws-server/src/controllers/eth_getStorageAt.ts
@@ -63,7 +63,6 @@ export const handleEthGetStorageAt = async ({
     relay,
     logger,
     request,
-    method,
     'getStorageAt',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getTransactionByHash.ts
+++ b/packages/ws-server/src/controllers/eth_getTransactionByHash.ts
@@ -63,7 +63,6 @@ export const handleEthGetTransactionByHash = async ({
     relay,
     logger,
     request,
-    method,
     'getTransactionByHash',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getTransactionCount.ts
+++ b/packages/ws-server/src/controllers/eth_getTransactionCount.ts
@@ -56,7 +56,6 @@ export const handleEthGetTransactionCount = async ({
     relay,
     logger,
     request,
-    method,
     'getTransactionCount',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_getTransactionReceipt.ts
+++ b/packages/ws-server/src/controllers/eth_getTransactionReceipt.ts
@@ -63,7 +63,6 @@ export const handleEthGetTransactionReceipt = async ({
     relay,
     logger,
     request,
-    method,
     'getTransactionReceipt',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
+++ b/packages/ws-server/src/controllers/eth_sendRawTransaction.ts
@@ -63,7 +63,6 @@ export const handleEthSendRawTransaction = async ({
     relay,
     logger,
     request,
-    method,
     'sendRawTransaction',
     requestIdPrefix,
     connectionIdPrefix,

--- a/packages/ws-server/src/controllers/helpers.ts
+++ b/packages/ws-server/src/controllers/helpers.ts
@@ -30,7 +30,6 @@ import { predefined } from '@hashgraph/json-rpc-relay';
  * @param {Relay} relay - The relay object for interacting with the Hedera network.
  * @param {any} logger - The logger object for logging messages and events.
  * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the request.
  * @param {string} rpcCallEndpoint - The Hedera RPC call endpoint to execute.
  * @param {string} requestIdPrefix - The prefix for the request ID.
  * @param {string} connectionIdPrefix - The prefix for the connection ID.
@@ -43,7 +42,6 @@ export const handleSendingRequestsToRelay = async (
   relay: Relay,
   logger: any,
   request: any,
-  method: string,
   rpcCallEndpoint: string,
   requestIdPrefix: string,
   connectionIdPrefix: string,
@@ -54,7 +52,7 @@ export const handleSendingRequestsToRelay = async (
       logger.debug(`${connectionIdPrefix} ${requestIdPrefix}: Fail to retrieve result for tag=${tag}. Data=${txRes}`);
     }
 
-    sendToClient(ctx.websocket, request, method, txRes, tag, logger, requestIdPrefix, connectionIdPrefix);
+    sendToClient(ctx.websocket, request, txRes, tag, logger, requestIdPrefix, connectionIdPrefix);
   } catch (error: any) {
     throw predefined.INTERNAL_ERROR(JSON.stringify(error.message || error));
   }

--- a/packages/ws-server/src/utils/utils.ts
+++ b/packages/ws-server/src/utils/utils.ts
@@ -96,7 +96,6 @@ export const sendToClient = (
   connection.send(
     JSON.stringify({
       jsonrpc: '2.0',
-      method,
       result: data,
       id: request.id,
     }),

--- a/packages/ws-server/src/utils/utils.ts
+++ b/packages/ws-server/src/utils/utils.ts
@@ -70,7 +70,6 @@ export const getMultipleAddressesEnabled = (): boolean => {
  * Resets the TTL timer for inactivity on the client connection.
  * @param {any} connection - The WebSocket connection object.
  * @param {any} request - The request object received from the client.
- * @param {string} method - The JSON-RPC method associated with the response.
  * @param {any} data - The data to be included in the response.
  * @param {string} tag - A tag used for logging and identifying the message.
  * @param {any} logger - The logger object for logging messages and events.
@@ -80,7 +79,6 @@ export const getMultipleAddressesEnabled = (): boolean => {
 export const sendToClient = (
   connection: any,
   request: any,
-  method: string,
   data: any,
   tag: string,
   logger: any,

--- a/packages/ws-server/tests/acceptance/blockNumber.spec.ts
+++ b/packages/ws-server/tests/acceptance/blockNumber.spec.ts
@@ -57,6 +57,7 @@ describe('@release @web-socket-batch-1 eth_blockNumber', async function () {
       WsTestHelper.assertJsonRpcObject(response);
       expect(Number(response.result)).to.gte(0);
       expect(response.result.startsWith('0x')).to.be.true;
+      expect(response.method).to.not.exist;
     });
   });
 
@@ -71,6 +72,7 @@ describe('@release @web-socket-batch-1 eth_blockNumber', async function () {
       const response = await ethersWsProvider.send(METHOD_NAME, []);
       expect(Number(response)).to.gte(0);
       expect(response.startsWith('0x')).to.be.true;
+      expect(response.method).to.not.exist;
     });
   });
 });

--- a/packages/ws-server/tests/acceptance/blockNumber.spec.ts
+++ b/packages/ws-server/tests/acceptance/blockNumber.spec.ts
@@ -57,7 +57,6 @@ describe('@release @web-socket-batch-1 eth_blockNumber', async function () {
       WsTestHelper.assertJsonRpcObject(response);
       expect(Number(response.result)).to.gte(0);
       expect(response.result.startsWith('0x')).to.be.true;
-      expect(response.method).to.not.exist;
     });
   });
 
@@ -72,7 +71,6 @@ describe('@release @web-socket-batch-1 eth_blockNumber', async function () {
       const response = await ethersWsProvider.send(METHOD_NAME, []);
       expect(Number(response)).to.gte(0);
       expect(response.startsWith('0x')).to.be.true;
-      expect(response.method).to.not.exist;
     });
   });
 });

--- a/packages/ws-server/tests/helper/index.ts
+++ b/packages/ws-server/tests/helper/index.ts
@@ -70,6 +70,7 @@ export class WsTestHelper {
     expect(obj).to.exist;
     expect(obj.id).to.eq(1);
     expect(obj.jsonrpc).to.eq('2.0');
+    expect(obj.method).to.not.exist;
   }
 
   static prepareJsonRpcObject(method: string, params: any[]) {

--- a/packages/ws-server/tests/helper/index.ts
+++ b/packages/ws-server/tests/helper/index.ts
@@ -70,7 +70,7 @@ export class WsTestHelper {
     expect(obj).to.exist;
     expect(obj.id).to.eq(1);
     expect(obj.jsonrpc).to.eq('2.0');
-    expect(obj.method).to.not.exist;
+    expect(obj.method).to.not.exist; // Should not have method field in response for standard non-subscription methods
   }
 
   static prepareJsonRpcObject(method: string, params: any[]) {


### PR DESCRIPTION
**Description**:

The response from Websocket connection contains the method field in the JSON response that makes it incompatible with blockchain client frameworks like go-ethereum

This PR modifies JSON responses from WS for all methods except subscription to make it work with client libraries such as go-ethereum


**Related issue(s)**:
This PR fixes issue  https://github.com/hashgraph/hedera-json-rpc-relay/issues/2440
Fixes #
- it removes `method` from the response

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
