### PR TITLE
fix: gasprice of transactions denoted in tinybars

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -156,7 +156,7 @@ const formatContractResult = (cr: any) => {
     cr.gas_price === null || cr.gas_price === '0x'
       ? '0x0'
       : isHex(cr.gas_price)
-      ? cr.gas_price
+      ? numberTo0x(BigInt(cr.gas_price) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF))
       : nanOrNumberTo0x(cr.gas_price);
 
   const commonFields = {

--- a/packages/relay/tests/lib/eth/eth-config.ts
+++ b/packages/relay/tests/lib/eth/eth-config.ts
@@ -591,7 +591,7 @@ export const DEFAULT_TRANSACTION = {
   chainId: '0x12a',
   from: `${defaultEvmAddress}`,
   gas: '0x7b',
-  gasPrice: '0x4a817c80',
+  gasPrice: '0xad78ebc5ac620000',
   hash: DEFAULT_TX_HASH,
   input: '0x0707',
   maxFeePerGas: null,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Currently, the `gasPrice` fetched via raw mirror node query is returned denominated in tinybars which leads to misunderstandings by users (and ethereum tools). The more accurate denomination is wei (weibar in hedera context).

Affected RPC endpoints:
```
eth_getTransactionByHash - gasPrice
eth_getTransactionByBlockHashAndIndex - gasPrice
eth_getTransactionByBlockNumberAndIndex - gasPrice
eth_getBlockByNumber - transactions array - gasPrice
eth_getBlockByHash - transactions array - gasPrice
```

**Steps to reproduce**:
Execute a json-rpc-relay request with the following body:
```bash
curl --location 'https://testnet.hashio.io/api' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc": "2.0",
    "method": "eth_getBlockByNumber",
    "params": [
        "0x5db6f5",
        true
    ],
    "id": 1
}'

```

**Related issue(s)**:

Fixes #2680

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
https://github.com/hashgraph/hedera-json-rpc-relay/issues/2680#issuecomment-2213633426

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
