### PR TITLE
test: re-included eth_getCode and eth_sendRawTransaction in the release testing flow

### DIFF
--- a/packages/ws-server/tests/acceptance/getCode.spec.ts
+++ b/packages/ws-server/tests/acceptance/getCode.spec.ts
@@ -56,13 +56,13 @@ describe('@web-socket-batch-2 eth_getCode', async function () {
     }
   });
 
-  it('should return the code ethers WebSocketProvider', async function () {
+  it('@release should return the code ethers WebSocketProvider', async function () {
     const codeFromWs = await ethersWsProvider.getCode(basicContractAddress);
     expect(codeFromWs).to.be.a('string');
     expect(codeFromRPC).to.equal(codeFromWs);
   });
 
-  it('should return the code through a websocket', async () => {
+  it('@release should return the code through a websocket', async () => {
     const param = [basicContractAddress, 'latest'];
     const response = await WsTestHelper.sendRequestToStandardWebSocket(METHOD_NAME, param);
     WsTestHelper.assertJsonRpcObject(response);

--- a/packages/ws-server/tests/acceptance/sendRawTransaction.spec.ts
+++ b/packages/ws-server/tests/acceptance/sendRawTransaction.spec.ts
@@ -109,7 +109,7 @@ describe('@web-socket-batch-2 eth_sendRawTransaction', async function () {
       });
     }
 
-    it(`Should execute eth_sendRawTransaction on Standard Web Socket and handle valid requests correctly`, async () => {
+    it(`@release Should execute eth_sendRawTransaction on Standard Web Socket and handle valid requests correctly`, async () => {
       tx.nonce = await relay.getAccountNonce(accounts[0].address);
       const signedTx = await accounts[0].wallet.signTransaction(tx);
 
@@ -179,7 +179,7 @@ describe('@web-socket-batch-2 eth_sendRawTransaction', async function () {
       });
     }
 
-    it(`Should execute eth_sendRawTransaction on Ethers Web Socket Provider and handle valid requests correctly`, async () => {
+    it(`@release Should execute eth_sendRawTransaction on Ethers Web Socket Provider and handle valid requests correctly`, async () => {
       tx.nonce = await relay.getAccountNonce(accounts[1].address);
       const signedTx = await accounts[1].wallet.signTransaction(tx); // const signedTx = await accounts[0].wallet.signTransaction(tx);
 


### PR DESCRIPTION
**Description**:
The problem described in https://github.com/hashgraph/hedera-json-rpc-relay/issues/2578 was caused by a lack of a certain configurations on GCP. Neccesary configurations were added to the production envionments, so the porblem was resolved. This PR re-includes eth_getCode and eth_sendRawTransaction back to release testing flow


**Related issue(s)**:

Fixes #2578 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
