### PR TITLE
fix: Adds usage of internal cache for getFilterChanges

### DIFF
--- a/packages/relay/src/lib/services/cacheService/cacheService.ts
+++ b/packages/relay/src/lib/services/cacheService/cacheService.ts
@@ -124,7 +124,7 @@ export class CacheService {
    * @private
    * @returns {boolean} Returns true if Redis caching is enabled, otherwise false.
    */
-  private isRedisEnabled(): boolean {
+  public isRedisEnabled(): boolean {
     const redisEnabled = process.env.REDIS_ENABLED && process.env.REDIS_ENABLED === 'true';
     const redisUrlValid = process.env.REDIS_URL && process.env.REDIS_URL !== '';
 

--- a/packages/relay/src/lib/services/ethService/ethFilterService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethFilterService/index.ts
@@ -209,7 +209,9 @@ export class FilterService implements IFilterService {
     FilterService.requireFiltersEnabled();
 
     const cacheKey = `${constants.CACHE_KEY.FILTERID}_${filterId}`;
-    const filter = await this.cacheService.getAsync(cacheKey, this.ethGetFilterChanges, requestIdPrefix);
+    const filter = this.cacheService.isRedisEnabled()
+      ? await this.cacheService.getAsync(cacheKey, this.ethGetFilterChanges, requestIdPrefix)
+      : await this.cacheService.get(cacheKey, this.ethGetFilterChanges, requestIdPrefix);
 
     if (!filter) {
       throw predefined.FILTER_NOT_FOUND;


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Currently, in getFilterChanges we get the filter id from the sharedCache. However, this won't work if the sharedCache option is disabled.

The PR modifies the filterService, so we check if the sharedCache is actually enabled.

**Related issue(s)**:

Fixes #2646 
