### PR TITLE
fix: updated CONTRACT_REVERT error code to the value `3`

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -37,7 +37,7 @@ export class JsonRpcError {
 export const predefined = {
   CONTRACT_REVERT: (errorMessage?: string, data: string = '') =>
     new JsonRpcError({
-      code: -32008,
+      code: 3,
       message: `execution reverted: ${decodeErrorMessage(errorMessage)}`,
       data: data,
     }),

--- a/packages/relay/tests/lib/eth/eth_call.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_call.spec.ts
@@ -414,7 +414,7 @@ describe('@ethCall Eth Call spec', async function () {
       const result = await ethImpl.call(ETH_CALL_REQ_ARGS, 'latest');
 
       expect(result).to.exist;
-      expect((result as JsonRpcError).code).to.equal(-32008);
+      expect((result as JsonRpcError).code).to.equal(3);
       expect((result as JsonRpcError).name).to.equal(undefined);
       expect((result as JsonRpcError).message).to.equal(`execution reverted: ${defaultErrorMessageText}`);
       expect((result as JsonRpcError).data).to.equal(defaultErrorMessageHex);
@@ -620,7 +620,7 @@ describe('@ethCall Eth Call spec', async function () {
         .reply(400, mockData.contractReverted);
       const result = await ethImpl.call(callData, 'latest');
       expect(result).to.be.not.null;
-      expect((result as JsonRpcError).code).to.eq(-32008);
+      expect((result as JsonRpcError).code).to.eq(3);
       expect((result as JsonRpcError).name).to.eq(undefined);
       expect((result as JsonRpcError).message).to.contain(mockData.contractReverted._status.messages[0].message);
     });
@@ -675,7 +675,7 @@ describe('@ethCall Eth Call spec', async function () {
       const result = await ethImpl.call(callData, 'latest');
       sinon.assert.notCalled(sdkClientStub.submitContractCallQueryWithRetry);
       expect(result).to.not.be.null;
-      expect((result as JsonRpcError).code).to.eq(-32008);
+      expect((result as JsonRpcError).code).to.eq(3);
       expect((result as JsonRpcError).name).to.eq(undefined);
       expect((result as JsonRpcError).message).to.contain(mockData.contractReverted._status.messages[0].message);
     });
@@ -706,7 +706,7 @@ describe('@ethCall Eth Call spec', async function () {
       const result = await ethImpl.call(callData, 'latest');
 
       expect(result).to.exist;
-      expect((result as JsonRpcError).code).to.eq(-32008);
+      expect((result as JsonRpcError).code).to.eq(3);
       expect((result as JsonRpcError).name).to.eq(undefined);
       expect((result as JsonRpcError).message).to.equal(`execution reverted: ${defaultErrorMessageText}`);
       expect((result as JsonRpcError).data).to.equal(defaultErrorMessageHex);

--- a/packages/server/src/koaJsonRpc/lib/HttpStatusCodeAndMessage.ts
+++ b/packages/server/src/koaJsonRpc/lib/HttpStatusCodeAndMessage.ts
@@ -17,8 +17,8 @@ const CONTRACT_REVERT = 'CONTRACT REVERT';
 const METHOD_NOT_FOUND = 'METHOD NOT FOUND';
 
 export const RpcErrorCodeToStatusMap = {
+  '3': new HttpStatusCodeAndMessage(200, CONTRACT_REVERT),
   '-32603': new HttpStatusCodeAndMessage(500, INTERNAL_ERROR),
-  '-32008': new HttpStatusCodeAndMessage(200, CONTRACT_REVERT),
   '-32600': new HttpStatusCodeAndMessage(400, INVALID_REQUEST),
   '-32602': new HttpStatusCodeAndMessage(400, INVALID_PARAMS_ERROR),
   '-32601': new HttpStatusCodeAndMessage(400, METHOD_NOT_FOUND),

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -608,7 +608,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       expect(response.status).to.be.equal(200);
       expect(response.data).to.exist;
       expect(response.data.error).to.exist;
-      expect(response.data.error.code).to.be.equal(-32008);
+      expect(response.data.error.code).to.be.equal(3);
       expect(response.data.error.message).to.contain('execution reverted: CONTRACT_REVERT_EXECUTED');
       expect(response.data.error.name).to.undefined;
     });


### PR DESCRIPTION
**Description**:
This PR changes the error code for CONTRACT_REVERT error to the value 3 so it can be compatible with ethereum tools like Viem, Hardhat, etc.

**Related issue(s)**: https://github.com/hashgraph/hedera-json-rpc-relay/issues/2522

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/2457

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
