### PR TITLE
fix: update helm chart release action

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -100,7 +100,8 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Publish helm chart
+        uses: stefanprodan/helm-gh-pages@v1.7.0
+        with:
+          target_dir: charts
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -101,7 +101,7 @@ jobs:
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
 
       - name: Publish helm chart
-        uses: stefanprodan/helm-gh-pages@v1.7.0
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
         with:
           target_dir: charts
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/.bump-version.js
+++ b/scripts/.bump-version.js
@@ -77,7 +77,7 @@ const helmChartRegex = "version: \\d+\\.\\d+\\.\\d+(-\\w+)?";
 replace({
   regex: helmChartRegex,
   replacement: `version: ${newVersion}`,
-  paths: ["charts/hedera-json-rpc-relay/Chart.yaml", "charts/hedera-json-rpc-relay-websocket/Chart.yaml"],
+  paths: ["charts/hedera-json-rpc-relay/Chart.yaml", "charts/hedera-json-rpc-relay-websocket/Chart.yaml","charts/hedera-json-rpc/Chart.yaml"],
   recursive: false,
   silent: false,
 });
@@ -86,7 +86,7 @@ const helmChartAppVersionRegex = 'appVersion: "\\d+\\.\\d+\\.\\d+(-\\w+)?"';
 replace({
   regex: helmChartAppVersionRegex,
   replacement: `appVersion: "${newVersion}"`,
-  paths: ["charts/hedera-json-rpc-relay/Chart.yaml", "charts/hedera-json-rpc-relay-websocket/Chart.yaml"],
+  paths: ["charts/hedera-json-rpc-relay/Chart.yaml", "charts/hedera-json-rpc-relay-websocket/Chart.yaml","charts/hedera-json-rpc/Chart.yaml"],
   recursive: false,
   silent: false,
 });


### PR DESCRIPTION
**Description**:

This PR updates the github action and version bump script to fix releasing of helm charts when new versions of hedera-json-rpc-relay are published.

* Update github action
* Update version bump script


**Related issue(s)**:

Fixes #2506 

PR #2549 needs to also be merged to fix missing releases

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
