### PR TITLE
fix: removed `RESOURCE_NOT_FOUND` error in eth_getStorageAt when response is null

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -825,12 +825,7 @@ export class EthImpl implements Eth {
     await this.mirrorNodeClient
       .getContractStateByAddressAndSlot(address, slot, blockEndTimestamp, requestIdPrefix)
       .then((response) => {
-        if (response === null) {
-          throw predefined.RESOURCE_NOT_FOUND(
-            `Cannot find current state for contract address ${address} at slot=${slot}`,
-          );
-        }
-        if (response.state.length > 0) {
+        if (response !== null && response.state.length > 0) {
           result = response.state[0].value;
         }
       })

--- a/packages/relay/tests/lib/eth/eth_getStorageAt.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getStorageAt.spec.ts
@@ -20,6 +20,7 @@
 import path from 'path';
 import dotenv from 'dotenv';
 import { expect, use } from 'chai';
+import { ethers } from 'ethers';
 import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -267,7 +268,7 @@ describe('@ethGetStorageAt eth_getStorageAt spec', async function () {
       expect(result).to.equal(DEFAULT_OLDER_CONTRACT_STATE.state[0].value);
     });
 
-    it('eth_getStorageAt should throw error when contract not found', async function () {
+    it('eth_getStorageAt should return Zero Hash when address is not found', async function () {
       // mirror node request mocks
       restMock
         .onGet(
@@ -275,15 +276,12 @@ describe('@ethGetStorageAt eth_getStorageAt spec', async function () {
         )
         .reply(404, DETAILD_CONTRACT_RESULT_NOT_FOUND);
 
-      const args = [CONTRACT_ADDRESS_1, defaultDetailedContractResults.state_changes[0].slot, numberTo0x(BLOCK_NUMBER)];
-
-      await RelayAssertions.assertRejection(
-        predefined.RESOURCE_NOT_FOUND(),
-        ethImpl.getStorageAt,
-        false,
-        ethImpl,
-        args,
+      const result = await ethImpl.getStorageAt(
+        CONTRACT_ADDRESS_1,
+        DEFAULT_OLDER_CONTRACT_STATE.state[0].slot,
+        numberTo0x(OLDER_BLOCK.number),
       );
+      expect(result).to.equal(ethers.ZeroHash);
     });
   });
 });

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -1038,6 +1038,19 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
       );
       expect(storageVal).to.eq(EXPECTED_STORAGE_VAL);
     });
+
+    it('should execute "eth_getStorageAt" request against an inactive address (contains no data) and receive a 32-byte-zero-hex string ', async function () {
+      const hexString = ethers.ZeroHash;
+      const inactiveAddress = ethers.Wallet.createRandom();
+
+      const storageVal = await relay.call(
+        RelayCalls.ETH_ENDPOINTS.ETH_GET_STORAGE_AT,
+        [inactiveAddress.address, '0x0', 'latest'],
+        requestId,
+      );
+
+      expect(storageVal).to.eq(hexString);
+    });
   });
 
   // Only run the following tests against a local node since they only work with the genesis account


### PR DESCRIPTION
**Description**:
This PR refines the syntax to handle the `RESOURCE_NOT_FOUND` error in `eth_getStorageAt`. With this fix, the Relay skips processing when the response from the mirror-node is null and return a 32-byte-zero-hex string instead of throwing error. Acceptance test is added to cover the update.

**Related issue(s)**:

Fixes #2491

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
