### PR TITLE
fix: fixed condition to employ HFS in submitEthereumTransaction()

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -250,7 +250,8 @@ export class SDKClient {
     const interactingEntity = ethereumTransactionData.toJSON()['to'].toString();
     let fileId: FileId | null = null;
 
-    if (ethereumTransactionData.toBytes().length <= 5120) {
+    // if callData's size is greater than `fileAppendChunkSize` => employ HFS to create new file to carry the rest of the contents of callData
+    if (ethereumTransactionData.callData.length <= this.fileAppendChunkSize) {
       ethereumTransaction.setEthereumData(ethereumTransactionData.toBytes());
     } else {
       fileId = await this.createFile(


### PR DESCRIPTION
**Description**:
Currently, when an `eth_sendRawTransaction` request contains a large `callData`, the Relay uses HFS to create a new file to handle the contents of the `callData`. The condition to use HFS is when `callData.length` exceeds the `fileChunkSize` value. However, in the original setup, the condition is evaluated by comparing the entire `ethereumTransactionData` object, not just `ethereumTransactionData.callData`. This leads to the mismatch between the `callData` size and the `fileChunkSize` value, and therefore throw `Null entity ID` error, when the `callData` size falls within the range of 2568 bytes to 5217 bytes, as described in [issue #2563](https://github.com/hashgraph/hedera-json-rpc-relay/issues/2563).

This PR fixes the problem by using `ethereumTransactionData.callData` for the HFS condition check.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/2563
Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/2544

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
