### PR TITLE
feat: enhance debug_traceTransaction to work with Opcode Logger

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -184,6 +184,10 @@ const formatContractResult = (cr: any) => {
   return null;
 };
 
+const strip0x = (input: string): string => {
+  return input.startsWith(EMPTY_HEX) ? input.substring(2) : input;
+};
+
 const prepend0x = (input: string): string => {
   return input.startsWith(EMPTY_HEX) ? input : EMPTY_HEX + input;
 };
@@ -265,6 +269,7 @@ export {
   trimPrecedingZeros,
   weibarHexToTinyBarInt,
   stringToHex,
+  strip0x,
   toHexString,
   isValidEthereumAddress,
 };

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -1,4 +1,4 @@
-/*-
+/* -
  *
  * Hedera JSON RPC Relay
  *
@@ -18,8 +18,8 @@
  *
  */
 
-import Axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
-import { MirrorNodeClientError } from './../errors/MirrorNodeClientError';
+import Axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import { MirrorNodeClientError } from '../errors/MirrorNodeClientError';
 import { Logger } from 'pino';
 import constants from './../constants';
 import { Histogram, Registry } from 'prom-client';
@@ -30,8 +30,9 @@ import { SDKClientError } from '../errors/SDKClientError';
 import { install as betterLookupInstall } from 'better-lookup';
 import { CacheService } from '../services/cacheService/cacheService';
 
-const http = require('http');
-const https = require('https');
+import http from 'http';
+import https from 'https';
+import { IOpcodesResponse } from './models/IOpcodesResponse';
 
 type REQUEST_METHODS = 'GET' | 'POST';
 
