### PR TITLE
fix: removed name field in JsonRpcError class

### DIFF
--- a/charts/hedera-json-rpc-relay/postman.json
+++ b/charts/hedera-json-rpc-relay/postman.json
@@ -617,7 +617,6 @@
 							"pm.test(\"Success\", () => {",
 							"    var response = pm.response.json();",
 							"    pm.expect(response.error.code).to.equal(-32601);",
-							"    pm.expect(response.error.name).to.equal(\"Method not found\");",
 							"    pm.expect(response.error.message.endsWith(\"Unsupported JSON-RPC method\")).to.be.true;",
 							"    pm.expect(response.id).to.equal(\"test_id\");",
 							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",

--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -23,12 +23,10 @@ import constants from '../../lib/constants';
 export class JsonRpcError {
   public code: number;
   public message: string;
-  public name?: string;
   public data?: string;
 
-  constructor(args: { name?: string; code: number; message: string; data?: string }, requestId?: string) {
+  constructor(args: { code: number; message: string; data?: string }, requestId?: string) {
     this.code = args.code;
-    this.name = args.name;
     this.message = requestId ? `[${constants.REQUEST_ID_STRING}${requestId}] ` + args.message : args.message;
     this.data = args.data;
   }
@@ -43,139 +41,114 @@ export const predefined = {
     }),
   GAS_LIMIT_TOO_HIGH: (gasLimit, maxGas) =>
     new JsonRpcError({
-      name: 'gasLimit too high',
       code: -32005,
       message: `Transaction gas limit '${gasLimit}' exceeds block gas limit '${maxGas}'`,
     }),
   GAS_LIMIT_TOO_LOW: (gasLimit, requiredGas) =>
     new JsonRpcError({
-      name: 'gasLimit too low',
       code: -32003,
       message: `Transaction gas limit provided '${gasLimit}' is insufficient of intrinsic gas required '${requiredGas}'`,
     }),
   GAS_PRICE_TOO_LOW: (gasPrice, minGasPrice) =>
     new JsonRpcError({
-      name: 'Gas price too low',
       code: -32009,
       message: `Gas price '${gasPrice}' is below configured minimum gas price '${minGasPrice}'`,
     }),
   HBAR_RATE_LIMIT_EXCEEDED: new JsonRpcError({
-    name: 'HBAR Rate limit exceeded',
     code: -32606,
     message: 'HBAR Rate limit exceeded',
   }),
   INSUFFICIENT_ACCOUNT_BALANCE: new JsonRpcError({
-    name: 'Insufficient account balance',
     code: -32000,
     message: 'Insufficient funds for transfer',
   }),
   INTERNAL_ERROR: (message = '') =>
     new JsonRpcError({
-      name: 'Internal error',
       code: -32603,
       message: message === '' || undefined ? 'Unknown error invoking RPC' : `Error invoking RPC: ${message}`,
     }),
   INVALID_PARAMETER: (index: number | string, message: string) =>
     new JsonRpcError({
-      name: 'Invalid parameter',
       code: -32602,
       message: `Invalid parameter ${index}: ${message}`,
     }),
   INVALID_PARAMETERS: new JsonRpcError({
-    name: 'Invalid parameters',
     code: -32602,
     message: 'Invalid params',
   }),
   INVALID_REQUEST: new JsonRpcError({
-    name: 'Invalid request',
     code: -32600,
     message: 'Invalid request',
   }),
   IP_RATE_LIMIT_EXCEEDED: (methodName: string) =>
     new JsonRpcError({
-      name: 'IP Rate limit exceeded',
       code: -32605,
       message: `IP Rate limit exceeded on ${methodName}`,
     }),
   MISSING_FROM_BLOCK_PARAM: new JsonRpcError({
-    name: 'Missing fromBlock parameter',
     code: -32011,
     message: 'Provided toBlock parameter without specifying fromBlock',
   }),
   MISSING_REQUIRED_PARAMETER: (index: number | string) =>
     new JsonRpcError({
-      name: 'Missing required parameters',
       code: -32602,
       message: `Missing value for required parameter ${index}`,
     }),
   NONCE_TOO_LOW: (nonce, currentNonce) =>
     new JsonRpcError({
-      name: 'Nonce too low',
       code: 32001,
       message: `Nonce too low. Provided nonce: ${nonce}, current nonce: ${currentNonce}`,
     }),
   NONCE_TOO_HIGH: (nonce, currentNonce) =>
     new JsonRpcError({
-      name: 'Nonce too high',
       code: 32002,
       message: `Nonce too high. Provided nonce: ${nonce}, current nonce: ${currentNonce}`,
     }),
   NO_MINING_WORK: new JsonRpcError({
-    name: 'No mining work',
     code: -32000,
     message: 'No mining work available yet',
   }),
   PARSE_ERROR: new JsonRpcError({
-    name: 'Parse error',
     code: -32700,
     message: 'Unable to parse JSON',
   }),
   RANGE_TOO_LARGE: (blockRange: number) =>
     new JsonRpcError({
-      name: 'Block range too large',
       code: -32000,
       message: `Exceeded maximum block range: ${blockRange}`,
     }),
   REQUEST_BEYOND_HEAD_BLOCK: (requested: number, latest: number) =>
     new JsonRpcError({
-      name: 'Incorrect block',
       code: -32000,
       message: `Request beyond head block: requested ${requested}, head ${latest}`,
     }),
   REQUEST_TIMEOUT: new JsonRpcError({
-    name: 'Request timeout',
     code: -32010,
     message: 'Request timeout. Please try again.',
   }),
   RESOURCE_NOT_FOUND: (message = '') =>
     new JsonRpcError({
-      name: 'Resource not found',
       code: -32001,
       message: `Requested resource not found. ${message}`,
     }),
   UNKNOWN_HISTORICAL_BALANCE: new JsonRpcError({
-    name: 'Unavailable balance',
     code: -32007,
     message: 'Historical balance data is available only after 15 minutes.',
   }),
   UNSUPPORTED_CHAIN_ID: (requested: string | number, current: string | number) =>
     new JsonRpcError({
-      name: 'ChainId not supported',
       code: -32000,
       message: `ChainId (${requested}) not supported. The correct chainId is ${current}`,
     }),
   UNSUPPORTED_METHOD: new JsonRpcError({
-    name: 'Method not found',
     code: -32601,
     message: 'Unsupported JSON-RPC method',
   }),
   UNSUPPORTED_TRANSACTION_TYPE: new JsonRpcError({
-    name: 'Unsupported transaction type',
     code: -32611,
     message: 'Unsupported transaction type',
   }),
   VALUE_TOO_LOW: new JsonRpcError({
-    name: 'Value too low',
     code: -32602,
     message: 'Value below 10_000_000_000 wei which is 1 tinybar',
   }),
@@ -186,7 +159,6 @@ export const predefined = {
     }
 
     return new JsonRpcError({
-      name: 'Invalid Contract Address',
       code: -32012,
       message: message,
     });
@@ -198,7 +170,6 @@ export const predefined = {
     }
 
     return new JsonRpcError({
-      name: 'Non Existing Contract Address',
       code: -32013,
       message: message,
     });
@@ -210,97 +181,80 @@ export const predefined = {
     }
 
     return new JsonRpcError({
-      name: 'Non Existing Account Address',
       code: -32014,
       message: message,
     });
   },
   COULD_NOT_ESTIMATE_GAS_PRICE: new JsonRpcError({
-    name: 'Could not estimate gas price',
     code: -32604,
     message: 'Error encountered estimating the gas price',
   }),
   COULD_NOT_RETRIEVE_LATEST_BLOCK: new JsonRpcError({
-    name: 'Could not retrieve latest block',
     code: -32607,
     message: 'Error encountered retrieving latest block',
   }),
   MAX_SUBSCRIPTIONS: new JsonRpcError({
-    name: 'Exceeded maximum allowed subscriptions',
     code: -32608,
     message: 'Exceeded maximum allowed subscriptions',
   }),
   UNSUPPORTED_HISTORICAL_EXECUTION: (blockId: string) =>
     new JsonRpcError({
-      name: 'Unsupported historical block request',
       code: -32609,
       message: `Unsupported historical block identifier encountered: ${blockId}`,
     }),
   UNSUPPORTED_OPERATION: (message: string) =>
     new JsonRpcError({
-      name: 'Unsupported operation',
       code: -32610,
       message: `Unsupported operation. ${message}`,
     }),
   PAGINATION_MAX: (count: number) =>
     new JsonRpcError({
-      name: 'Mirror Node pagination count range too large',
       code: -32011,
       message: `Exceeded maximum mirror node pagination count: ${count}`,
     }),
   MAX_BLOCK_SIZE: (count: number) =>
     new JsonRpcError({
-      name: 'Block size too large',
       code: -32000,
       message: `Exceeded max transactions that can be returned in a block: ${count}`,
     }),
   UNKNOWN_BLOCK: (msg?: string | null) =>
     new JsonRpcError({
-      name: 'Unknown block',
       code: -39012,
       message: msg || 'Unknown block',
     }),
   INVALID_BLOCK_RANGE: new JsonRpcError({
-    name: 'Invalid block range',
     code: -39013,
     message: 'Invalid block range',
   }),
   FILTER_NOT_FOUND: new JsonRpcError({
-    name: 'Filter not found',
     code: -32001,
     message: 'Filter not found',
   }),
   TRANSACTION_SIZE_TOO_BIG: (actualSize: string, expectedSize: string) =>
     new JsonRpcError({
-      name: 'Transaction size too big',
       code: -32201,
       message: `Oversized data: transaction size ${actualSize}, transaction limit ${expectedSize}`,
     }),
   BATCH_REQUESTS_DISABLED: new JsonRpcError({
-    name: 'Batch requests disabled',
     code: -32202,
     message: 'Batch requests are disabled',
   }),
   BATCH_REQUESTS_AMOUNT_MAX_EXCEEDED: (amount: number, max: number) =>
     new JsonRpcError({
-      name: 'Batch requests amount max exceeded',
       code: -32203,
       message: `Batch request amount ${amount} exceeds max ${max}`,
     }),
   WS_BATCH_REQUESTS_DISABLED: new JsonRpcError({
-    name: 'WS batch requests disabled',
     code: -32205,
     message: 'WS batch requests are disabled',
   }),
   WS_BATCH_REQUESTS_AMOUNT_MAX_EXCEEDED: (amount: number, max: number) =>
     new JsonRpcError({
-      name: 'WS batch requests amount max exceeded',
       code: -32206,
       message: `Batch request amount ${amount} exceeds max ${max}`,
     }),
   INVALID_ARGUMENTS: (message: string) =>
     new JsonRpcError({
-      name: 'Invalid argument',
       code: -32000,
       message: `Invalid arguments: ${message}`,
     }),

