### PR TITLE
feat: Add precheck for blob transactions

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -169,6 +169,11 @@ export const predefined = {
     code: -32601,
     message: 'Unsupported JSON-RPC method',
   }),
+  UNSUPPORTED_TRANSACTION_TYPE: new JsonRpcError({
+    name: 'Unsupported transaction type',
+    code: -32611,
+    message: 'Unsupported transaction type',
+  }),
   VALUE_TOO_LOW: new JsonRpcError({
     name: 'Value too low',
     code: -32602,

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -52,6 +52,7 @@ export class Precheck {
    * @param gasPrice
    */
   async sendRawTransactionCheck(parsedTx: ethers.Transaction, gasPrice: number, requestId?: string) {
+    this.transactionType(parsedTx, requestId);
     this.gasLimit(parsedTx, requestId);
     const mirrorAccountInfo = await this.verifyAccount(parsedTx, requestId);
     await this.nonce(parsedTx, mirrorAccountInfo.ethereum_nonce, requestId);
@@ -299,6 +300,19 @@ export class Precheck {
 
     if (transactionSize > transactionSizeLimit) {
       throw predefined.TRANSACTION_SIZE_TOO_BIG(String(transactionSize), String(transactionSizeLimit));
+    }
+  }
+
+  private transactionType(tx: Transaction, requestId?: string) {
+    // Blob transactions are not supported as per HIP 866
+    if (tx.type === 3) {
+      const requestIdPrefix = formatRequestIdMessage(requestId);
+      this.logger.trace(
+        `${requestIdPrefix} Transaction with type=${
+          tx.type
+        } is unsupported for sendRawTransaction(transaction=${JSON.stringify(tx)})`,
+      );
+      throw predefined.UNSUPPORTED_TRANSACTION_TYPE;
     }
   }
 }

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -303,7 +303,7 @@ export class Precheck {
     }
   }
 
-  private transactionType(tx: Transaction, requestId?: string) {
+  transactionType(tx: Transaction, requestId?: string) {
     // Blob transactions are not supported as per HIP 866
     if (tx.type === 3) {
       const requestIdPrefix = formatRequestIdMessage(requestId);

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -341,6 +341,7 @@ export { expectUnsupportedMethod, expectedError, signTransaction, mockData, rand
 export const bytecode =
   '0x608060405234801561001057600080fd5b5060405161078938038061078983398181016040528101906100329190';
 export const blockHashTrimmed = '0x3c08bbbee74d287b1dcd3f0ca6d1d2cb92c90883c4acf9747de9f3f3162ad25b';
+export const blobVersionedHash = '0x3c08bbbee74d287b1dcd3f0ca6d1d2cb92c90883c4acf9747de9f3f3162ad25b';
 export const blockHash = `${blockHashTrimmed}999fc7e86699f60f2a3fb3ed9a646c6b`;
 export const blockHash2 = `${blockHashTrimmed}999fc7e86699f60f2a3fb3ed9a646c6c`;
 export const blockHash3 = `${blockHashTrimmed}999fc7e86699f60f2a3fb3ed9a646c6d`;

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -218,5 +218,23 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       expect(`Error invoking RPC: ${response.message}`).to.equal(predefined.INTERNAL_ERROR(response.message).message);
       sinon.assert.calledOnce(sdkClientStub.submitEthereumTransaction);
     });
+
+    it('should throw precheck error for type=3 transactions', async function () {
+      const type3tx = {
+        ...transaction,
+        type: 3,
+        maxFeePerBlobGas: transaction.gasPrice,
+        blobVersionedHashes: [ethereumHash],
+      };
+      const signed = await signTransaction(type3tx);
+
+      await RelayAssertions.assertRejection(
+        predefined.UNSUPPORTED_TRANSACTION_TYPE,
+        ethImpl.sendRawTransaction,
+        false,
+        ethImpl,
+        [signed, getRequestId()],
+      );
+    });
   });
 });

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -2021,4 +2021,40 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       }
     });
   });
+
+  describe('Shard Blob Transactions', async function () {
+    let defaultLondonTransactionData, defaultGasPrice, defaultGasLimit;
+    let defaultBlobVersionedHashes = ['0x6265617665726275696c642e6f7267476265617665726275696c642e6f726747'];
+
+    before(() => {
+      defaultGasPrice = numberTo0x(Assertions.defaultGasPrice);
+      defaultGasLimit = numberTo0x(3_000_000);
+
+      defaultLondonTransactionData = {
+        value: ONE_TINYBAR,
+        chainId: Number(CHAIN_ID),
+        maxPriorityFeePerGas: defaultGasPrice,
+        maxFeePerGas: defaultGasPrice,
+        gasLimit: defaultGasLimit,
+      };
+    });
+
+    it('Type 3 transactions are not supported for eth_sendRawTransaction', async () => {
+      const transaction = {
+        ...defaultLondonTransactionData,
+        type: 3,
+        maxFeePerBlobGas: defaultGasPrice,
+        blobVersionedHashes: defaultBlobVersionedHashes,
+      };
+
+      const signedTx = await accounts[0].wallet.signTransaction(transaction);
+      await Assertions.assertPredefinedRpcError(
+        predefined.UNSUPPORTED_TRANSACTION_TYPE,
+        relay.sendRawTransaction,
+        false,
+        relay,
+        [signedTx, requestId],
+      );
+    });
+  });
 });


### PR DESCRIPTION
**Description**:
Adds a precheck to `eth_sendRawTransaction` that rejects transactions with `type=3` with a new predefined error:
`UNSUPPORTED_TRANSACTION_TYPE(code: -32611, message: "Unsupported transaction type")`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
