### PR TITLE
fix: 2561 release automation cannot find npm

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -152,6 +152,11 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -153,7 +153,7 @@ jobs:
           passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: '18'
 

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -78,6 +78,11 @@ jobs:
             git checkout ${RELEASE_BRANCH}
           fi
 
+      - name: Set up Node.js
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: '18'
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
Applied the Node.js install right before the npm ci.

**Related issue(s)**:

Fixes #2561 

