### PR TITLE
feat: track hbar expenses for submit tx

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -500,10 +500,14 @@ export class SDKClient {
           `${requestIdPrefix} Invalid response format, expected record availability: ${JSON.stringify(resp)}`,
         );
       }
-      const transactionRecord: TransactionRecord = await resp.getRecord(this.clientMain);
+      const transactionRecord = await new TransactionRecordQuery()
+        .setTransactionId(resp.transactionId!)
+        .setValidateReceiptStatus(false)
+        .execute(this.clientMain);
+
       const cost = transactionRecord.transactionFee.toTinybars().toNumber();
 
-      this.logger.debug(
+      this.logger.trace(
         `${requestIdPrefix} ${resp.transactionId} ${callerName} ${transactionName} record status: ${Status.Success} (${Status.Success._code}), cost: ${transactionRecord.transactionFee}`,
       );
       this.captureMetrics(

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -500,13 +500,19 @@ export class SDKClient {
           `${requestIdPrefix} Invalid response format, expected record availability: ${JSON.stringify(resp)}`,
         );
       }
-      const transactionRecord = await new TransactionRecordQuery()
-        .setTransactionId(resp.transactionId!)
-        .setValidateReceiptStatus(false)
-        .execute(this.clientMain);
+
+      const transactionRecord = await this.executeQuery(
+        new TransactionRecordQuery()
+          .setTransactionId(resp.transactionId)
+          .setNodeAccountIds([resp.nodeId])
+          .setValidateReceiptStatus(false),
+        this.clientMain,
+        callerName,
+        interactingEntity,
+        requestId,
+      );
 
       const cost = transactionRecord.transactionFee.toTinybars().toNumber();
-
       this.logger.trace(
         `${requestIdPrefix} ${resp.transactionId} ${callerName} ${transactionName} record status: ${Status.Success} (${Status.Success._code}), cost: ${transactionRecord.transactionFee}`,
       );

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -102,9 +102,9 @@ describe('RPC Server Acceptance Tests', function () {
     logger.info(`MIRROR_NODE_URL: ${process.env.MIRROR_NODE_URL}`);
     logger.info(`E2E_RELAY_HOST: ${process.env.E2E_RELAY_HOST}`);
 
-    if (global.relayIsLocal) {
-      runLocalRelay();
-    }
+    // if (global.relayIsLocal) {
+    //   runLocalRelay();
+    // }
 
     // cache start balance
     startOperatorBalance = await global.servicesNode.getOperatorBalance();
@@ -153,10 +153,10 @@ describe('RPC Server Acceptance Tests', function () {
     logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
 
     //stop relay
-    logger.info('Stop relay');
-    if (relayServer !== undefined) {
-      relayServer.close();
-    }
+    // logger.info('Stop relay');
+    // if (relayServer !== undefined) {
+    //   relayServer.close();
+    // }
 
     if (process.env.TEST_WS_SERVER === 'true' && socketServer !== undefined) {
       socketServer.close();

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -102,9 +102,9 @@ describe('RPC Server Acceptance Tests', function () {
     logger.info(`MIRROR_NODE_URL: ${process.env.MIRROR_NODE_URL}`);
     logger.info(`E2E_RELAY_HOST: ${process.env.E2E_RELAY_HOST}`);
 
-    // if (global.relayIsLocal) {
-    //   runLocalRelay();
-    // }
+    if (global.relayIsLocal) {
+      runLocalRelay();
+    }
 
     // cache start balance
     startOperatorBalance = await global.servicesNode.getOperatorBalance();
@@ -153,10 +153,10 @@ describe('RPC Server Acceptance Tests', function () {
     logger.info(`Acceptance Tests spent ${Hbar.fromTinybars(cost)}`);
 
     //stop relay
-    // logger.info('Stop relay');
-    // if (relayServer !== undefined) {
-    //   relayServer.close();
-    // }
+    logger.info('Stop relay');
+    if (relayServer !== undefined) {
+      relayServer.close();
+    }
 
     if (process.env.TEST_WS_SERVER === 'true' && socketServer !== undefined) {
       socketServer.close();


### PR DESCRIPTION
**Description**:
This PR modifies submit transaction logic to account for hbar expenses. Previously we didn't track operator expenses for ethereum transactions. This PR is using executeGetTransactionRecord method, which takes the record and deduct the cost from the budget.

**Related issue(s)**:

Fixes #2703 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
