### PR TITLE
feat: add logsBloom class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20762,6 +20762,7 @@
       "name": "@hashgraph/json-rpc-relay",
       "version": "0.52.0-SNAPSHOT",
       "dependencies": {
+        "@ethereumjs/util": "^9.0.3",
         "@ethersproject/asm": "^5.7.0",
         "@hashgraph/sdk": "^2.48.1",
         "@keyvhq/core": "^1.6.9",
@@ -20770,6 +20771,7 @@
         "better-lookup": "^1.3.0",
         "buffer": "^6.0.3",
         "dotenv": "^16.0.0",
+        "ethereum-cryptography": "^2.2.1",
         "ethers": "^6.7.0",
         "find-config": "^1.0.0",
         "keccak": "^3.0.2",
@@ -20793,12 +20795,101 @@
         "typescript": "^4.6.4"
       }
     },
+    "packages/relay/node_modules/@ethereumjs/rlp": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
+      "bin": {
+        "rlp": "bin/rlp.cjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/relay/node_modules/@ethereumjs/util": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.0.3.tgz",
+      "integrity": "sha512-PmwzWDflky+7jlZIFqiGsBPap12tk9zK5SVH9YW2OEnDN7OEhCjUOMzbOqwuClrbkSIkM2ERivd7sXZ48Rh/vg==",
+      "dependencies": {
+        "@ethereumjs/rlp": "^5.0.2",
+        "ethereum-cryptography": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "packages/relay/node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "dependencies": {
         "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/relay/node_modules/@scure/base": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
+      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/relay/node_modules/@scure/bip32": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "dependencies": {
+        "@noble/curves": "~1.4.0",
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/relay/node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/relay/node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/relay/node_modules/@scure/bip39": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "dependencies": {
+        "@noble/hashes": "~1.4.0",
+        "@scure/base": "~1.1.6"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/relay/node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -20814,6 +20905,39 @@
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "packages/relay/node_modules/ethereum-cryptography": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "dependencies": {
+        "@noble/curves": "1.4.2",
+        "@noble/hashes": "1.4.0",
+        "@scure/bip32": "1.4.0",
+        "@scure/bip39": "1.3.0"
+      }
+    },
+    "packages/relay/node_modules/ethereum-cryptography/node_modules/@noble/curves": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/relay/node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "packages/relay/node_modules/ethers": {
       "version": "6.13.0",
@@ -22906,6 +23030,7 @@
     "@hashgraph/json-rpc-relay": {
       "version": "file:packages/relay",
       "requires": {
+        "@ethereumjs/util": "^9.0.3",
         "@ethersproject/asm": "^5.7.0",
         "@hashgraph/sdk": "^2.48.1",
         "@keyvhq/core": "^1.6.9",
@@ -22918,6 +23043,7 @@
         "buffer": "^6.0.3",
         "chai": "^4.3.6",
         "dotenv": "^16.0.0",
+        "ethereum-cryptography": "^2.2.1",
         "ethers": "^6.7.0",
         "find-config": "^1.0.0",
         "keccak": "^3.0.2",
@@ -22935,12 +23061,72 @@
         "typescript": "^4.6.4"
       },
       "dependencies": {
+        "@ethereumjs/rlp": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
+          "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA=="
+        },
+        "@ethereumjs/util": {
+          "version": "9.0.3",
+          "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.0.3.tgz",
+          "integrity": "sha512-PmwzWDflky+7jlZIFqiGsBPap12tk9zK5SVH9YW2OEnDN7OEhCjUOMzbOqwuClrbkSIkM2ERivd7sXZ48Rh/vg==",
+          "requires": {
+            "@ethereumjs/rlp": "^5.0.2",
+            "ethereum-cryptography": "^2.1.3"
+          }
+        },
         "@noble/curves": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
           "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
           "requires": {
             "@noble/hashes": "1.3.2"
+          }
+        },
+        "@scure/base": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
+          "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g=="
+        },
+        "@scure/bip32": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+          "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+          "requires": {
+            "@noble/curves": "~1.4.0",
+            "@noble/hashes": "~1.4.0",
+            "@scure/base": "~1.1.6"
+          },
+          "dependencies": {
+            "@noble/curves": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+              "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+              "requires": {
+                "@noble/hashes": "1.4.0"
+              }
+            },
+            "@noble/hashes": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+              "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+            }
+          }
+        },
+        "@scure/bip39": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+          "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+          "requires": {
+            "@noble/hashes": "~1.4.0",
+            "@scure/base": "~1.1.6"
+          },
+          "dependencies": {
+            "@noble/hashes": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+              "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+            }
           }
         },
         "@types/node": {
@@ -22953,6 +23139,32 @@
           "version": "4.0.0-beta.5",
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
           "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "ethereum-cryptography": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+          "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+          "requires": {
+            "@noble/curves": "1.4.2",
+            "@noble/hashes": "1.4.0",
+            "@scure/bip32": "1.4.0",
+            "@scure/bip39": "1.3.0"
+          },
+          "dependencies": {
+            "@noble/curves": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+              "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+              "requires": {
+                "@noble/hashes": "1.4.0"
+              }
+            },
+            "@noble/hashes": {
+              "version": "1.4.0",
+              "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+              "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+            }
+          }
         },
         "ethers": {
           "version": "6.13.0",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -48,6 +48,7 @@
     "test:eth-get-logs": "nyc ts-mocha --recursive './tests/**/*.spec.ts' './tests/**/**/*.spec.ts' -g '@ethGetLogs' --exit"
   },
   "dependencies": {
+    "@ethereumjs/util": "^9.0.3",
     "@ethersproject/asm": "^5.7.0",
     "@hashgraph/sdk": "^2.48.1",
     "@keyvhq/core": "^1.6.9",
@@ -56,6 +57,7 @@
     "better-lookup": "^1.3.0",
     "buffer": "^6.0.3",
     "dotenv": "^16.0.0",
+    "ethereum-cryptography": "^2.2.1",
     "ethers": "^6.7.0",
     "find-config": "^1.0.0",
     "keccak": "^3.0.2",

--- a/packages/relay/src/lib/utils/bloom/index.ts
+++ b/packages/relay/src/lib/utils/bloom/index.ts
@@ -1,0 +1,93 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { keccak256 } from 'ethereum-cryptography/keccak.js';
+
+const BYTE_SIZE = 256;
+
+export class Bloom {
+  bitvector: Uint8Array;
+
+  /**
+   * Represents a Bloom filter.
+   */
+  constructor(bitvector?: Uint8Array) {
+    if (!bitvector) {
+      this.bitvector = new Uint8Array(BYTE_SIZE);
+    } else {
+      if (bitvector.length !== BYTE_SIZE) throw new Error('bitvectors must be 2048 bits long');
+      this.bitvector = bitvector;
+    }
+  }
+
+  /**
+   * Adds an element to a bit vector of a 64 byte bloom filter.
+   * @param e - The element to add
+   */
+  add(e: Uint8Array) {
+    e = keccak256(e);
+    const mask = 2047; // binary 11111111111
+
+    for (let i = 0; i < 3; i++) {
+      const first2bytes = new DataView(e.buffer).getUint16(i * 2);
+      const loc = mask & first2bytes;
+      const byteLoc = loc >> 3;
+      const bitLoc = 1 << loc % 8;
+      this.bitvector[BYTE_SIZE - byteLoc - 1] |= bitLoc;
+    }
+  }
+
+  /**
+   * Checks if an element is in the bloom.
+   * @param e - The element to check
+   */
+  check(e: Uint8Array): boolean {
+    e = keccak256(e);
+    const mask = 2047; // binary 11111111111
+    let match = true;
+
+    for (let i = 0; i < 3 && match; i++) {
+      const first2bytes = new DataView(e.buffer).getUint16(i * 2);
+      const loc = mask & first2bytes;
+      const byteLoc = loc >> 3;
+      const bitLoc = 1 << loc % 8;
+      match = (this.bitvector[BYTE_SIZE - byteLoc - 1] & bitLoc) !== 0;
+    }
+
+    return Boolean(match);
+  }
+
+  /**
+   * Checks if multiple topics are in a bloom.
+   * @returns `true` if every topic is in the bloom
+   */
+  multiCheck(topics: Uint8Array[]): boolean {
+    return topics.every((t: Uint8Array) => this.check(t));
+  }
+
+  /**
+   * Bitwise or blooms together.
+   */
+  or(bloom: Bloom) {
+    for (let i = 0; i <= BYTE_SIZE; i++) {
+      this.bitvector[i] = this.bitvector[i] | bloom.bitvector[i];
+    }
+  }
+}

--- a/packages/relay/tests/lib/utils/bloom.spec.ts
+++ b/packages/relay/tests/lib/utils/bloom.spec.ts
@@ -1,0 +1,93 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { assert } from 'chai';
+import { Bloom } from '../../../src/lib/utils/bloom';
+import { hexToBytes, utf8ToBytes, bytesToHex } from '@ethereumjs/util';
+
+const byteSize = 256;
+
+describe.only('bloom', () => {
+  it('should initialize without params', () => {
+    const b = new Bloom();
+    assert.deepEqual(b.bitvector, new Uint8Array(byteSize), 'should be empty');
+  });
+
+  it('shouldnt initialize with invalid bitvector', () => {
+    assert.throws(
+      () => new Bloom(new Uint8Array(byteSize / 2)),
+      /bitvectors must be 2048 bits long/,
+      undefined,
+      'should fail for invalid length',
+    );
+  });
+
+  it('should contain values of hardcoded bitvector', () => {
+    const hex =
+      '0x00000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000';
+    const vector = hexToBytes(hex);
+
+    const b = new Bloom(vector);
+    assert.isTrue(b.check(utf8ToBytes('value 1')), 'should contain string "value 1"');
+    assert.isTrue(b.check(utf8ToBytes('value 2')), 'should contain string "value 2"');
+  });
+
+  it('check shouldnt be tautology', () => {
+    const b = new Bloom();
+    assert.isFalse(b.check(utf8ToBytes('random value')), 'should not contain string "random value"');
+  });
+
+  it('should correctly add value', () => {
+    const b = new Bloom();
+    b.add(utf8ToBytes('value'));
+    const found = b.check(utf8ToBytes('value'));
+    assert.isTrue(found, 'should contain added value');
+  });
+
+  it('should check multiple values', () => {
+    const b = new Bloom();
+    b.add(utf8ToBytes('value 1'));
+    b.add(utf8ToBytes('value 2'));
+    const found = b.multiCheck([utf8ToBytes('value 1'), utf8ToBytes('value 2')]);
+    assert.isTrue(found, 'should contain both values');
+  });
+
+  it('should or two filters', () => {
+    const b1 = new Bloom();
+    b1.add(utf8ToBytes('value 1'));
+    const b2 = new Bloom();
+    b2.add(utf8ToBytes('value 2'));
+
+    b1.or(b2);
+    assert.isTrue(b1.check(utf8ToBytes('value 2')), 'should contain "value 2" after or');
+  });
+
+  it('should generate the correct bloom filter value', () => {
+    const bloom = new Bloom();
+    bloom.add(hexToBytes('0x1d7022f5b17d2f8b695918fb48fa1089c9f85401'));
+    bloom.add(hexToBytes('0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925'));
+    bloom.add(hexToBytes('0x0000000000000000000000005409ed021d9299bf6814279a6a1411a7e866a631'));
+    bloom.add(hexToBytes('0x0000000000000000000000001dc4c1cefef38a777b15aa20260a54e584b16c48'));
+    assert.equal(
+      bytesToHex(bloom.bitvector),
+      '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000081100200000000000000000000000000000000000000000000000000000000008000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000002000000000000000004000000000000000000000',
+    );
+  });
+});

--- a/packages/relay/tests/lib/utils/bloom.spec.ts
+++ b/packages/relay/tests/lib/utils/bloom.spec.ts
@@ -24,7 +24,7 @@ import { hexToBytes, utf8ToBytes, bytesToHex } from '@ethereumjs/util';
 
 const byteSize = 256;
 
-describe.only('bloom', () => {
+describe('bloom', () => {
   it('should initialize without params', () => {
     const b = new Bloom();
     assert.deepEqual(b.bitvector, new Uint8Array(byteSize), 'should be empty');


### PR DESCRIPTION
**Description**:
This PR adds logsBloom object, which can take care of all bloom calculations, needed when there is missing logsBloom. Example are synthetic transactions, where we don't have logsBloom from the mirror node response. This PR only adds the class for this, calculations will be done in another to keep them tight and focused. 

**Related issue(s)**:

Fixes #2683 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
