### PR TITLE
fix:  eth_getBlockTransactionCountByNumber is not supported in wss

### DIFF
--- a/tools/golang-json-rpc-tests/main.go
+++ b/tools/golang-json-rpc-tests/main.go
@@ -107,13 +107,13 @@ func main() {
     testGetLogs(client, contractAddress, nil)
     testStorageAt(client, contractAddress, "0x0")
     testGetTransactionByHash(client, signedTx.Hash().Hex())
-    testGetTransactionCount(client)
     testGetTransactionReceipt(client, signedTx.Hash().Hex())
     if *wss {
         return;
     }
 
     // https only methods
+    testGetTransactionCount(client)
     testFeeHistory(client, 5, blockNumber, []float64{10, 50, 90})
     testGetAccounts(client)
     testGetBlockTransactionCountByHash(client, blockHash)


### PR DESCRIPTION
**Description**:
eth_getBlockTransactionCountByNumber is not supported in wss. It shuld be treated as such

**Related issue(s)**:

Fixes #2651 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
