### PR TITLE
fix: fixing Field HEDERA_NETWORK on configMap helm chart template, when is not a string but a json.

### DIFF
--- a/charts/hedera-json-rpc-relay/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay/templates/configmap.yaml
@@ -7,5 +7,10 @@ metadata:
     {{ include "json-rpc-relay.labels" . | nindent 4 }}
 data:
   {{- range $key, $value := .Values.config }}
-    {{ $key }}: {{ if typeIs "float64" $value }}{{ $value | int64 | quote }}{{ else }}{{ $value | quote }}{{ end }}
+    {{- if eq $key "HEDERA_NETWORK" }}
+      {{ $key }}: {{ if typeIs "string" $value}} {{ $value | lower | quote }} {{else}} {{ printf "{%s}" (tpl (join "," $value | trimPrefix "[" | trimSuffix "]") $) | squote }} {{end}}
+    {{- else }}
+      {{ $key }}: {{ if typeIs "float64" $value }}{{ $value | int64 | quote }}{{ else }}{{ $value | quote }}{{ end }}
+    {{- end }}
   {{- end }}
+


### PR DESCRIPTION
**Description**:
fixing Field HEDERA_NETWORK on configMap helm chart template, when is not a string but a json.

**Related issue(s)**:

Fixes #2497 

**Notes for reviewer**:

**Before Change/Fix:**

help template:
```bash
helm template relay-deploy-test2 charts/hedera-json-rpc-relay --set config.MIRROR_NODE_URL="http://fullstack-deployment-rest" --set config.MIRROR_NODE_URL_WEB3="http://fullstack-deployment-web3" --set config.CHAIN_ID="298" --set config.LOG_LEVEL="debug" --set config.HEDERA_NETWORK='{"0.testnet.hedera.com:50211":"0.0.3"}'  --set image.tag="main" --output-dir out
```

ConfigMap Extract:
```
    HEDERA_NETWORK: "[\"0.testnet.hedera.com:50211\":\"0.0.3\"]"
```

helm logs:
```
[2024-05-16 01:36:29.001 +0000] INFO (relay/44185 on Admins-Laptop-3.local): Configurations successfully loaded
undefined:1
["0.testnet.hedera.com:50211":"0.0.3"]
                             ^

SyntaxError: Unexpected token : in JSON at position 29
```

**After Change / Fix:**

**for a single value like `previewnet`, `testnet` or `mainnet`**

helm template command:
```
helm template relay-deploy-test2 charts/hedera-json-rpc-relay --set config.MIRROR_NODE_URL="http://fullstack-deployment-rest" --set config.MIRROR_NODE_URL_WEB3="http://fullstack-deployment-web3" --set config.CHAIN_ID="298" --set config.LOG_LEVEL="debug" --set config.HEDERA_NETWORK=previewnet  --set image.tag="main" --output-dir out
```

ConfigMap Extract:
```
HEDERA_NETWORK:  "previewnet" 
```

Relay logs when deploying using the charts:
```
SDK client successfully configured to "previewnet" for account null with request timeout value: 10000
```

**for a json with a single node:**

Helm Command:
```
 helm template relay-deploy-test2 charts/hedera-json-rpc-relay --set config.MIRROR_NODE_URL="http://fullstack-deployment-rest" --set config.MIRROR_NODE_URL_WEB3="http://fullstack-deployment-web3" --set config.CHAIN_ID="298" --set config.LOG_LEVEL="debug" --set config.HEDERA_NETWORK='{"0.testnet.hedera.com:50211":"0.0.3"}'  --set image.tag="main" --output-dir out

```


ConfigMap Extract:
```
      HEDERA_NETWORK:  '{"0.testnet.hedera.com:50211":"0.0.3"}' 
```

Relay logs when deployed using the above command:

```
SDK client successfully configured to "{\"0.testnet.hedera.com::50211\":\"0.0.3\"}" for account null with request timeout value: 10000

```



**for a json with multiple nodes (3):**
```bash
 helm template relay-deploy-test2 charts/hedera-json-rpc-relay --set config.MIRROR_NODE_URL="http://fullstack-deployment-rest" --set config.MIRROR_NODE_URL_WEB3="http://fullstack-deployment-web3" --set config.CHAIN_ID="298" --set config.LOG_LEVEL="debug" --set config.HEDERA_NETWORK='{"0.testnet.hedera.com:50211":"0.0.3","1.testnet.hedera.com:50211":"0.0.4","2.testnet.hedera.com:50211":"0.0.5"}'  --set image.tag="main" --output-dir out
```

configMap Extract:
```
HEDERA_NETWORK:  '{"0.testnet.hedera.com:50211":"0.0.3","1.testnet.hedera.com::50211":"0.0.4","2.testnet.hedera.com:50211":"0.0.5"}'
```

Relay logs when deployed using the above command:

```
SDK client successfully configured to "{\"0.testnet.hedera.com:50211\":\"0.0.3\",\"1.testnet.hedera.com::50211\":\"0.0.4\",\"2.testnet.hedera.com:50211\":\"0.0.5\"}" for account null with request timeout value: 10000
```


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
