### PR TITLE
fix: net_version now reads chainId from config and return decimal value

### DIFF
--- a/charts/hedera-json-rpc-relay/postman.json
+++ b/charts/hedera-json-rpc-relay/postman.json
@@ -1,1089 +1,1035 @@
 {
-	"info": {
-		"_postman_id": "351c728f-14b0-4b18-a499-4b100b68a822",
-		"name": "Relay",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "21244258"
-	},
-	"item": [
-		{
-			"name": "eth_accounts",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.be.an(\"array\");",
-							"    pm.expect(response.result).length(0);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_accounts\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_blockNumber",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_blockNumber\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_chainId",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_chainId\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_estimateGas",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_estimateGas\",\n    \"params\": [{\"to\":\"0xd3CdA913deB6f67967B99D67aCDFa1712C293601\", \"value\":\"0x1\"}]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_feeHistory",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result.baseFeePerGas).to.be.an(\"array\");",
-							"    pm.expect(response.result.baseFeePerGas).length(4);",
-							"    pm.expect(response.result.gasUsedRatio).to.be.an(\"array\");",
-							"    pm.expect(response.result.gasUsedRatio).length(3);",
-							"    pm.expect(response.result.oldestBlock).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.reward).to.be.an(\"array\");",
-							"    pm.expect(response.result.reward).length(3);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_feeHistory\",\n    \"params\": [\"0x3\", \"latest\", [25, 75]]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_gasPrice",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_gasPrice\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getBalance",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBalance\",\n    \"params\": [\"0x0000000000000000000000000000000000000062\", \"latest\"]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getBlockByNumber",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result.timestamp).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.difficulty).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.extraData).to.match(/^0x$/);",
-							"    pm.expect(response.result.gasLimit).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.baseFeePerGas).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.gasUsed).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.logsBloom).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.miner).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.mixHash).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.nonce).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.receiptsRoot).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.sha3Uncles).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.size).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.stateRoot).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.totalDifficulty).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.transactions).to.be.an(\"array\");",
-							"    pm.expect(response.result.transactionsRoot).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.uncles).to.be.an(\"array\");",
-							"    pm.expect(response.result.number).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.hash).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.result.parentHash).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\"id\": \"test_id\",\"jsonrpc\": \"2.0\",\"method\": \"eth_getBlockByNumber\",\"params\": [\"latest\", true]}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getBlockTransactionCountByNumber",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBlockTransactionCountByNumber\",\n    \"params\": [\n        \"latest\"\n    ]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getTransactionReceipt",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.be.null;",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionReceipt\",\n    \"params\": [\"0x0000000000000000000000000000000000000000000000000000000000000001\"]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getUncleByBlockHashAndIndex",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.be.null;",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getUncleByBlockHashAndIndex\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getUncleByBlockNumberAndIndex",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.be.null;",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getUncleByBlockNumberAndIndex\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getUncleCountByBlockHash",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.equal(\"0x0\");",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getUncleCountByBlockHash\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getUncleCountByBlockNumber",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.equal(\"0x0\");",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getUncleCountByBlockNumber\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getWork",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(response.error.code).to.equal(-32601);",
-							"    pm.expect(response.error.message.endsWith(\"Unsupported JSON-RPC method\")).to.be.true;",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getWork\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "unsupported_function",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(response.error.code).to.equal(-32601);",
-							"    pm.expect(response.error.message).to.equal(\"Method unsupported_function not found\");",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"unsupported_function\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "invalid_request",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(response.error.code).to.equal(-32600);",
-							"    pm.expect(response.error.message).to.equal(\"Invalid Request\");",
-							"    pm.expect(response.id).is.null;",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_hashrate",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.equal(\"0x0\");",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_hashrate\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_mining",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.equal(false);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_mining\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_submitWork",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.equal(false);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_submitWork\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_syncing",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.equal(false);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_syncing\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "net_listening",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.equal(\"false\");",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_listening\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "net_version",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_version\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "web3_clientVersion",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^relay[/]/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_clientVersion\",\n    \"params\": []\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "eth_getTransactionCount",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Success\", () => {",
-							"    var response = pm.response.json();",
-							"    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-							"    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
-							"    pm.expect(response.id).to.equal(\"test_id\");",
-							"    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
-							"});",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionCount\",\n    \"params\": [\n        \"0x0000000000000000000000000000000000000062\", \"latest\"\n    ]\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "{{baseUrl}}",
-					"host": [
-						"{{baseUrl}}"
-					]
-				}
-			},
-			"response": []
-		}
-	],
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		}
-	],
-	"variable": [
-		{
-			"key": "baseUrl",
-			"value": "localhost:7546",
-			"type": "string"
-		}
-	]
+  "info": {
+    "_postman_id": "351c728f-14b0-4b18-a499-4b100b68a822",
+    "name": "Relay",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "21244258"
+  },
+  "item": [
+    {
+      "name": "eth_accounts",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.be.an(\"array\");",
+              "    pm.expect(response.result).length(0);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_accounts\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_blockNumber",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_blockNumber\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_chainId",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_chainId\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_estimateGas",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_estimateGas\",\n    \"params\": [{\"to\":\"0xd3CdA913deB6f67967B99D67aCDFa1712C293601\", \"value\":\"0x1\"}]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_feeHistory",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result.baseFeePerGas).to.be.an(\"array\");",
+              "    pm.expect(response.result.baseFeePerGas).length(4);",
+              "    pm.expect(response.result.gasUsedRatio).to.be.an(\"array\");",
+              "    pm.expect(response.result.gasUsedRatio).length(3);",
+              "    pm.expect(response.result.oldestBlock).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.reward).to.be.an(\"array\");",
+              "    pm.expect(response.result.reward).length(3);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_feeHistory\",\n    \"params\": [\"0x3\", \"latest\", [25, 75]]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_gasPrice",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_gasPrice\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getBalance",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBalance\",\n    \"params\": [\"0x0000000000000000000000000000000000000062\", \"latest\"]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getBlockByNumber",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result.timestamp).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.difficulty).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.extraData).to.match(/^0x$/);",
+              "    pm.expect(response.result.gasLimit).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.baseFeePerGas).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.gasUsed).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.logsBloom).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.miner).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.mixHash).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.nonce).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.receiptsRoot).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.sha3Uncles).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.size).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.stateRoot).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.totalDifficulty).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.transactions).to.be.an(\"array\");",
+              "    pm.expect(response.result.transactionsRoot).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.uncles).to.be.an(\"array\");",
+              "    pm.expect(response.result.number).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.hash).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result.parentHash).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"id\": \"test_id\",\"jsonrpc\": \"2.0\",\"method\": \"eth_getBlockByNumber\",\"params\": [\"latest\", true]}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getBlockTransactionCountByNumber",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBlockTransactionCountByNumber\",\n    \"params\": [\n        \"latest\"\n    ]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getTransactionReceipt",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.be.null;",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionReceipt\",\n    \"params\": [\"0x0000000000000000000000000000000000000000000000000000000000000001\"]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getUncleByBlockHashAndIndex",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.be.null;",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getUncleByBlockHashAndIndex\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getUncleByBlockNumberAndIndex",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.be.null;",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getUncleByBlockNumberAndIndex\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getUncleCountByBlockHash",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.equal(\"0x0\");",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getUncleCountByBlockHash\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getUncleCountByBlockNumber",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.equal(\"0x0\");",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getUncleCountByBlockNumber\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getWork",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(response.error.code).to.equal(-32601);",
+              "    pm.expect(response.error.message.endsWith(\"Unsupported JSON-RPC method\")).to.be.true;",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getWork\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "unsupported_function",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(response.error.code).to.equal(-32601);",
+              "    pm.expect(response.error.message).to.equal(\"Method unsupported_function not found\");",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"unsupported_function\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "invalid_request",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(response.error.code).to.equal(-32600);",
+              "    pm.expect(response.error.message).to.equal(\"Invalid Request\");",
+              "    pm.expect(response.id).is.null;",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_hashrate",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.equal(\"0x0\");",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_hashrate\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_mining",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.equal(false);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_mining\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_submitWork",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.equal(false);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_submitWork\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_syncing",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.equal(false);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_syncing\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "net_listening",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.equal(\"false\");",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_listening\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "net_version",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^\\d+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_version\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "web3_clientVersion",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^relay[/]/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_clientVersion\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "eth_getTransactionCount",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionCount\",\n    \"params\": [\n        \"0x0000000000000000000000000000000000000062\", \"latest\"\n    ]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [""]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [""]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "localhost:7546",
+      "type": "string"
+    }
+  ]
 }

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -924,7 +924,7 @@
       "result": {
         "name": "The current chain id.",
         "schema": {
-          "$ref": "#/components/schemas/uint"
+          "$ref": "#/components/schemas/int"
         }
       }
     },
