### PR TITLE
fix: fixed unexpected returns for eth_getLog requests with zero address

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -32,6 +32,7 @@ import { CacheService } from '../services/cacheService/cacheService';
 
 import http from 'http';
 import https from 'https';
+import { ethers } from 'ethers';
 import { IOpcodesResponse } from './models/IOpcodesResponse';
 
 type REQUEST_METHODS = 'GET' | 'POST';
@@ -853,6 +854,8 @@ export class MirrorNodeClient {
     limitOrderParams?: ILimitOrderParams,
     requestIdPrefix?: string,
   ) {
+    if (address === ethers.ZeroAddress) return [];
+
     const queryParams = this.prepareLogsParams(contractLogsResultsParams, limitOrderParams);
     const apiEndpoint = MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_BY_ADDRESS_ENDPOINT.replace(
       MirrorNodeClient.ADDRESS_PLACEHOLDER,

--- a/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
@@ -56,6 +56,7 @@ import {
   DEFAULT_NULL_LOG_TOPICS,
   NOT_FOUND_RES,
 } from './eth-config';
+import { ethers } from 'ethers';
 import { generateEthTestEnv } from './eth-helpers';
 
 dotenv.config({ path: path.resolve(__dirname, '../../test.env') });
@@ -578,8 +579,16 @@ describe('@ethGetLogs using MirrorNode', async function () {
 
     const result = await ethImpl.getLogs(null, '0x5', '0x10', null, DEFAULT_LOG_TOPICS);
 
-    expect(result).to.exist;
     expectLogData1(result[0]);
     expectLogData2(result[1]);
+  });
+
+  it('Should return empty log if address = ZeroAddress', async () => {
+    restMock.onGet(BLOCKS_LIMIT_ORDER_URL).reply(200, { blocks: [latestBlock] });
+    restMock.onGet('blocks/0').reply(200, DEFAULT_BLOCK);
+    restMock.onGet('blocks/latest').reply(200, DEFAULT_BLOCK);
+    const result = await ethImpl.getLogs(null, '0x0', 'latest', ethers.ZeroAddress, DEFAULT_LOG_TOPICS);
+    expect(result.length).to.eq(0);
+    expect(result).to.deep.equal([]);
   });
 });

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -31,8 +31,9 @@ import { getRequestId, mockData, random20BytesAddress } from './../helpers';
 const registry = new Registry();
 
 import pino from 'pino';
-import { SDKClientError } from '../../src/lib/errors/SDKClientError';
+import { ethers } from 'ethers';
 import { predefined } from '../../src/lib/errors/JsonRpcError';
+import { SDKClientError } from '../../src/lib/errors/SDKClientError';
 import { CacheService } from '../../src/lib/services/cacheService/cacheService';
 const logger = pino();
 const noTransactions = '?transactions=false';
@@ -731,6 +732,12 @@ describe('MirrorNodeClient', async function () {
     expect(firstResult.address).equal(log.address);
     expect(firstResult.contract_id).equal(log.contract_id);
     expect(firstResult.index).equal(log.index);
+  });
+  it('`getContractResultsLogsByAddress` with ZeroAddress ', async () => {
+    const results = await mirrorNodeInstance.getContractResultsLogsByAddress(ethers.ZeroAddress);
+    expect(results).to.exist;
+    expect(results.length).to.eq(0);
+    expect(results).to.deep.equal([]);
   });
 
   it('`getContractCurrentStateByAddressAndSlot`', async () => {

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -431,6 +431,41 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         );
         expect(logs.length).to.be.greaterThan(2);
       });
+
+      it('should return empty logs if address = ZeroAddress', async () => {
+        const logs = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS,
+          [
+            {
+              fromBlock: '0x0',
+              toBlock: 'latest',
+              address: ethers.ZeroAddress,
+            },
+          ],
+          requestId,
+        );
+        expect(logs.length).to.eq(0);
+      });
+
+      it('should return only logs of non-zero addresses', async () => {
+        const currentBlock = Number(await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_BLOCK_NUMBER, [], requestId));
+        let blocksBehindLatest = 0;
+        if (currentBlock > 10) {
+          blocksBehindLatest = currentBlock - 10;
+        }
+        const logs = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS,
+          [
+            {
+              fromBlock: numberTo0x(blocksBehindLatest),
+              toBlock: 'latest',
+              address: [ethers.ZeroAddress, contractAddress2],
+            },
+          ],
+          requestId,
+        );
+        expect(logs.length).to.eq(1);
+      });
     });
 
     describe('Block related RPC calls', () => {


### PR DESCRIPTION
**Description**:
This PR addresses the issue of unexpected records being returned from `eth_getLog` requests with zero addresses. The update ensures that if the `address` parameter equals `ZeroAddress`, the call to the mirror node is skipped, and an empty array is returned immediately.

**Related issue(s)**:

Fixes #2614

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
