### PR TITLE
fix: added support for undefined params requests in WS server (#2463)

### DIFF
--- a/packages/ws-server/src/controllers/index.ts
+++ b/packages/ws-server/src/controllers/index.ts
@@ -97,7 +97,10 @@ export const getRequestResult = async (
   wsMetricRegistry: WsMetricRegistry,
 ): Promise<any> => {
   // Extract the method and parameters from the received request
-  const { method, params } = request;
+  let { method, params } = request;
+
+  // support go-ethereum client by turning undefined into empty array
+  if (!params) params = [];
 
   // Increment metrics for the received method
   wsMetricRegistry.getCounter('methodsCounter').labels(method).inc();

--- a/packages/ws-server/tests/helper/index.ts
+++ b/packages/ws-server/tests/helper/index.ts
@@ -38,7 +38,7 @@ export class WsTestHelper {
     }
   }
 
-  static async sendRequestToStandardWebSocket(method: string, params: any[], ms?: number | undefined) {
+  static async sendRequestToStandardWebSocket(method: string, params: any, ms?: number | undefined) {
     const webSocket = new WebSocket(WsTestConstant.WS_RELAY_URL);
 
     let response: any;


### PR DESCRIPTION
**Description**:
The Go-ethereum eth-client package does not include params field in the jsonrpc request object for methods that do not require any params, i.e. eth_chainId, eth_gasPrice, etc. This absence results in undefined `params`, causing errors during server parsing. This PR addresses the issue by resolving undefined `params`, converting them into an empty array to mitigate the problem. Additionally, it adds acceptance tests to ensure coverage of the update.


**Related issue(s)**:

Fixes #2463 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