--- a/packages/relay/tests/assertions.ts
+++ b/packages/relay/tests/assertions.ts
@@ -16,9 +16,9 @@ export default class RelayAssertions {
     return await expect(method.apply(thisObj, args), `${error.message}`).to.eventually.be.rejected.and.satisfy(
       (err) => {
         if (!checkMessage) {
-          return err.code === error.code && err.name === error.name;
+          return err.code === error.code;
         }
-        return err.code === error.code && err.name === error.name && err.message === error.message;
+        return err.code === error.code && err.message === error.message;
       },
     );
   };

--- a/packages/relay/tests/lib/errors/JsonRpcError.spec.ts
+++ b/packages/relay/tests/lib/errors/JsonRpcError.spec.ts
@@ -25,13 +25,11 @@ describe('Errors', () => {
   describe('JsonRpcError', () => {
     it('Constructs correctly without request ID', () => {
       const err = new JsonRpcError({
-        name: 'TestError',
         code: -32999,
         message: 'test error: foo',
         data: 'some data',
       });
       expect(err.code).to.eq(-32999);
-      expect(err.name).to.eq('TestError');
       expect(err.data).to.eq('some data');
 
       // Check that request ID is *not* prefixed
@@ -41,7 +39,6 @@ describe('Errors', () => {
     it('Constructs correctly with request ID', () => {
       const err = new JsonRpcError(
         {
-          name: 'TestError',
           code: -32999,
           message: 'test error: foo',
           data: 'some data',
@@ -49,9 +46,7 @@ describe('Errors', () => {
         'abcd-1234',
       );
       expect(err.code).to.eq(-32999);
-      expect(err.name).to.eq('TestError');
       expect(err.data).to.eq('some data');
-
       // Check that request ID is prefixed
       expect(err.message).to.eq('[Request ID: abcd-1234] test error: foo');
     });

--- a/packages/relay/tests/lib/eth/eth_call.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_call.spec.ts
@@ -343,7 +343,6 @@ describe('@ethCall Eth Call spec', async function () {
 
       const result = await ethImpl.call(callData, 'latest');
 
-      expect((result as JsonRpcError).name).to.equal('Non Existing Account Address');
       expect((result as JsonRpcError).code).to.equal(-32014);
       expect((result as JsonRpcError).message).to.equal(
         `Non Existing Account Address: ${callData.from}. Expected an Account Address.`,
@@ -401,7 +400,6 @@ describe('@ethCall Eth Call spec', async function () {
       const call: string | JsonRpcError = await ethImpl.call(ETH_CALL_REQ_ARGS, 'latest');
 
       expect((call as JsonRpcError).code).to.equal(expectedError.code);
-      expect((call as JsonRpcError).name).to.equal(expectedError.name);
       expect((call as JsonRpcError).message).to.equal(expectedError.message);
     });
 
@@ -415,7 +413,6 @@ describe('@ethCall Eth Call spec', async function () {
 
       expect(result).to.exist;
       expect((result as JsonRpcError).code).to.equal(3);
-      expect((result as JsonRpcError).name).to.equal(undefined);
       expect((result as JsonRpcError).message).to.equal(`execution reverted: ${defaultErrorMessageText}`);
       expect((result as JsonRpcError).data).to.equal(defaultErrorMessageHex);
     });
@@ -456,7 +453,6 @@ describe('@ethCall Eth Call spec', async function () {
 
       expect(result).to.exist;
       expect((result as JsonRpcError).code).to.equal(-32603);
-      expect((result as JsonRpcError).name).to.equal('Internal error');
       expect((result as JsonRpcError).message).to.equal(
         'Error invoking RPC: Invalid contractCallResponse from consensus-node: undefined',
       );
@@ -603,7 +599,6 @@ describe('@ethCall Eth Call spec', async function () {
       const result = await ethImpl.call(callData, 'latest');
       expect(result).to.be.not.null;
       expect((result as JsonRpcError).code).to.eq(-32605);
-      expect((result as JsonRpcError).name).to.eq('IP Rate limit exceeded');
     });
 
     it('eth_call with all fields but mirrorNode throws 400', async function () {
@@ -621,7 +616,6 @@ describe('@ethCall Eth Call spec', async function () {
       const result = await ethImpl.call(callData, 'latest');
       expect(result).to.be.not.null;
       expect((result as JsonRpcError).code).to.eq(3);
-      expect((result as JsonRpcError).name).to.eq(undefined);
       expect((result as JsonRpcError).message).to.contain(mockData.contractReverted._status.messages[0].message);
     });
 
@@ -676,7 +670,6 @@ describe('@ethCall Eth Call spec', async function () {
       sinon.assert.notCalled(sdkClientStub.submitContractCallQueryWithRetry);
       expect(result).to.not.be.null;
       expect((result as JsonRpcError).code).to.eq(3);
-      expect((result as JsonRpcError).name).to.eq(undefined);
       expect((result as JsonRpcError).message).to.contain(mockData.contractReverted._status.messages[0].message);
     });
 
@@ -707,7 +700,6 @@ describe('@ethCall Eth Call spec', async function () {
 
       expect(result).to.exist;
       expect((result as JsonRpcError).code).to.eq(3);
-      expect((result as JsonRpcError).name).to.eq(undefined);
       expect((result as JsonRpcError).message).to.equal(`execution reverted: ${defaultErrorMessageText}`);
       expect((result as JsonRpcError).data).to.equal(defaultErrorMessageHex);
     });

--- a/packages/relay/tests/lib/eth/eth_common.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_common.spec.ts
@@ -97,8 +97,6 @@ describe('@ethCommon', async function () {
       const result = Relay.eth().getWork();
       expect(result).to.have.property('code');
       expect(result.code).to.be.equal(-32601);
-      expect(result).to.have.property('name');
-      expect(result.name).to.be.equal('Method not found');
       expect(result).to.have.property('message');
       expect(result.message).to.be.equal('Unsupported JSON-RPC method');
     });

--- a/packages/relay/tests/lib/eth/eth_estimateGas.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_estimateGas.spec.ts
@@ -161,7 +161,6 @@ describe('@ethEstimateGas Estimate Gas spec', async function () {
     const result = await ethImpl.estimateGas(callData, null);
     expect(result).to.not.be.null;
     expect((result as JsonRpcError).code).to.eq(-32602);
-    expect((result as JsonRpcError).name).to.eq('Invalid parameter');
   });
 
   it('should eth_estimateGas transfer to existing account', async function () {
@@ -246,7 +245,6 @@ describe('@ethEstimateGas Estimate Gas spec', async function () {
 
     expect(result).to.exist;
     expect((result as JsonRpcError).code).to.equal(-32602);
-    expect((result as JsonRpcError).name).to.equal('Invalid parameter');
     expect((result as JsonRpcError).message).to.equal(
       `Invalid parameter 0: Invalid 'value' field in transaction param. Value must be greater than 0`,
     );
@@ -293,7 +291,6 @@ describe('@ethEstimateGas Estimate Gas spec', async function () {
 
     expect(result).to.exist;
     expect((result as JsonRpcError).code).to.equal(-32602);
-    expect((result as JsonRpcError).name).to.equal('Invalid parameter');
     expect((result as JsonRpcError).message).to.equal(
       `Invalid parameter 0: Invalid 'value' field in transaction param. Value must be greater than 0`,
     );

--- a/packages/relay/tests/lib/eth/eth_getCode.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getCode.spec.ts
@@ -151,7 +151,6 @@ describe('@ethGetCode using MirrorNode', async function () {
           expect(error).to.exist;
           expect(error instanceof JsonRpcError);
           expect(error.code).to.eq(expectedError.code);
-          expect(error.name).to.eq(expectedError.name);
           expect(error.message).to.eq(expectedError.message);
         }
       });

--- a/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
@@ -456,7 +456,6 @@ describe('@ethGetLogs using MirrorNode', async function () {
 
     await ethGetLogsFailing(ethImpl, [null, null, '0x5', null, null], (error) => {
       expect(error.code).to.equal(-32011);
-      expect(error.name).to.equal('Missing fromBlock parameter');
       expect(error.message).to.equal('Provided toBlock parameter without specifying fromBlock');
     });
   });

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -1101,7 +1101,6 @@ describe('MirrorNodeClient', async function () {
           `Exceeded maximum mirror node pagination count: ${constants.MAX_MIRROR_NODE_PAGINATION}`,
         );
         expect(e.code).to.equal(errorRef.code);
-        expect(e.name).to.equal(errorRef.name);
       }
     });
   });

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -33,6 +33,7 @@ import { Transaction, ethers } from 'ethers';
 import constants from '../../src/lib/constants';
 import { JsonRpcError, predefined } from '../../src';
 import { CacheService } from '../../src/lib/services/cacheService/cacheService';
+import { ONE_TINYBAR_IN_WEI_HEX } from './eth/eth-config';
 const logger = pino();
 
 const limitOrderPostFix = '?order=desc&limit=1';
@@ -469,7 +470,6 @@ describe('Precheck', async function () {
       } catch (e: any) {
         expect(e).to.exist;
         expect(e.code).to.eq(-32001);
-        expect(e.name).to.eq('Resource not found');
         expect(e.message).to.contain(parsedTx.from);
       }
     });
@@ -576,7 +576,7 @@ describe('Precheck', async function () {
 
   describe('transactionType', async function () {
     const defaultTx = {
-      value: oneTinyBar,
+      value: ONE_TINYBAR_IN_WEI_HEX,
       gasPrice: defaultGasPrice,
       gasLimit: defaultGasLimit,
       chainId: defaultChainId,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -217,7 +217,6 @@ const logAndHandleResponse = async (methodName: any, methodParams: any, methodFu
 
       return new JsonRpcError(
         {
-          name: response.name,
           code: response.code,
           message: response.message,
           data: response.data,
@@ -239,7 +238,6 @@ const logAndHandleResponse = async (methodName: any, methodParams: any, methodFu
     logger.error(`${requestIdPrefix} ${error.message}`);
     return new JsonRpcError(
       {
-        name: error.name,
         code: error.code,
         message: error.message,
         data: error.data,

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -356,7 +356,6 @@ export default class Assertions {
 
       const { error } = e?.response ? e.response.bodyJson : e;
       expect(error.code).to.equal(expectedError.code);
-      expect(error.name).to.equal(expectedError.name);
       if (checkMessage) {
         expect(error.message).to.include(expectedError.message);
       }

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -576,7 +576,6 @@ describe('RPC Server', async function () {
       expect(response.data[2].id).to.be.equal('4');
       expect(response.data[2].error).to.be.an('Object');
       expect(response.data[2].error.code).to.be.equal(-32602);
-      expect(response.data[2].error.name).to.be.equal('Missing required parameters');
       expect(
         response.data[2].error.message.endsWith('Missing value for required parameter 1'),
         'Missing value for required parameter 1',
@@ -2312,7 +2311,7 @@ class BaseTest {
     expect(response, "Default response: Should have 'data' property").to.have.property('data');
   }
 
-  static errorResponseChecks(response, code, message, name?) {
+  static errorResponseChecks(response, code, message) {
     BaseTest.validRequestIdCheck(response);
     expect(response, "Error response: should have 'data' property").to.have.property('data');
     expect(response.data, "Error response: 'data' should have 'id' property").to.have.property('id');
@@ -2329,13 +2328,6 @@ class BaseTest {
       response.data.error.message.endsWith(message),
       `Error response: 'data.error.message' should end with passed ${message} value, but came with ${response.data.error.message}`,
     ).to.be.true;
-    if (name) {
-      expect(response.data.error, "Error response: 'data.error' should have 'name' property").to.have.property('name');
-      expect(
-        response.data.error.name,
-        "Error response: 'data.error.name' should match passed 'name' value",
-      ).to.be.equal(name);
-    }
   }
 
   static unsupportedJsonRpcMethodChecks(response: any) {
@@ -2348,7 +2340,6 @@ class BaseTest {
     expect(response.status).to.eq(400);
     expect(response.statusText).to.eq('Bad Request');
 
-    expect(response.data.error.name).to.eq('Batch requests disabled');
     expect(response.data.error.message).to.eq('Batch requests are disabled');
     expect(response.data.error.code).to.eq(-32202);
   }
@@ -2362,7 +2353,6 @@ class BaseTest {
   static batchRequestLimitError(response: any, amount: number, max: number) {
     expect(response.status).to.eq(400);
     expect(response.statusText).to.eq('Bad Request');
-    expect(response.data.error.name).to.eq('Batch requests amount max exceeded');
     expect(response.data.error.message).to.eq(`Batch request amount ${amount} exceeds max ${max}`);
     expect(response.data.error.code).to.eq(-32203);
   }

--- a/packages/server/tests/postman.json
+++ b/packages/server/tests/postman.json
@@ -589,7 +589,6 @@
               "pm.test(\"Success\", () => {",
               "    var response = pm.response.json();",
               "    pm.expect(response.error.code).to.equal(-32601);",
-              "    pm.expect(response.error.name).to.equal(\"Method not found\");",
               "    pm.expect(response.error.message.endsWith(\"Unsupported JSON-RPC method\")).to.be.true;",
               "    pm.expect(response.id).to.equal(\"test_id\");",
               "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",

--- a/packages/ws-server/tests/acceptance/sendRawTransaction.spec.ts
+++ b/packages/ws-server/tests/acceptance/sendRawTransaction.spec.ts
@@ -166,7 +166,6 @@ describe('@web-socket-batch-2 eth_sendRawTransaction', async function () {
         const expectedNonceTooLowError = predefined.NONCE_TOO_LOW(0, signerNonce);
         const errObj = response.result;
         expect(errObj.code).to.eq(expectedNonceTooLowError.code);
-        expect(errObj.name).to.eq(expectedNonceTooLowError.name);
         expect(errObj.message).to.contain(expectedNonceTooLowError.message);
       }
     });
@@ -225,7 +224,6 @@ describe('@web-socket-batch-2 eth_sendRawTransaction', async function () {
         const errObj = await ethersWsProvider.send(METHOD_NAME, [constants.DETERMINISTIC_DEPLOYER_TRANSACTION]);
         const expectedNonceTooLowError = predefined.NONCE_TOO_LOW(0, signerNonce);
         expect(errObj.code).to.eq(expectedNonceTooLowError.code);
-        expect(errObj.name).to.eq(expectedNonceTooLowError.name);
         expect(errObj.message).to.contain(expectedNonceTooLowError.message);
       }
     });

--- a/packages/ws-server/tests/acceptance/subscribe.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribe.spec.ts
@@ -242,7 +242,6 @@ describe('@web-socket-batch-3 eth_subscribe', async function () {
       await new Promise((resolve) => setTimeout(resolve, 200));
 
       expect(JSON.parse(response).code).to.eq(predefined.INVALID_REQUEST.code);
-      expect(JSON.parse(response).name).to.eq(predefined.INVALID_REQUEST.name);
       expect(JSON.parse(response).message).to.eq(predefined.INVALID_REQUEST.message);
 
       webSocket.close();
@@ -339,7 +338,6 @@ describe('@web-socket-batch-3 eth_subscribe', async function () {
 
       expect(response.id).to.be.eq(requestId);
       expect(response.error.code).to.be.eq(-32602);
-      expect(response.error.name).to.be.eq('Invalid parameter');
       expect(response.error.message).to.be.eq(
         `Invalid parameter filters.address: Only one contract address is allowed`,
       );
@@ -365,7 +363,6 @@ describe('@web-socket-batch-3 eth_subscribe', async function () {
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       expect(response.error.code).to.eq(predefined.UNSUPPORTED_METHOD.code);
-      expect(response.error.name).to.eq(predefined.UNSUPPORTED_METHOD.name);
       expect(response.error.message).to.eq(predefined.UNSUPPORTED_METHOD.message);
 
       // close the connection
@@ -386,7 +383,6 @@ describe('@web-socket-batch-3 eth_subscribe', async function () {
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       expect(response.error.code).to.eq(predefined.UNSUPPORTED_METHOD.code);
-      expect(response.error.name).to.eq(predefined.UNSUPPORTED_METHOD.name);
       expect(response.error.message).to.eq(predefined.UNSUPPORTED_METHOD.message);
 
       // close the connection

--- a/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
@@ -158,8 +158,6 @@ describe('@web-socket-batch-3 eth_subscribe newHeads', async function () {
             expect(response.error.code).to.equal(-32601);
             expect(response.error).to.have.property('message');
             expect(response.error.message).to.equal('Unsupported JSON-RPC method');
-            expect(response.error).to.have.property('name');
-            expect(response.error.name).to.equal('Method not found');
             resolve();
           } catch (error) {
             reject(error);


### PR DESCRIPTION
**Description**:
This PR removes the `name` field in JsonRpcError class to conform to the JSON-RPC 2.0 Specification. Many tests were updated to apply this new changes.

**Related issue(s)**:

Fixes #2589

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