@@ -72,6 +73,7 @@ export class MirrorNodeClient {
   private static GET_CONTRACT_RESULTS_DETAILS_BY_ADDRESS_AND_TIMESTAMP_ENDPOINT = `contracts/${MirrorNodeClient.ADDRESS_PLACEHOLDER}/results/${MirrorNodeClient.TIMESTAMP_PLACEHOLDER}`;
   private static GET_CONTRACT_RESULTS_DETAILS_BY_CONTRACT_ID_ENDPOINT = `contracts/${MirrorNodeClient.CONTRACT_ID_PLACEHOLDER}/results/${MirrorNodeClient.TIMESTAMP_PLACEHOLDER}`;
   private static GET_CONTRACTS_RESULTS_ACTIONS = `contracts/results/${MirrorNodeClient.TRANSACTION_ID_PLACEHOLDER}/actions`;
+  private static GET_CONTRACTS_RESULTS_OPCODES = `contracts/results/${MirrorNodeClient.TRANSACTION_ID_PLACEHOLDER}/opcodes`;
   private static GET_CONTRACT_RESULT_ENDPOINT = 'contracts/results/';
   private static GET_CONTRACT_RESULT_LOGS_ENDPOINT = 'contracts/results/logs';
   private static GET_CONTRACT_RESULT_LOGS_BY_ADDRESS_ENDPOINT = `contracts/${MirrorNodeClient.ADDRESS_PLACEHOLDER}/results/logs`;
@@ -102,6 +104,7 @@ export class MirrorNodeClient {
     [MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT, [404]],
     [MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_BY_ADDRESS_ENDPOINT, [404]],
     [MirrorNodeClient.GET_CONTRACT_RESULTS_ENDPOINT, [404]],
+    [MirrorNodeClient.GET_CONTRACTS_RESULTS_OPCODES, [404]],
     [MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT, [404]],
     [MirrorNodeClient.GET_NETWORK_FEES_ENDPOINT, [404]],
     [MirrorNodeClient.GET_TOKENS_ENDPOINT, [404]],
@@ -148,9 +151,18 @@ export class MirrorNodeClient {
    */
   private readonly register: Registry;
 
-  private mirrorResponseHistogram;
+  /**
+   * The histogram used for tracking the response time of the mirror node.
+   * @private
+   */
+  private readonly mirrorResponseHistogram: Histogram;
 
+  /**
+   * The cache service used for caching responses.
+   * @private
+   */
   private readonly cacheService: CacheService;
+
   static readonly EVM_ADDRESS_REGEX: RegExp = /\/accounts\/([\d\.]+)/;
 
   static mirrorNodeContractResultsPageMax = parseInt(process.env.MIRROR_NODE_CONTRACT_RESULTS_PG_MAX!) || 25;
@@ -303,14 +315,14 @@ export class MirrorNodeClient {
     return `${baseUrl}${MirrorNodeClient.API_V1_POST_FIX}`;
   }
 
-  private async request(
+  private async request<T>(
     path: string,
     pathLabel: string,
     method: REQUEST_METHODS,
     data?: any,
     requestIdPrefix?: string,
     retries?: number,
-  ): Promise<any> {
+  ): Promise<T | null> {
     const start = Date.now();
     // extract request id from prefix and remove trailing ']' character
     const requestId =
@@ -318,11 +330,8 @@ export class MirrorNodeClient {
         ?.split(MirrorNodeClient.REQUEST_PREFIX_SEPARATOR)[1]
         .replace(MirrorNodeClient.REQUEST_PREFIX_TRAILING_BRACKET, MirrorNodeClient.EMPTY_STRING) ||
       MirrorNodeClient.EMPTY_STRING;
-    let ms;
     const controller = new AbortController();
     try {
-      let response;
-
       const axiosRequestConfig: AxiosRequestConfig = {
         headers: {
           [MirrorNodeClient.REQUESTID_LABEL]: requestId,
@@ -335,18 +344,19 @@ export class MirrorNodeClient {
         axiosRequestConfig['axios-retry'] = { retries };
       }
 
+      let response: AxiosResponse<T, any>;
       if (method === MirrorNodeClient.HTTP_GET) {
-        response = await this.restClient.get(path, axiosRequestConfig);
+        response = await this.restClient.get<T>(path, axiosRequestConfig);
       } else {
-        response = await this.web3Client.post(path, data, axiosRequestConfig);
+        response = await this.web3Client.post<T>(path, data, axiosRequestConfig);
       }
 
       const ms = Date.now() - start;
       this.logger.debug(`${requestId} [${method}] ${path} ${response.status} ${ms} ms`);
-      this.mirrorResponseHistogram.labels(pathLabel, response.status).observe(ms);
+      this.mirrorResponseHistogram.labels(pathLabel, response.status?.toString()).observe(ms);
       return response.data;
     } catch (error: any) {
-      ms = Date.now() - start;
+      const ms = Date.now() - start;
       const effectiveStatusCode =
         error.response?.status ||
         MirrorNodeClientError.ErrorCodes[error.code] ||
@@ -362,15 +372,25 @@ export class MirrorNodeClient {
     return null;
   }
 
-  async get(path: string, pathLabel: string, requestIdPrefix?: string, retries?: number): Promise<any> {
-    return this.request(path, pathLabel, 'GET', null, requestIdPrefix, retries);
+  async get<T = any>(path: string, pathLabel: string, requestIdPrefix?: string, retries?: number): Promise<T | null> {
+    return this.request<T>(path, pathLabel, 'GET', null, requestIdPrefix, retries);
   }
 
-  async post(path: string, data: any, pathLabel: string, requestIdPrefix?: string, retries?: number): Promise<any> {
+  async post<T = any>(
+    path: string,
+    data: any,
+    pathLabel: string,
+    requestIdPrefix?: string,
+    retries?: number,
+  ): Promise<any> {
     if (!data) data = {};
-    return this.request(path, pathLabel, 'POST', data, requestIdPrefix, retries);
+    return this.request<T>(path, pathLabel, 'POST', data, requestIdPrefix, retries);
   }
 
+  /**
+   * @returns null if the error code is in the accepted error responses,
+   * @throws MirrorNodeClientError if the error code is not in the accepted error responses.
+   */
   handleError(
     error: any,
     path: string,
@@ -382,7 +402,7 @@ export class MirrorNodeClient {
     const mirrorError = new MirrorNodeClientError(error, effectiveStatusCode);
     const acceptedErrorResponses = MirrorNodeClient.acceptedErrorStatusesResponsePerRequestPathMap.get(pathLabel);
 
-    if (error.response && acceptedErrorResponses && acceptedErrorResponses.indexOf(effectiveStatusCode) !== -1) {
+    if (error.response && acceptedErrorResponses?.includes(effectiveStatusCode)) {
       this.logger.debug(`${requestIdPrefix} [${method}] ${path} ${effectiveStatusCode} status`);
       return null;
     }
@@ -698,7 +718,7 @@ export class MirrorNodeClient {
    * the mirror node DB and `transaction_index` or `block_number` is returned as `undefined`. A single re-fetch is sufficient to
    * resolve this problem.
    * @param transactionIdOrHash
-   * @param requestId
+   * @param requestIdPrefix
    */
   public async getContractResultWithRetry(transactionIdOrHash: string, requestIdPrefix?: string) {
     const contractResult = await this.getContractResult(transactionIdOrHash, requestIdPrefix);
@@ -740,6 +760,19 @@ export class MirrorNodeClient {
     return this.get(
       `${this.getContractResultsActionsByTransactionIdPath(transactionIdOrHash)}`,
       MirrorNodeClient.GET_CONTRACTS_RESULTS_ACTIONS,
+      requestIdPrefix,
+    );
+  }
+
+  public async getContractsResultsOpcodes(
+    transactionIdOrHash: string,
+    requestIdPrefix?: string,
+    params?: { memory?: boolean; stack?: boolean; storage?: boolean },
+  ): Promise<IOpcodesResponse | null> {
+    const queryParams = params ? this.getQueryParams(params) : '';
+    return this.get<IOpcodesResponse>(
+      `${this.getContractResultsOpcodesByTransactionIdPath(transactionIdOrHash)}${queryParams}`,
+      MirrorNodeClient.GET_CONTRACTS_RESULTS_OPCODES,
       requestIdPrefix,
     );
   }
@@ -925,6 +958,13 @@ export class MirrorNodeClient {
     );
   }
 
+  private getContractResultsOpcodesByTransactionIdPath(transactionIdOrHash: string) {
+    return MirrorNodeClient.GET_CONTRACTS_RESULTS_OPCODES.replace(
+      MirrorNodeClient.TRANSACTION_ID_PLACEHOLDER,
+      transactionIdOrHash,
+    );
+  }
+
   public async getTokenById(tokenId: string, requestIdPrefix?: string, retries?: number) {
     return this.get(
       `${MirrorNodeClient.GET_TOKENS_ENDPOINT}/${tokenId}`,
@@ -1006,7 +1046,6 @@ export class MirrorNodeClient {
    * Check if transaction fail is because of contract revert and try to fetch and log the reason.
    *
    * @param e
-   * @param requestId
    * @param requestIdPrefix
    */
   public async getContractRevertReasonFromTransaction(e: any, requestIdPrefix: string): Promise<any | undefined> {
@@ -1084,6 +1123,7 @@ export class MirrorNodeClient {
    * @param searchableTypes the types to search for
    * @param callerName calling method name
    * @param requestIdPrefix the request id prefix message
+   * @param retries the number of retries
    * @returns entity object or null if not found
    */
   public async resolveEntityType(

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -346,7 +346,11 @@ export class MirrorNodeClient {
 
       let response: AxiosResponse<T, any>;
       if (method === MirrorNodeClient.HTTP_GET) {
-        response = await this.restClient.get<T>(path, axiosRequestConfig);
+        if (pathLabel == MirrorNodeClient.GET_CONTRACTS_RESULTS_OPCODES) {
+          response = await this.web3Client.get<T>(path, axiosRequestConfig);
+        } else {
+          response = await this.restClient.get<T>(path, axiosRequestConfig);
+        }
       } else {
         response = await this.web3Client.post<T>(path, data, axiosRequestConfig);
       }

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -382,7 +382,7 @@ export class MirrorNodeClient {
     pathLabel: string,
     requestIdPrefix?: string,
     retries?: number,
-  ): Promise<any> {
+  ): Promise<T | null> {
     if (!data) data = {};
     return this.request<T>(path, pathLabel, 'POST', data, requestIdPrefix, retries);
   }

--- a/packages/relay/src/lib/clients/models/IOpcode.ts
+++ b/packages/relay/src/lib/clients/models/IOpcode.ts
@@ -1,0 +1,11 @@
+export interface IOpcode {
+  pc?: number;
+  op?: string;
+  gas?: number;
+  gas_cost?: number;
+  depth?: number;
+  stack?: string[];
+  memory?: string[];
+  storage?: { [key: string]: string };
+  reason?: string | null;
+}

--- a/packages/relay/src/lib/clients/models/IOpcode.ts
+++ b/packages/relay/src/lib/clients/models/IOpcode.ts
@@ -1,3 +1,23 @@
+/* -
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 export interface IOpcode {
   pc?: number;
   op?: string;

--- a/packages/relay/src/lib/clients/models/IOpcodesResponse.ts
+++ b/packages/relay/src/lib/clients/models/IOpcodesResponse.ts
@@ -1,3 +1,23 @@
+/* -
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 import { IOpcode } from './IOpcode';
 
 export interface IOpcodesResponse {

--- a/packages/relay/src/lib/clients/models/IOpcodesResponse.ts
+++ b/packages/relay/src/lib/clients/models/IOpcodesResponse.ts
@@ -1,0 +1,10 @@
+import { IOpcode } from './IOpcode';
+
+export interface IOpcodesResponse {
+  address?: string;
+  contract_id?: string;
+  gas?: number;
+  failed?: boolean;
+  return_value?: string;
+  opcodes?: IOpcode[];
+}

--- a/packages/relay/src/lib/services/debugService/IDebugService.ts
+++ b/packages/relay/src/lib/services/debugService/IDebugService.ts
@@ -22,7 +22,7 @@ import type { TracerType } from '../../constants';
 
 export interface IDebugService {
   debug_traceTransaction: (
-    transactionHash: string,
+    transactionIdOrHash: string,
     tracer: TracerType,
     tracerConfig: object,
     requestIdPrefix?: string,

--- a/packages/relay/src/lib/services/debugService/index.ts
+++ b/packages/relay/src/lib/services/debugService/index.ts
@@ -159,9 +159,13 @@ export class DebugService implements IDebugService {
    *
    * @async
    * @param {IOpcodesResponse | null} result - The response from mirror node.
+   * @param {object} options - The options used for the opcode tracer.
    * @returns {Promise<object>} The formatted opcode response.
    */
-  async formatOpcodesResult(result: IOpcodesResponse | null): Promise<object> {
+  async formatOpcodesResult(
+    result: IOpcodesResponse | null,
+    options: { memory?: boolean; stack?: boolean; storage?: boolean },
+  ): Promise<object> {
     if (!result) {
       return {
         gas: 0,
@@ -183,9 +187,9 @@ export class DebugService implements IDebugService {
           gas: opcode.gas,
           gasCost: opcode.gas_cost,
           depth: opcode.depth,
-          stack: opcode.stack,
-          memory: opcode.memory,
-          storage: opcode.storage,
+          stack: options.stack ? opcode.stack : null,
+          memory: options.memory ? opcode.memory : null,
+          storage: options.storage ? opcode.storage : null,
           reason: opcode.reason ? strip0x(opcode.reason) : null,
         };
       }),
@@ -261,12 +265,17 @@ export class DebugService implements IDebugService {
     requestIdPrefix?: string,
   ): Promise<object> {
     try {
-      const response = await this.mirrorNodeClient.getContractsResultsOpcodes(transactionIdOrHash, requestIdPrefix, {
+      const options = {
         memory: !tracerConfig.disableMemory,
         stack: !tracerConfig.disableStack,
         storage: !tracerConfig.disableStorage,
-      });
-      return await this.formatOpcodesResult(response);
+      };
+      const response = await this.mirrorNodeClient.getContractsResultsOpcodes(
+        transactionIdOrHash,
+        requestIdPrefix,
+        options,
+      );
+      return await this.formatOpcodesResult(response, options);
     } catch (e) {
       throw this.common.genericErrorHandler(e);
     }

--- a/packages/relay/src/lib/services/debugService/index.ts
+++ b/packages/relay/src/lib/services/debugService/index.ts
@@ -86,7 +86,7 @@ export class DebugService implements IDebugService {
    * Trace a transaction for debugging purposes.
    *
    * @async
-   * @param {string} transactionHash - The hash of the transaction to be traced.
+   * @param {string} transactionIdOrHash - The ID or hash of the transaction to be traced.
    * @param {TracerType} tracer - The type of tracer to use (either 'CallTracer' or 'OpcodeLogger').
    * @param {object} tracerConfig - The configuration object for the tracer.
    * @param {string} [requestIdPrefix] - An optional request id.
@@ -97,18 +97,18 @@ export class DebugService implements IDebugService {
    * const result = await debug_traceTransaction('0x123abc', TracerType.CallTracer, {"tracerConfig": {"onlyTopCall": false}}, some request id);
    */
   async debug_traceTransaction(
-    transactionHash: string,
+    transactionIdOrHash: string,
     tracer: TracerType,
     tracerConfig: object,
     requestIdPrefix?: string,
   ): Promise<any> {
-    this.logger.trace(`${requestIdPrefix} debug_traceTransaction(${transactionHash})`);
+    this.logger.trace(`${requestIdPrefix} debug_traceTransaction(${transactionIdOrHash})`);
     try {
       DebugService.requireDebugAPIEnabled();
       if (tracer === TracerType.CallTracer) {
-        return await this.callTracer(transactionHash, tracerConfig, requestIdPrefix);
+        return await this.callTracer(transactionIdOrHash, tracerConfig, requestIdPrefix);
       } else if (tracer === TracerType.OpcodeLogger) {
-        return await this.callOpcodeLogger(transactionHash, tracerConfig, requestIdPrefix);
+        return await this.callOpcodeLogger(transactionIdOrHash, tracerConfig, requestIdPrefix);
       }
     } catch (e) {
       throw this.common.genericErrorHandler(e);
@@ -247,7 +247,7 @@ export class DebugService implements IDebugService {
   /**
    * Returns the final formatted response for opcodeLogger config.
    * @async
-   * @param {string} transactionHash - The hash of the transaction to be debugged.
+   * @param {string} transactionIdOrHash - The ID or hash of the transaction to be debugged.
    * @param {object} tracerConfig - The tracer config to be used.
    * @param {boolean} tracerConfig.disableMemory - Whether to disable memory.
    * @param {boolean} tracerConfig.disableStack - Whether to disable stack.
@@ -256,12 +256,12 @@ export class DebugService implements IDebugService {
    * @returns {Promise<object>} The formatted response.
    */
   async callOpcodeLogger(
-    transactionHash: string,
+    transactionIdOrHash: string,
     tracerConfig: { disableMemory?: boolean; disableStack?: boolean; disableStorage?: boolean },
     requestIdPrefix?: string,
   ): Promise<object> {
     try {
-      const response = await this.mirrorNodeClient.getContractsResultsOpcodes(transactionHash, requestIdPrefix, {
+      const response = await this.mirrorNodeClient.getContractsResultsOpcodes(transactionIdOrHash, requestIdPrefix, {
         memory: !tracerConfig.disableMemory,
         stack: !tracerConfig.disableStack,
         storage: !tracerConfig.disableStorage,

--- a/packages/relay/src/lib/services/debugService/index.ts
+++ b/packages/relay/src/lib/services/debugService/index.ts
@@ -322,7 +322,8 @@ export class DebugService implements IDebugService {
         // if we have more than one call executed during the transactions we would return all calls
         // except the first one in the sub-calls array,
         // therefore we need to exclude the first one from the actions response
-        calls: tracerConfig.onlyTopCall || actionsResponse.actions.length === 1 ? undefined : formattedActions.slice(1),
+        calls:
+          tracerConfig?.onlyTopCall || actionsResponse.actions.length === 1 ? undefined : formattedActions.slice(1),
       };
     } catch (e) {
       throw this.common.genericErrorHandler(e);

--- a/packages/relay/src/lib/services/debugService/index.ts
+++ b/packages/relay/src/lib/services/debugService/index.ts
@@ -22,7 +22,7 @@ import type { Logger } from 'pino';
 import type { MirrorNodeClient } from '../../clients';
 import type { IDebugService } from './IDebugService';
 import type { CommonService } from '../ethService';
-import { decodeErrorMessage, numberTo0x, prepend0x, strip0x, toHexString } from '../../../formatters';
+import { decodeErrorMessage, numberTo0x, strip0x } from '../../../formatters';
 import constants from '../../constants';
 import { TracerType, CallType } from '../../constants';
 import { predefined } from '../../errors/JsonRpcError';

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -27,6 +27,18 @@ import { v4 as uuid } from 'uuid';
 // Randomly generated key
 const defaultPrivateKey = '8841e004c6f47af679c91d9282adc62aeb9fabd19cdff6a9da5a358d0613c30a';
 
+const getQueryParams = (params: object) => {
+  if (!Object.keys(params).length) {
+    return '';
+  }
+
+  return '?'.concat(
+    Object.entries(params)
+      .map(([key, value]) => `${key}=${value}`)
+      .join('&'),
+  );
+};
+
 const expectUnsupportedMethod = (result) => {
   expect(result).to.have.property('code');
   expect(result.code).to.be.equal(-32601);
@@ -336,7 +348,15 @@ const mockData = {
   },
 };
 
-export { expectUnsupportedMethod, expectedError, signTransaction, mockData, random20BytesAddress, getRequestId };
+export {
+  expectUnsupportedMethod,
+  expectedError,
+  signTransaction,
+  mockData,
+  random20BytesAddress,
+  getRequestId,
+  getQueryParams,
+};
 
 export const bytecode =
   '0x608060405234801561001057600080fd5b5060405161078938038061078983398181016040528101906100329190';

--- a/packages/relay/tests/lib/services/debugService/debug.spec.ts
+++ b/packages/relay/tests/lib/services/debugService/debug.spec.ts
@@ -57,7 +57,6 @@ describe('Debug API Test Suite', async function () {
   const contractAddress2 = '0x000000000000000000000000000000000000040a';
   const tracerConfigTrue = { onlyTopCall: true };
   const tracerConfigFalse = { onlyTopCall: false };
-  const opcodeConfigFalse = { disableStack: false, disableMemory: false, disableStorage: false };
   const callTracer: TracerType = TracerType.CallTracer;
   const opcodeLogger: TracerType = TracerType.OpcodeLogger;
   const CONTRACTS_RESULTS_OPCODES = `contracts/results/${transactionHash}/opcodes`;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -27,7 +27,6 @@ import path from 'path';
 import fs from 'fs';
 import { v4 as uuid } from 'uuid';
 import { formatRequestIdMessage } from './formatters';
-import _ from 'lodash';
 
 const mainLogger = pino({
   name: 'hedera-json-rpc-relay',

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -664,12 +664,11 @@ app.useRpc('eth_maxPriorityFeePerGas', async () => {
  */
 
 app.useRpc('debug_traceTransaction', async (params: any) => {
-  const transactionHash = params[0];
-  const tracer = params[1].tracer;
-  const tracerConfig =
-    tracer && tracer === TracerType.CallTracer ? params[1].tracerConfig : _.omit(params[1], ['tracer', 'tracerConfig']);
-  return logAndHandleResponse('debug_traceTransaction', [transactionHash, tracer, tracerConfig], (requestId) =>
-    relay.eth().debugService().debug_traceTransaction(transactionHash, tracer, tracerConfig, requestId),
+  const transactionIdOrHash = params[0];
+  const { tracer, ...otherParams } = params[1];
+  const tracerConfig = tracer === TracerType.CallTracer ? otherParams.tracerConfig : otherParams;
+  return logAndHandleResponse('debug_traceTransaction', [transactionIdOrHash, tracer, tracerConfig], (requestId) =>
+    relay.eth().debugService().debug_traceTransaction(transactionIdOrHash, tracer, tracerConfig, requestId),
   );
 });
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -21,12 +21,13 @@
 import { Relay, RelayImpl, JsonRpcError, predefined, MirrorNodeClientError } from '@hashgraph/json-rpc-relay';
 import { collectDefaultMetrics, Histogram, Registry } from 'prom-client';
 import KoaJsonRpc from './koaJsonRpc';
-import { Validator } from './validator';
+import { TracerType, Validator } from './validator';
 import pino from 'pino';
 import path from 'path';
 import fs from 'fs';
 import { v4 as uuid } from 'uuid';
 import { formatRequestIdMessage } from './formatters';
+import _ from 'lodash';
 
 const mainLogger = pino({
   name: 'hedera-json-rpc-relay',
@@ -665,7 +666,8 @@ app.useRpc('eth_maxPriorityFeePerGas', async () => {
 app.useRpc('debug_traceTransaction', async (params: any) => {
   const transactionHash = params[0];
   const tracer = params[1].tracer;
-  const tracerConfig = params[1].tracerConfig;
+  const tracerConfig =
+    tracer && tracer === TracerType.CallTracer ? params[1].tracerConfig : _.omit(params[1], ['tracer', 'tracerConfig']);
   return logAndHandleResponse('debug_traceTransaction', [transactionHash, tracer, tracerConfig], (requestId) =>
     relay.eth().debugService().debug_traceTransaction(transactionHash, tracer, tracerConfig, requestId),
   );

--- a/packages/server/src/validator/constants.ts
+++ b/packages/server/src/validator/constants.ts
@@ -8,6 +8,8 @@ export const BLOCK_NUMBER_ERROR =
 export const BLOCK_PARAMS_ERROR = `Expected ${HASH_ERROR} in object, 0x prefixed hexadecimal block number, or the string "latest", "earliest" or "pending"`;
 export const BLOCK_HASH_ERROR = `Expected ${HASH_ERROR} of a block`;
 export const TRANSACTION_HASH_ERROR = `Expected ${HASH_ERROR} of a transaction`;
+export const TRANSACTION_ID_ERROR = `Expected a transaction ID string in the format "shard.realm.num-sss-nnn" where sss are seconds and nnn are nanoseconds`;
+export const TRANSACTION_ID_REGEX = /^(\d)\.(\d)\.(\d{1,10})-(\d{1,19})-(\d{1,9})$/;
 export const TOPIC_HASH_ERROR = `Expected ${HASH_ERROR} of a topic`;
 export const INVALID_BLOCK_HASH_TAG_NUMBER = 'The value passed is not a valid blockHash/blockNumber/blockTag value:';
 export enum TracerType {

--- a/packages/server/src/validator/methods.ts
+++ b/packages/server/src/validator/methods.ts
@@ -165,7 +165,7 @@ export const METHODS = {
   debug_traceTransaction: {
     0: {
       required: true,
-      type: 'hex',
+      type: 'hex|transactionId',
     },
     1: {
       required: true,

--- a/packages/server/src/validator/types.ts
+++ b/packages/server/src/validator/types.ts
@@ -94,7 +94,20 @@ export const TYPES = {
   tracerConfig: {
     test: (param: Record<string, any>) => {
       return (
-        typeof param === 'object' && param !== null && 'onlyTopCall' in param && typeof param.onlyTopCall === 'boolean'
+        // validate callTracer type
+        // { tracer: "callTracer", tracerConfig: { onlyTopCall: true } }
+        (typeof param === 'object' &&
+          param !== null &&
+          'onlyTopCall' in param &&
+          typeof param.onlyTopCall === 'boolean') ||
+        // validate opcodeLogger type
+        //  { tracer: "opcodeLogger", disableMemory: true, disableStack: true, disableStorage: true }
+        (typeof param === 'object' &&
+          (('disableMemory' in param && typeof param.disableMemory === 'boolean') ||
+            param?.disableMemory === undefined) &&
+          (('disableStack' in param && typeof param.disableStack === 'boolean') || param?.disableStack === undefined) &&
+          (('disableStorage' in param && typeof param.disableStorage === 'boolean') ||
+            param?.disableStorage === undefined))
       );
     },
     error: 'Invalid tracerConfig',

--- a/packages/server/src/validator/types.ts
+++ b/packages/server/src/validator/types.ts
@@ -87,28 +87,26 @@ export const TYPES = {
     test: (param: string) => new RegExp(Constants.BASE_HEX_REGEX + '{64}$').test(param),
     error: Constants.TRANSACTION_HASH_ERROR,
   },
+  transactionId: {
+    test: (param: string) => new RegExp(Constants.TRANSACTION_ID_REGEX).test(param),
+    error: Constants.TRANSACTION_ID_ERROR,
+  },
   tracerType: {
     test: (param: Constants.TracerType) => Object.values(Constants.TracerType).includes(param),
     error: 'Invalid tracer type',
   },
   tracerConfig: {
     test: (param: Record<string, any>) => {
-      return (
-        // validate callTracer type
-        // { tracer: "callTracer", tracerConfig: { onlyTopCall: true } }
-        (typeof param === 'object' &&
-          param !== null &&
-          'onlyTopCall' in param &&
-          typeof param.onlyTopCall === 'boolean') ||
-        // validate opcodeLogger type
-        //  { tracer: "opcodeLogger", disableMemory: true, disableStack: true, disableStorage: true }
-        (typeof param === 'object' &&
-          (('disableMemory' in param && typeof param.disableMemory === 'boolean') ||
-            param?.disableMemory === undefined) &&
-          (('disableStack' in param && typeof param.disableStack === 'boolean') || param?.disableStack === undefined) &&
-          (('disableStorage' in param && typeof param.disableStorage === 'boolean') ||
-            param?.disableStorage === undefined))
-      );
+      const isValidCallTracerConfig: boolean =
+        typeof param === 'object' && 'onlyTopCall' in param && typeof param.onlyTopCall === 'boolean';
+
+      const isValidOpcodeLoggerConfig: boolean =
+        typeof param === 'object' &&
+        (!('disableMemory' in param) || typeof param.disableMemory === 'boolean') &&
+        (!('disableStack' in param) || typeof param.disableStack === 'boolean') &&
+        (!('disableStorage' in param) || typeof param.disableStorage === 'boolean');
+
+      return isValidCallTracerConfig || isValidOpcodeLoggerConfig;
     },
     error: 'Invalid tracerConfig',
   },

--- a/packages/server/src/validator/utils.ts
+++ b/packages/server/src/validator/utils.ts
@@ -22,7 +22,7 @@ export function validateParam(index: number | string, param: any, validation: an
       results.push(result);
     }
     if (results.every((item) => item === false)) {
-      const errorMessages = paramType.map((t) => t.error).join(' OR ');
+      const errorMessages = paramType.map((t) => Validator.TYPES[t].error).join(' OR ');
       throw predefined.INVALID_PARAMETER(index, `The value passed is not valid: ${param}. ${errorMessages}`);
     }
   }

--- a/packages/server/src/validator/utils.ts
+++ b/packages/server/src/validator/utils.ts
@@ -22,10 +22,8 @@ export function validateParam(index: number | string, param: any, validation: an
       results.push(result);
     }
     if (results.every((item) => item === false)) {
-      throw predefined.INVALID_PARAMETER(
-        index,
-        `The value passed is not a valid blockHash/blockNumber/blockTag value: ${param}`,
-      );
+      const errorMessages = paramType.map((t) => t.error).join(' OR ');
+      throw predefined.INVALID_PARAMETER(index, `The value passed is not valid: ${param}. ${errorMessages}`);
     }
   }
 

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -17,11 +17,14 @@
  * limitations under the License.
  *
  */
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 import { ethers } from 'ethers';
-import { JsonRpcError, predefined } from '../../../relay/src/lib/errors/JsonRpcError';
+import { JsonRpcError, predefined } from '@hashgraph/json-rpc-relay';
 import { numberTo0x } from '../../../relay/src/formatters';
 import RelayAssertions from '../../../relay/tests/assertions';
+import chaiExclude from 'chai-exclude';
+
+chai.use(chaiExclude);
 
 export default class Assertions {
   static emptyHex = '0x';
@@ -345,8 +348,8 @@ export default class Assertions {
     expectedError: JsonRpcError,
     method: () => Promise<any>,
     checkMessage: boolean,
-    thisObj,
-    args?: any[],
+    thisObj: any,
+    args?: any,
   ): Promise<any> => {
     try {
       await method.apply(thisObj, args);
@@ -391,10 +394,10 @@ export default class Assertions {
   static assertRejection = async (
     error: JsonRpcError,
     method: () => Promise<any>,
-    args: any[],
+    args: any,
     checkMessage: boolean,
   ): Promise<any> => {
-    return await expect(method.apply(global.relay, args)).to.eventually.be.rejected.and.satisfy((err) => {
+    return expect(method.apply(global.relay, args)).to.eventually.be.rejected.and.satisfy((err) => {
       if (!checkMessage) {
         return [error.code, error.name].every((substring) => err.body.includes(substring));
       }
@@ -413,12 +416,12 @@ export default class Assertions {
   };
 
   static validateResultDebugValues = (
-    result,
+    result: { from: string; calls: any[] },
     excludedValues: string[],
     nestedExcludedValues: string[],
-    expectedResult,
+    expectedResult: { from?: any; calls?: any[] },
   ) => {
-    const hasValidHash = (currentValue) => RelayAssertions.validateHash(currentValue);
+    const hasValidHash = (currentValue: string) => RelayAssertions.validateHash(currentValue);
 
     // Validate result schema
     expect(result).to.have.keys(Object.keys(expectedResult));

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -26,6 +26,7 @@ import Assertions from '../helpers/assertions';
 import app from '../../src/server';
 import { Validator } from '../../src/validator';
 import RelayCalls from '../../tests/helpers/constants';
+import * as Constants from '../../src/validator/constants';
 dotenv.config({ path: path.resolve(__dirname, './test.env') });
 
 const MISSING_PARAM_ERROR = 'Missing value for required parameter';
@@ -64,7 +65,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.invalidRequestSpecError(error.response, -32600, `Invalid Request`);
     }
   });
@@ -92,7 +93,7 @@ describe('RPC Server', async function () {
       expect(response.data.id, "Default response: 'data.id' should equal '2'").to.be.equal('2');
       expect(response.data.jsonrpc, "Default response: 'data.jsonrpc' should equal '2.0'").to.be.equal('2.0');
       expect(response.data.result).to.be.equal('0x' + Number(process.env.CHAIN_ID).toString(16));
-    } catch (error) {
+    } catch (error: any) {
       expect(true, `Unexpected error: ${error.message}`).to.eq(false);
     }
 
@@ -133,7 +134,7 @@ describe('RPC Server', async function () {
         method: RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH,
         params: ['0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7237170ae5e5e7957eb6392'],
       });
-    } catch (error) {
+    } catch (error: any) {
       expect(error.message).to.equal('Request failed with status code 500');
     }
   });
@@ -256,7 +257,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.methodNotFoundCheck(error.response, RelayCalls.ETH_ENDPOINTS.WEB3_SHA);
     }
   });
@@ -271,7 +272,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.methodNotFoundCheck(error.response, RelayCalls.ETH_ENDPOINTS.NET_PEER_COUNT);
     }
   });
@@ -286,7 +287,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.unsupportedJsonRpcMethodChecks(error.response);
     }
   });
@@ -301,7 +302,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.methodNotFoundCheck(error.response, RelayCalls.ETH_ENDPOINTS.ETH_SIGN_TYPED_DATA);
     }
   });
@@ -316,7 +317,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.unsupportedJsonRpcMethodChecks(error.response);
     }
   });
@@ -331,7 +332,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.unsupportedJsonRpcMethodChecks(error.response);
     }
   });
@@ -346,7 +347,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.unsupportedJsonRpcMethodChecks(error.response);
     }
   });
@@ -361,7 +362,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.unsupportedJsonRpcMethodChecks(error.response);
     }
   });
@@ -376,7 +377,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.methodNotFoundCheck(error.response, RelayCalls.ETH_ENDPOINTS.ETH_GET_PROOF);
     }
   });
@@ -391,7 +392,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.unsupportedJsonRpcMethodChecks(error.response);
     }
   });
@@ -406,7 +407,7 @@ describe('RPC Server', async function () {
       });
 
       Assertions.expectedError();
-    } catch (error) {
+    } catch (error: any) {
       BaseTest.unsupportedJsonRpcMethodChecks(error.response);
     }
   });
@@ -644,7 +645,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -659,7 +660,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, 'Expected TransactionObject, value: 0x0');
         }
       });
@@ -674,7 +675,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -693,7 +694,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -712,7 +713,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -731,7 +732,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -750,7 +751,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -769,7 +770,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -788,7 +789,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -807,7 +808,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -826,7 +827,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -845,7 +846,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -866,7 +867,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -881,7 +882,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, Validator.ADDRESS_ERROR + ', value: 0x0');
         }
       });
@@ -896,7 +897,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -911,11 +912,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `The value passed is not a valid blockHash/blockNumber/blockTag value: 123`,
+            `The value passed is not valid: 123. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -930,11 +931,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            'The value passed is not a valid blockHash/blockNumber/blockTag value: newest',
+            `The value passed is not valid: newest. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -951,7 +952,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -966,7 +967,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -985,7 +986,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -1000,11 +1001,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 1: ${Validator.INVALID_BLOCK_HASH_TAG_NUMBER} 123`,
+            `Invalid parameter 1: The value passed is not valid: 123. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -1019,11 +1020,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 1: ${Validator.INVALID_BLOCK_HASH_TAG_NUMBER} newest`,
+            `Invalid parameter 1: The value passed is not valid: newest. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -1040,7 +1041,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1055,7 +1056,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1074,7 +1075,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1093,7 +1094,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -1108,7 +1109,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1129,7 +1130,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1144,7 +1145,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1163,7 +1164,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -1178,7 +1179,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1199,7 +1200,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1214,7 +1215,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1233,7 +1234,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -1248,11 +1249,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            'The value passed is not a valid blockHash/blockNumber/blockTag value: 123',
+            `Invalid parameter 1: The value passed is not valid: 123. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -1267,11 +1268,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            'Invalid parameter 1: The value passed is not a valid blockHash/blockNumber/blockTag value: newest',
+            `Invalid parameter 1: The value passed is not valid: newest. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -1288,7 +1289,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1303,7 +1304,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, 'Expected TransactionObject, value: 0x0');
         }
       });
@@ -1318,7 +1319,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1337,7 +1338,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1356,7 +1357,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1375,7 +1376,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1394,7 +1395,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1413,7 +1414,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1432,7 +1433,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1451,7 +1452,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1470,7 +1471,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1489,7 +1490,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1508,7 +1509,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1527,7 +1528,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1548,7 +1549,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1563,7 +1564,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1584,7 +1585,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1599,7 +1600,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1616,7 +1617,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1631,7 +1632,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -1646,7 +1647,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1667,7 +1668,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1682,7 +1683,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1703,7 +1704,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1718,7 +1719,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1737,7 +1738,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1758,7 +1759,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1773,7 +1774,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1792,7 +1793,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -1807,7 +1808,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1826,11 +1827,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 2: ${Validator.INVALID_BLOCK_HASH_TAG_NUMBER} 123`,
+            `Invalid parameter 2: The value passed is not valid: 123. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -1845,11 +1846,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 2: ${Validator.INVALID_BLOCK_HASH_TAG_NUMBER} newest`,
+            `Invalid parameter 2: The value passed is not valid: newest. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -1864,11 +1865,11 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 2: ${Validator.INVALID_BLOCK_HASH_TAG_NUMBER} newest`,
+            `Invalid parameter 2: The value passed is not valid: newest. ${Constants.BLOCK_NUMBER_ERROR} OR ${Constants.BLOCK_HASH_ERROR}`,
           );
         }
       });
@@ -1885,7 +1886,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1900,7 +1901,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1919,7 +1920,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -1934,7 +1935,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1955,7 +1956,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 0');
         }
       });
@@ -1970,7 +1971,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -1989,7 +1990,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2008,7 +2009,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(error.response, Validator.ERROR_CODE, MISSING_PARAM_ERROR + ' 1');
         }
       });
@@ -2023,7 +2024,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2044,7 +2045,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2063,7 +2064,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2082,7 +2083,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2101,7 +2102,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2120,7 +2121,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2139,7 +2140,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2158,7 +2159,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2177,7 +2178,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
@@ -2196,7 +2197,7 @@ describe('RPC Server', async function () {
           });
 
           Assertions.expectedError();
-        } catch (error) {
+        } catch (error: any) {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,


### PR DESCRIPTION
**Description**:

With the implemenation of `/api/v1/contracts/results/{transactionIdOrHash}/opcodes` in the `web3` module of `hedera-mirror-node`, we can now utilise it by extending our support for debugging transactions. 

This PR:
- makes the neccessery changes to the `debug_traceTransaction` endpoint
- adds acceptance tests for calling `debug_traceTransaction` with `TracerType.OpcodeLogger`.

**Related issue(s)**:

Fixes #2431

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
