### PR TITLE
fix: reduced the SDK usage in batch 3 to stablize the batch

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -802,8 +802,16 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       const mirrorContract = await mirrorNode.get(`/contracts/${deployerContractAddress}`, requestId);
       contractId = ContractId.fromString(mirrorContract.contract_id);
 
-      primaryAccountNonce = await servicesNode.getAccountNonce(accounts[0].accountId);
-      secondaryAccountNonce = await servicesNode.getAccountNonce(accounts[1].accountId);
+      primaryAccountNonce = await relay.call(
+        RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT,
+        [accounts[0].address, 'latest'],
+        requestId,
+      );
+      secondaryAccountNonce = await relay.call(
+        RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_COUNT,
+        [accounts[1].address, 'latest'],
+        requestId,
+      );
     });
 
     it('@release should execute "eth_getTransactionCount" primary', async function () {
@@ -812,7 +820,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         [mirrorPrimaryAccount.address, deployerContractTx.blockNumber],
         requestId,
       );
-      expect(res).to.be.equal(Utils.add0xPrefix(Utils.toHex(primaryAccountNonce.toInt())));
+      expect(res).to.be.equal(primaryAccountNonce);
     });
 
     it('should execute "eth_getTransactionCount" secondary', async function () {
@@ -821,7 +829,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         [mirrorSecondaryAccount.address, deployerContractTx.blockNumber],
         requestId,
       );
-      expect(res).to.be.equal(Utils.add0xPrefix(Utils.toHex(secondaryAccountNonce.toInt())));
+      expect(res).to.be.equal(secondaryAccountNonce);
     });
 
     it('@release should execute "eth_getTransactionCount" historic', async function () {
@@ -857,7 +865,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         [mirrorPrimaryAccount.address, deployerContractTx.blockNumber],
         requestId,
       );
-      expect(res).to.be.equal(Utils.add0xPrefix(Utils.toHex(primaryAccountNonce.toInt())));
+      expect(res).to.be.equal(primaryAccountNonce);
     });
 
     it('@release should execute "eth_getTransactionCount" contract with id converted to evm_address historic', async function () {


### PR DESCRIPTION
**Description**:
Initially, batch 3 frequently failed with the `GrpcServiceError: gRPC service failed with status: TIMEOUT` error. This occurred because batch 3 contained consecutive test cases that exhaustively utilized the SDK to retrieve and prepare for testing materials. This PR addresses the issue by reducing the SDK usage and delegating some tasks to the relay in batch 3. This prevents the exhaustive use of the SDK and thereby avoids the GrpcServiceError: gRPC service failed with status: TIMEOUT error.

**Related issue(s)**:

Fixes #2568

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
