### PR TITLE
fix: Test fix for nonce values on networks other thant local node.

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -194,20 +194,32 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           [logs[0].transactionHash],
           requestId,
         );
+        const transactionCountLog0Block = await relay.provider.getTransactionCount(
+          log0Block.from,
+          log0Block.blockNumber,
+        );
 
         log4Block = await relay.call(
           RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH,
-          [logs[4].transactionHash],
+          [logs[logs.length - 1].transactionHash],
           requestId,
+        );
+        const transactionCountLog4Block = await relay.provider.getTransactionCount(
+          log4Block.from,
+          log4Block.blockNumber,
         );
 
         expect(log0Block).to.exist;
         expect(log0Block).to.have.property('blockNumber');
-        expect(log0Block.nonce).to.equal('0x0');
+
+        // nonce is zero based, so we need to subtract 1
+        expect(parseInt(log0Block.nonce, 16)).to.equal(transactionCountLog0Block - 1);
 
         expect(log4Block).to.exist;
         expect(log4Block).to.have.property('blockNumber');
-        expect(log4Block.nonce).to.equal('0x4');
+
+        // nonce is zero based, so we need to subtract 1
+        expect(parseInt(log4Block.nonce, 16)).to.equal(transactionCountLog4Block - 1);
       });
 
       it('should be able to use `fromBlock` param', async () => {


### PR DESCRIPTION
Test fix.  Replaces hard coded values that work on local node with values fetched from `eth_getTransactionCount` 

Fixes #2458 

