### PR TITLE
ci: Update actions/download-artifact and actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/acceptance-public.yml
+++ b/.github/workflows/acceptance-public.yml
@@ -156,9 +156,10 @@ jobs:
           egress-policy: audit
 
       - name: Download Test Reports
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: Test Results
+          pattern: Test Results (*)
+          merge-multiple: true
 
       - name: Publish Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -104,9 +104,9 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
-          name: Test Results
+          name: Test Results (${{ inputs.testfilter }})
           path: test-*.xml
 
       - name: Upload coverage report

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -133,9 +133,10 @@ jobs:
           egress-policy: audit
 
       - name: Download Test Reports
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: Test Results
+          pattern: Test Results (*)
+          merge-multiple: true
 
       - name: Publish Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload logs to GitHub
         if: ${{ always() && !cancelled() }}
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: logs.tgz
           path: ./logs.tgz

--- a/.github/workflows/manual-testing.yml
+++ b/.github/workflows/manual-testing.yml
@@ -140,9 +140,10 @@ jobs:
           egress-policy: audit
 
       - name: Download Test Reports
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
-          name: Test Results
+          pattern: Test Results (*)
+          merge-multiple: true
 
       - name: Publish Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: Test Results
           path: test-*.xml

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -79,7 +79,7 @@ jobs:
         run: tar -czf ${{ env.PACKAGE_NAME }}-v${{env.TAG}}.tgz -C ./packages . 
 
       - name: Upload artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ${{ env.PACKAGE_NAME }}-v${{env.TAG}}
           path: ./*.tgz


### PR DESCRIPTION
**Description**:
This PR is addressing the following note:

```
Warning

actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.
```
It has addressed the [Breaking Changes](https://github.com/actions/upload-artifact/tree/main?tab=readme-ov-file#breaking-changes) in v4 where is needed:

```
Uploading to the same named Artifact multiple times.

Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

```

**Related issue(s)**:

Fixes #2596

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
