### PR TITLE
fix: reworked gas comparison logic

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -56,6 +56,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
   let mirrorContractDetails;
   let requestId: string;
   let account2Address: string;
+  let expectedGasPrice: string;
 
   const CHAIN_ID = process.env.CHAIN_ID || '0x12a';
   const INCORRECT_CHAIN_ID = 999;
@@ -84,6 +85,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
     this.beforeAll(async () => {
       requestId = Utils.generateRequestId();
       const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
+      expectedGasPrice = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, [], requestId);
 
       const initialAccount: AliasAccount = global.accounts[0];
       const neededAccounts: number = 3;
@@ -463,7 +465,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           [mirrorBlock.hash.substring(0, 66), false],
           requestId,
         );
-        Assertions.block(blockResult, mirrorBlock, mirrorTransactions, false);
+        Assertions.block(blockResult, mirrorBlock, mirrorTransactions, expectedGasPrice, false);
       });
 
       it('@release should execute "eth_getBlockByHash", hydrated transactions = true', async function () {
@@ -474,7 +476,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         );
         // Remove synthetic transactions
         blockResult.transactions = blockResult.transactions.filter((transaction) => transaction.value !== '0x1234');
-        Assertions.block(blockResult, mirrorBlock, mirrorTransactions, true);
+        Assertions.block(blockResult, mirrorBlock, mirrorTransactions, expectedGasPrice, true);
       });
 
       it('should execute "eth_getBlockByHash" for non-existing block hash and hydrated transactions = false', async function () {
@@ -503,7 +505,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         );
         // Remove synthetic transactions
         blockResult.transactions = blockResult.transactions.filter((transaction) => transaction.value !== '0x1234');
-        Assertions.block(blockResult, mirrorBlock, mirrorTransactions, false);
+        Assertions.block(blockResult, mirrorBlock, mirrorTransactions, expectedGasPrice, false);
       });
 
       it('@release should execute "eth_getBlockByNumber", hydrated transactions = true', async function () {
@@ -514,7 +516,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         );
         // Remove synthetic transactions
         blockResult.transactions = blockResult.transactions.filter((transaction) => transaction.value !== '0x1234');
-        Assertions.block(blockResult, mirrorBlock, mirrorTransactions, true);
+        Assertions.block(blockResult, mirrorBlock, mirrorTransactions, expectedGasPrice, true);
       });
 
       it('should execute "eth_getBlockByNumber" for non existing block number and hydrated transactions = true', async function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -58,6 +58,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
   let tokenId;
   let requestId;
   let htsAddress;
+  let expectedGasPrice: string;
   let basicContract: ethers.Contract;
   let basicContractAddress: string;
   let parentContractAddress: string;
@@ -92,6 +93,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
   this.beforeAll(async () => {
     requestId = Utils.generateRequestId();
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
+    expectedGasPrice = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, [], requestId);
 
     const initialAccount: AliasAccount = global.accounts[0];
 
@@ -417,7 +419,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
       const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, [], requestId);
       expect(res).to.exist;
       if (process.env.LOCAL_NODE && process.env.LOCAL_NODE !== 'false') {
-        expect(res).be.equal(ethers.toQuantity(Assertions.defaultGasPrice));
+        expect(res).be.equal(expectedGasPrice);
       } else {
         expect(Number(res)).to.be.gt(0);
       }

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -65,12 +65,18 @@ export default class Assertions {
    * @param mirrorTransactions
    * @param hydratedTransactions - aka showDetails flag
    */
-  public static block(relayResponse, mirrorNodeResponse, mirrorTransactions, hydratedTransactions = false) {
+  public static block(
+    relayResponse,
+    mirrorNodeResponse,
+    mirrorTransactions,
+    expectedGasPrice,
+    hydratedTransactions = false,
+  ) {
     // Assert static values
     expect(relayResponse.baseFeePerGas).to.exist;
 
     if (process.env.LOCAL_NODE && process.env.LOCAL_NODE !== 'false') {
-      expect(relayResponse.baseFeePerGas).to.be.equal(ethers.toQuantity(this.defaultGasPrice));
+      expect(relayResponse.baseFeePerGas).to.be.equal(expectedGasPrice);
     } else {
       expect(Number(relayResponse.baseFeePerGas)).to.be.gt(0);
     }


### PR DESCRIPTION
**Description**:
This PR reworks gas comparison logic. Originally, gas price was compared to a hard-coded value, 71 HBARs, which is only true if the environment is local-net or previewnet. The new logic retrieves the expected gas value from the Relay for the comparison so it would be correct in all environments.

**Related issue(s)**:

Fixes #2610 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
