### PR TITLE
feat: make `revertReason` consistent on `eth_getTransactionReceipt`

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -50,6 +50,14 @@ function hexToASCII(str: string): string {
   return ascii;
 }
 
+function ASCIIToHex(ascii: string): string {
+  const hex: string[] = [];
+  for (let n = 0; n < ascii.length; n++) {
+    hex.push(Number(ascii.charCodeAt(n)).toString(16));
+  }
+  return hex.join('');
+}
+
 /**
  * Converts an EVM ErrorMessage to a readable form. For example this :
  * 0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d53657420746f2072657665727400000000000000000000000000000000000000
@@ -289,4 +297,5 @@ export {
   toHexString,
   isValidEthereumAddress,
   isHex,
+  ASCIIToHex,
 };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -39,6 +39,8 @@ import {
   toHash32,
   weibarHexToTinyBarInt,
   trimPrecedingZeros,
+  ASCIIToHex,
+  isHex,
 } from '../formatters';
 import crypto from 'crypto';
 import HAPIService from './services/hapiService/hapiService';
@@ -2003,7 +2005,9 @@ export class EthImpl implements Eth {
       };
 
       if (receiptResponse.error_message) {
-        receipt.revertReason = receiptResponse.error_message;
+        receipt.revertReason = isHex(prepend0x(receiptResponse.error_message))
+          ? receiptResponse.error_message
+          : prepend0x(ASCIIToHex(receiptResponse.error_message));
       }
 
       this.logger.trace(`${requestIdPrefix} receipt for ${hash} found in block ${receipt.blockNumber}`);

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -466,7 +466,7 @@ describe('Formatters', () => {
       expect(isHex('0x58')).to.be.true;
     });
   });
-  describe.only('ASCIIToHex Function', () => {
+  describe('ASCIIToHex Function', () => {
     const inputs = ['Lorem Ipsum', 'Foo', 'Bar'];
     const outputs = ['4c6f72656d20497073756d', '466f6f', '426172'];
 

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -37,6 +37,7 @@ import {
   isValidEthereumAddress,
   trimPrecedingZeros,
   isHex,
+  ASCIIToHex,
 } from '../../src/formatters';
 import constants from '../../src/lib/constants';
 import { BigNumber as BN } from 'bignumber.js';
@@ -463,6 +464,28 @@ describe('Formatters', () => {
 
     it('should return true for a known gasPrice', () => {
       expect(isHex('0x58')).to.be.true;
+    });
+  });
+  describe.only('ASCIIToHex Function', () => {
+    const inputs = ['Lorem Ipsum', 'Foo', 'Bar'];
+    const outputs = ['4c6f72656d20497073756d', '466f6f', '426172'];
+
+    it('should return "" for empty string', () => {
+      expect(ASCIIToHex('')).to.equal('');
+    });
+
+    it('should return valid hex', () => {
+      expect(isHex(prepend0x(ASCIIToHex(inputs[0])))).to.be.true;
+    });
+
+    it('should return expected hex formatted value', () => {
+      expect(inputs[0]).to.equal(hexToASCII(ASCIIToHex(inputs[0])));
+    });
+
+    it('should decode correctly regarding hardcoded mapping', () => {
+      for (let i = 0; i < inputs.length; i++) {
+        expect(ASCIIToHex(inputs[i])).to.eq(outputs[i]);
+      }
     });
   });
 });


### PR DESCRIPTION
### Problem

There is inconsistency in `revertReason` field on `eth_getTransactionReceipt`:
- in some transactions, an ASCII-encoded string reason has been returned (e.g. `PRECOMPILE_ERROR`) 
- but in others, a hex-encoded reason has been returned (based on the contract's ABI, e.g. `0xcf4791810000000000000000000000000000000000000000000000000000000000000001`)

There are several tx's, I executed against the testnet to validate the issue:
- ASCII-encoded string reason TX hash - [0xc998ea6b8101b3d5b44acff9af2f478114ce6e74a8221443ec2ecd2f1a045f17](https://testnet.mirrornode.hedera.com/api/v1/contracts/results/0xc998ea6b8101b3d5b44acff9af2f478114ce6e74a8221443ec2ecd2f1a045f17)
- hex-encoded reason TX hash - [0xc363c5e434544e54399a23e92894fdbe50b65a9dc3ad5b1989dd900c33cc44a5](https://testnet.mirrornode.hedera.com/api/v1/contracts/results/0xc363c5e434544e54399a23e92894fdbe50b65a9dc3ad5b1989dd900c33cc44a5)

The inconsistency still exists in the relay's route `eth_getTransactionReceipt`.
- ASCII-encoded string for revertReason
![ascii](https://github.com/hashgraph/hedera-json-rpc-relay/assets/20220658/3853aa6d-335b-4c34-a44e-c7751e093de6)
- hex-encoded revertReason
![hex](https://github.com/hashgraph/hedera-json-rpc-relay/assets/20220658/d1b241ab-270f-4daa-a415-47a42134ee74)

### Solution

Make the `revertReason` field consistent and always return a hex-encoded revert reason. We can not stick to the ASCII-encoded string reasons because the contract's reverts are resolved to `0x<functionSelector><revertData>` which wouldn't resolve to valid ASCII-encoded strings. These types of reverts must be decoded regarding contract's ABI.

### Fixes
- [2516](https://github.com/hashgraph/hedera-json-rpc-relay/issues/2516)

### Related issues
- https://github.com/hashgraph/hedera-mirror-node/issues/7038
- https://github.com/hashgraph/hedera-mirror-node/issues/7214

_No response_