@@ -1236,6 +1236,11 @@
         "title": "65 hex encoded bytes",
         "type": "string",
         "pattern": "^0x[0-9a-f]{512}$"
+      },
+      "int": {
+        "title": "decimal value integer",
+        "type": "string",
+        "pattern": "^\\d+$"
       },
       "uint": {
         "title": "hex encoded unsigned integer",

--- a/packages/relay/src/lib/net.ts
+++ b/packages/relay/src/lib/net.ts
@@ -19,15 +19,19 @@
  */
 
 import { Net } from '../index';
+import constants from './constants';
 import { Client } from '@hashgraph/sdk';
 
 export class NetImpl implements Net {
   private client: Client;
   private readonly chainId: string;
 
-  constructor(client: Client, chainId: string) {
+  constructor(client: Client) {
     this.client = client;
-    this.chainId = chainId;
+
+    const hederaNetwork: string = (process.env.HEDERA_NETWORK || '{}').toLowerCase();
+    this.chainId = process.env.CHAIN_ID || constants.CHAIN_IDS[hederaNetwork] || '298';
+    if (this.chainId.startsWith('0x')) this.chainId = parseInt(this.chainId, 16).toString();
   }
 
   /**
@@ -39,7 +43,6 @@ export class NetImpl implements Net {
 
   /**
    * This is the chain id we registered.
-   * TODO Support some config when launching the server for this. dotenv support?
    */
   version(): string {
     return this.chainId;

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -63,7 +63,7 @@ export class RelayImpl implements Relay {
     this.clientMain = hapiService.getMainClientInstance();
 
     this.web3Impl = new Web3Impl(this.clientMain);
-    this.netImpl = new NetImpl(this.clientMain, chainId);
+    this.netImpl = new NetImpl(this.clientMain);
 
     this.mirrorNodeClient = new MirrorNodeClient(
       process.env.MIRROR_NODE_URL || '',

--- a/packages/relay/tests/lib/net.spec.ts
+++ b/packages/relay/tests/lib/net.spec.ts
@@ -18,18 +18,27 @@
  *
  */
 
+import pino from 'pino';
 import { expect } from 'chai';
 import { Registry } from 'prom-client';
 import { RelayImpl } from '../../src/lib/relay';
+import constants from '../../src/lib/constants';
 
-import pino from 'pino';
 const logger = pino();
-
 const Relay = new RelayImpl(logger, new Registry());
 
 describe('Net', async function () {
-  it('should execute "net_listening"', async function () {
-    const result = await Relay.net().listening();
+  it('should execute "net_listening"', function () {
+    const result = Relay.net().listening();
     expect(result).to.eq(false);
+  });
+
+  it('should execute "net_version"', function () {
+    const hederaNetwork: string = (process.env.HEDERA_NETWORK || '{}').toLowerCase();
+    let expectedNetVersion = process.env.CHAIN_ID || constants.CHAIN_IDS[hederaNetwork] || '298';
+    if (expectedNetVersion.startsWith('0x')) expectedNetVersion = parseInt(expectedNetVersion, 16).toString();
+
+    const actualNetVersion = Relay.net().version();
+    expect(actualNetVersion).to.eq(expectedNetVersion);
   });
 });

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -600,7 +600,11 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
     it('should execute "net_version"', async function () {
       const res = await relay.call(RelayCalls.ETH_ENDPOINTS.NET_VERSION, [], requestId);
-      expect(res).to.be.equal(CHAIN_ID);
+
+      let expectedVersion = CHAIN_ID as string;
+      if (expectedVersion.startsWith('0x')) expectedVersion = parseInt(expectedVersion, 16).toString();
+
+      expect(res).to.be.equal(expectedVersion);
     });
 
     it('should execute "eth_getUncleByBlockHashAndIndex"', async function () {

--- a/packages/server/tests/postman.json
+++ b/packages/server/tests/postman.json
@@ -901,7 +901,7 @@
               "pm.test(\"Success\", () => {",
               "    var response = pm.response.json();",
               "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-              "    pm.expect(response.result).to.match(/^0x[a-f0-9]+$/);",
+              "    pm.expect(response.result).to.match(/^\\d+$/);",
               "    pm.expect(response.id).to.equal(\"test_id\");",
               "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
               "});",


### PR DESCRIPTION
**Description**:
The `net_version` method previously returned a hexadecimal value for the netVersion, which deviates from the standard behavior adopted by many other services in the industry that return a decimal value. This PR ensures that the `net_version` method returns a decimal value instead of a hexadecimal one. Additionally, associated tests have been also added to verify this change.

This PR also takes the opportunity to add support for the `net()` module to read the chainId from the configuration at launch, rather than requiring it as a passed-in parameter.

**Related issue(s)**:

Fixes #2629 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
