### PR TITLE
fix: fixed setting WS_NEW_HEADS_ENABLED true as default logic at Relay level

### DIFF
--- a/packages/relay/src/lib/poller.ts
+++ b/packages/relay/src/lib/poller.ts
@@ -48,7 +48,8 @@ export class Poller {
     this.logger = logger;
     this.polls = [];
     this.pollingInterval = Number(process.env.WS_POLLING_INTERVAL) || 500;
-    this.newHeadsEnabled = process.env.WS_NEW_HEADS_ENABLED ? Boolean(Number(process.env.WS_NEW_HEADS_ENABLED)) : true;
+    this.newHeadsEnabled =
+      typeof process.env.WS_NEW_HEADS_ENABLED !== 'undefined' ? process.env.WS_NEW_HEADS_ENABLED === 'true' : true;
 
     const activePollsGaugeName = 'rpc_websocket_active_polls';
     register.removeSingleMetric(activePollsGaugeName);

--- a/packages/ws-server/src/controllers/eth_subscribe.ts
+++ b/packages/ws-server/src/controllers/eth_subscribe.ts
@@ -77,9 +77,9 @@ const handleEthSubscribeNewHeads = (
   requestIdPrefix: string,
 ): { response: any; subscriptionId: any } => {
   const wsNewHeadsEnabled =
-    typeof process.env.WS_NEW_HEADS_ENABLED !== 'undefined' ? process.env.WS_NEW_HEADS_ENABLED : 'true';
+    typeof process.env.WS_NEW_HEADS_ENABLED !== 'undefined' ? process.env.WS_NEW_HEADS_ENABLED === 'true' : true;
 
-  if (wsNewHeadsEnabled === 'true') {
+  if (wsNewHeadsEnabled) {
     ({ response, subscriptionId } = subscribeToNewHeads(filters, response, subscriptionId, ctx, event, relay, logger));
   } else {
     logger.warn(

--- a/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
@@ -131,7 +131,6 @@ describe('@release @web-socket-batch-3 eth_subscribe newHeads', async function (
 
   beforeEach(async () => {
     process.env.WS_NEW_HEADS_ENABLED = originalWsNewHeadsEnabledValue;
-
     process.env.WS_SUBSCRIPTION_LIMIT = '10';
 
     wsProvider = await new ethers.WebSocketProvider(WS_RELAY_URL);
@@ -197,10 +196,12 @@ describe('@release @web-socket-batch-3 eth_subscribe newHeads', async function (
       }
 
       await new Promise((resolve) => setTimeout(resolve, 500));
+      process.env.WS_NEW_HEADS_ENABLED = originalWsNewHeadsEnabledValue;
     });
 
     it('should subscribe to newHeads even when WS_NEW_HEADS_ENABLED=undefined, and receive a valid JSON RPC response', async (done) => {
-      expect(process.env.WS_NEW_HEADS_ENABLED).to.eq('undefined');
+      delete process.env.WS_NEW_HEADS_ENABLED;
+      expect(process.env.WS_NEW_HEADS_ENABLED).to.be.undefined;
 
       const webSocket = new WebSocket(WS_RELAY_URL);
       const subscriptionId = 1;

--- a/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
@@ -198,6 +198,36 @@ describe('@release @web-socket-batch-3 eth_subscribe newHeads', async function (
 
       await new Promise((resolve) => setTimeout(resolve, 500));
     });
+
+    it('should subscribe to newHeads even when WS_NEW_HEADS_ENABLED=undefined, and receive a valid JSON RPC response', async (done) => {
+      expect(process.env.WS_NEW_HEADS_ENABLED).to.eq('undefined');
+
+      const webSocket = new WebSocket(WS_RELAY_URL);
+      const subscriptionId = 1;
+      webSocket.on('open', function open() {
+        webSocket.send(
+          JSON.stringify({
+            id: subscriptionId,
+            jsonrpc: '2.0',
+            method: 'eth_subscribe',
+            params: ['newHeads', { includeTransactions: true }],
+          }),
+        );
+      });
+
+      let responseCounter = 0;
+
+      Utils.sendTransaction(ONE_TINYBAR, CHAIN_ID, accounts, rpcServer, requestId, mirrorNodeServer);
+      webSocket.on('message', function incoming(data) {
+        const response = JSON.parse(data);
+        responseCounter++;
+        verifyResponse(response, done, webSocket, true);
+        if (responseCounter > 1) {
+          webSocket.close();
+        }
+      });
+      done();
+    });
   });
 
   describe('Subscriptions for newHeads', async function () {


### PR DESCRIPTION
**Description**:
This PR fixes setting WS_NEW_HEADS_ENABLED true as default logic at the Relay level, also added an acceptance test to make sure newHeads works even when WS_NEW_HEADS_ENABLED is undefined.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
