### PR TITLE
feat: replaced getRecord network calls with calls to mirror node to avoid SDK costs

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -672,141 +672,85 @@ export class SDKClient {
     callerName: string,
     interactingEntity: string,
   ) => {
-    const requestIdPrefix = formatRequestIdMessage(requestId);
     const hexedCallData = Buffer.from(callData).toString('hex');
     const currentDateNow = Date.now();
-    let fileCreateTx, fileAppendTx;
+    let fileCreateTx: any, fileAppendTx: any;
 
     try {
-      const shouldLimit = this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.transactionMode, callerName);
-      if (shouldLimit) {
+      // check if should limit hbar
+      if (this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.transactionMode, callerName))
         throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
-      }
 
-      fileCreateTx = await new FileCreateTransaction()
+      // prepare fileCreateTx
+      fileCreateTx = new FileCreateTransaction()
         .setContents(hexedCallData.substring(0, this.fileAppendChunkSize))
         .setKeys(client.operatorPublicKey ? [client.operatorPublicKey] : []);
 
+      // execute fileCreateTx
       const fileCreateTxResponse = await fileCreateTx.execute(client);
+
+      // extract fileId
       const { fileId } = await fileCreateTxResponse.getReceipt(client);
 
-      // get transaction fee and add expense to limiter
-      const createFileRecord = await fileCreateTxResponse.getRecord(this.clientMain);
-      let transactionFee = createFileRecord.transactionFee;
-      this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
-
-      this.captureMetrics(
-        SDKClient.transactionMode,
-        fileCreateTx.constructor.name,
-        Status.Success,
-        createFileRecord.transactionFee.toTinybars().toNumber(),
-        createFileRecord?.contractFunctionResult?.gasUsed,
-        callerName,
-        interactingEntity,
-      );
-
+      // fileAppend process
       if (fileId && callData.length > this.fileAppendChunkSize) {
-        fileAppendTx = await new FileAppendTransaction()
+        // prepare fileAppendTx
+        fileAppendTx = new FileAppendTransaction()
           .setFileId(fileId)
           .setContents(hexedCallData.substring(this.fileAppendChunkSize, hexedCallData.length))
           .setChunkSize(this.fileAppendChunkSize)
           .setMaxChunks(this.maxChunks);
-        const fileAppendTxResponse = await fileAppendTx.execute(client);
 
-        // get transaction fee and add expense to limiter
-        const appendFileRecord = await fileAppendTxResponse.getRecord(this.clientMain);
-        transactionFee = appendFileRecord.transactionFee;
-        this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
+        // execute fileAppendTx
+        await fileAppendTx.execute(client);
+      }
 
-        this.captureMetrics(
-          SDKClient.transactionMode,
+      // Ensure that the calldata file is not empty
+      if (fileId) {
+        // @todo: figure out the relationship between query.getCost() with the actual HBAR operator get charged => capture in metrics
+        const fileSize = (await new FileInfoQuery().setFileId(fileId).execute(client)).size;
+
+        if (callData.length > 0 && fileSize.isZero()) {
+          throw new SDKClientError({}, `${requestId} Created file is empty. `);
+        }
+        this.logger.trace(`${requestId} Created file with fileId: ${fileId} and file size ${fileSize}`);
+      }
+
+      return fileId;
+    } catch (error: any) {
+      this.logger.warn(`${requestId} ${error['message']} `);
+      throw new SDKClientError(error, error.message);
+    } finally {
+      /**
+       * @note Retrieving and capturing the charged transaction fees of FileCreateTx and FileAppendTx at the end of the flow
+       *       ensures these fees are eventually captured in the metrics and rate limiter class, even if SDK transactions fail at any point.
+       */
+
+      // retrieve txFee for fileCreateTx and capture them in metrics and rate limitter
+      await this.retrieveAndCaptureChargedTxFee(
+        fileCreateTx.transactionId!.toString(),
+        0,
+        requestId,
+        currentDateNow,
+        fileCreateTx.constructor.name,
+        0,
+        callerName,
+        interactingEntity,
+      );
+
+      // retrieve txFee for fileAppendTx and capture them in metrics and rate limitter
+      if (fileAppendTx) {
+        await this.retrieveAndCaptureChargedTxFee(
+          fileAppendTx.transactionId!.toString(),
+          0,
+          requestId,
+          currentDateNow,
           fileAppendTx.constructor.name,
-          Status.Success,
-          await this.calculateFileAppendTxTotalTinybarsCost(fileAppendTx),
           0,
           callerName,
           interactingEntity,
         );
       }
-
-      // Ensure that the calldata file is not empty
-      if (fileId) {
-        const fileSize = await (await new FileInfoQuery().setFileId(fileId).execute(client)).size;
-
-        if (callData.length > 0 && fileSize.isZero()) {
-          throw new SDKClientError({}, `${requestIdPrefix} Created file is empty. `);
-        }
-        this.logger.trace(`${requestIdPrefix} Created file with fileId: ${fileId} and file size ${fileSize}`);
-      }
-
-      return fileId;
-    } catch (error: any) {
-      const sdkClientError = new SDKClientError(error, error.message);
-      let transactionFee: number | Hbar = 0;
-
-      // if valid network error utilize transaction id
-      if (sdkClientError.isValidNetworkError()) {
-        try {
-          const transactionCreateRecord = await new TransactionRecordQuery()
-            .setTransactionId(fileCreateTx.transactionId!)
-            .setNodeAccountIds(fileCreateTx.nodeAccountIds!)
-            .setValidateReceiptStatus(false)
-            .execute(this.clientMain);
-          transactionFee = transactionCreateRecord.transactionFee;
-          this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
-
-          this.captureMetrics(
-            SDKClient.transactionMode,
-            fileCreateTx.constructor.name,
-            sdkClientError.status,
-            transactionFee.toTinybars().toNumber(),
-            transactionCreateRecord?.contractFunctionResult?.gasUsed,
-            callerName,
-            interactingEntity,
-          );
-
-          this.logger.info(
-            `${requestIdPrefix} ${fileCreateTx.transactionId} ${callerName} ${fileCreateTx.constructor.name} status: ${sdkClientError.status} (${sdkClientError.status._code}), cost: ${transactionFee}`,
-          );
-
-          if (fileAppendTx) {
-            const transactionAppendRecord = await new TransactionRecordQuery()
-              .setTransactionId(fileAppendTx.transactionId!)
-              .setNodeAccountIds(fileAppendTx.nodeAccountIds!)
-              .setValidateReceiptStatus(false)
-              .execute(this.clientMain);
-            transactionFee = transactionAppendRecord.transactionFee;
-            this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
-
-            this.captureMetrics(
-              SDKClient.transactionMode,
-              fileCreateTx.constructor.name,
-              sdkClientError.status,
-              transactionFee.toTinybars().toNumber(),
-              transactionCreateRecord?.contractFunctionResult?.gasUsed,
-              callerName,
-              interactingEntity,
-            );
-
-            this.logger.info(
-              `${requestIdPrefix} ${fileAppendTx.transactionId} ${callerName} ${fileCreateTx.constructor.name} status: ${sdkClientError.status} (${sdkClientError.status._code}), cost: ${transactionFee}`,
-            );
-          }
-        } catch (err: any) {
-          const recordQueryError = new SDKClientError(err, err.message);
-          this.logger.error(
-            recordQueryError,
-            `${requestIdPrefix} Error raised during TransactionRecordQuery for ${fileCreateTx.transactionId}`,
-          );
-        }
-      }
-
-      this.logger.info(`${requestIdPrefix} HBAR_RATE_LIMIT_EXCEEDED cost: ${transactionFee}`);
-
-      if (error instanceof JsonRpcError) {
-        throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
-      }
-      throw sdkClientError;
     }
   };
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -260,10 +260,6 @@ export class SDKClient {
     );
   }
 
-  async getRecord(transactionResponse: TransactionResponse) {
-    return transactionResponse.getRecord(this.clientMain);
-  }
-
   async submitEthereumTransaction(
     transactionBuffer: Uint8Array,
     callerName: string,
@@ -549,91 +545,6 @@ export class SDKClient {
     }
   };
 
-  async executeGetTransactionRecord(
-    resp: TransactionResponse,
-    transactionName: string,
-    callerName: string,
-    interactingEntity: string,
-    requestId?: string,
-  ): Promise<TransactionRecord> {
-    const requestIdPrefix = formatRequestIdMessage(requestId);
-    const currentDateNow = Date.now();
-    try {
-      if (!resp.getRecord) {
-        throw new SDKClientError(
-          {},
-          `${requestIdPrefix} Invalid response format, expected record availability: ${JSON.stringify(resp)}`,
-        );
-      }
-      const shouldLimit = this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.recordMode, transactionName);
-      if (shouldLimit) {
-        throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
-      }
-
-      const transactionRecord: TransactionRecord = await resp.getRecord(this.clientMain);
-      const cost = transactionRecord.transactionFee.toTinybars().toNumber();
-      this.hbarLimiter.addExpense(cost, currentDateNow);
-      this.logger.info(
-        `${requestIdPrefix} ${resp.transactionId} ${callerName} ${transactionName} record status: ${Status.Success} (${Status.Success._code}), cost: ${transactionRecord.transactionFee}`,
-      );
-      this.captureMetrics(
-        SDKClient.transactionMode,
-        transactionName,
-        transactionRecord.receipt.status,
-        cost,
-        transactionRecord?.contractFunctionResult?.gasUsed,
-        callerName,
-        interactingEntity,
-      );
-
-      this.hbarLimiter.addExpense(cost, currentDateNow);
-
-      return transactionRecord;
-    } catch (e: any) {
-      // capture sdk record retrieval errors and shorten familiar stack trace
-      const sdkClientError = new SDKClientError(e, e.message);
-      let transactionFee: number | Hbar = 0;
-      if (sdkClientError.isValidNetworkError()) {
-        try {
-          // pull transaction record for fee
-          const transactionRecord = await new TransactionRecordQuery()
-            .setTransactionId(resp.transactionId!)
-            .setNodeAccountIds([resp.nodeId])
-            .setValidateReceiptStatus(false)
-            .execute(this.clientMain);
-          transactionFee = transactionRecord.transactionFee;
-
-          this.captureMetrics(
-            SDKClient.transactionMode,
-            transactionName,
-            sdkClientError.status,
-            transactionFee.toTinybars().toNumber(),
-            transactionRecord?.contractFunctionResult?.gasUsed,
-            callerName,
-            interactingEntity,
-          );
-
-          this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
-        } catch (err: any) {
-          const recordQueryError = new SDKClientError(err, err.message);
-          this.logger.error(
-            recordQueryError,
-            `${requestIdPrefix} Error raised during TransactionRecordQuery for ${resp.transactionId}`,
-          );
-        }
-      }
-
-      this.logger.debug(
-        `${requestIdPrefix} ${resp.transactionId} ${callerName} ${transactionName} record status: ${sdkClientError.status} (${sdkClientError.status._code}), cost: ${transactionFee}`,
-      );
-
-      if (e instanceof JsonRpcError) {
-        throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
-      }
-      throw sdkClientError;
-    }
-  }
-
   private captureMetrics = (mode, type, status, cost, gas, caller, interactingEntity) => {
     const resolvedCost = cost ? cost : 0;
     const resolvedGas = typeof gas === 'object' ? gas.toInt() : 0;
@@ -652,17 +563,6 @@ export class SDKClient {
 
   private static HbarToWeiBar(balance: AccountBalance): BigNumber {
     return balance.hbars.to(HbarUnit.Tinybar).multipliedBy(constants.TINYBAR_TO_WEIBAR_COEF);
-  }
-
-  private async calculateFileAppendTxTotalTinybarsCost(fileAppendTx: FileAppendTransaction): Promise<number> {
-    // @ts-ignore
-    const fileAppendTxs = fileAppendTx._transactionIds.list.map((txId) =>
-      new TransactionRecordQuery().setTransactionId(txId).execute(this.clientMain),
-    );
-
-    return (await Promise.all(fileAppendTxs)).reduce((base, record) => {
-      return base + record.transactionFee.toTinybars().toNumber();
-    }, 0);
   }
 
   private createFile = async (

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -672,142 +672,72 @@ export class SDKClient {
     callerName: string,
     interactingEntity: string,
   ) => {
-    const requestIdPrefix = formatRequestIdMessage(requestId);
     const hexedCallData = Buffer.from(callData).toString('hex');
     const currentDateNow = Date.now();
-    let fileCreateTx, fileAppendTx;
 
-    try {
-      const shouldLimit = this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.transactionMode, callerName);
-      if (shouldLimit) {
-        throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
-      }
+    // check if should limit hbar
+    if (this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.transactionMode, callerName))
+      throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
 
-      fileCreateTx = await new FileCreateTransaction()
-        .setContents(hexedCallData.substring(0, this.fileAppendChunkSize))
-        .setKeys(client.operatorPublicKey ? [client.operatorPublicKey] : []);
+    // prepare fileCreateTx
+    const fileCreateTx = new FileCreateTransaction()
+      .setContents(hexedCallData.substring(0, this.fileAppendChunkSize))
+      .setKeys(client.operatorPublicKey ? [client.operatorPublicKey] : []);
 
-      const fileCreateTxResponse = await fileCreateTx.execute(client);
-      const { fileId } = await fileCreateTxResponse.getReceipt(client);
+    // execute fileCreateTx
+    const fileCreateTxResponse = await fileCreateTx.execute(client);
 
-      // get transaction fee and add expense to limiter
-      const createFileRecord = await fileCreateTxResponse.getRecord(this.clientMain);
-      let transactionFee = createFileRecord.transactionFee;
-      this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
+    // retrieve txFee for fileCreateTx and capture them in metrics and rate limitter
+    await this.retrieveAndCaptureChargedTxFee(
+      fileCreateTx.transactionId!.toString(),
+      0,
+      requestId,
+      currentDateNow,
+      fileCreateTx.constructor.name,
+      0,
+      callerName,
+      interactingEntity,
+    );
 
-      this.captureMetrics(
-        SDKClient.transactionMode,
-        fileCreateTx.constructor.name,
-        Status.Success,
-        createFileRecord.transactionFee.toTinybars().toNumber(),
-        createFileRecord?.contractFunctionResult?.gasUsed,
+    // extract fileId
+    const { fileId } = await fileCreateTxResponse.getReceipt(client);
+
+    // fileAppend process
+    if (fileId && callData.length > this.fileAppendChunkSize) {
+      // prepare fileAppendTx
+      const fileAppendTx = new FileAppendTransaction()
+        .setFileId(fileId)
+        .setContents(hexedCallData.substring(this.fileAppendChunkSize, hexedCallData.length))
+        .setChunkSize(this.fileAppendChunkSize)
+        .setMaxChunks(this.maxChunks);
+
+      // execute fileAppendTx
+      await fileAppendTx.execute(client);
+
+      // retrieve txFee for fileAppendTx and capture them in metrics and rate limitter
+      await this.retrieveAndCaptureChargedTxFee(
+        fileAppendTx.transactionId!.toString(),
+        0,
+        requestId,
+        currentDateNow,
+        fileAppendTx.constructor.name,
+        0,
         callerName,
         interactingEntity,
       );
-
-      if (fileId && callData.length > this.fileAppendChunkSize) {
-        fileAppendTx = await new FileAppendTransaction()
-          .setFileId(fileId)
-          .setContents(hexedCallData.substring(this.fileAppendChunkSize, hexedCallData.length))
-          .setChunkSize(this.fileAppendChunkSize)
-          .setMaxChunks(this.maxChunks);
-        const fileAppendTxResponse = await fileAppendTx.execute(client);
-
-        // get transaction fee and add expense to limiter
-        const appendFileRecord = await fileAppendTxResponse.getRecord(this.clientMain);
-        transactionFee = appendFileRecord.transactionFee;
-        this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
-
-        this.captureMetrics(
-          SDKClient.transactionMode,
-          fileAppendTx.constructor.name,
-          Status.Success,
-          await this.calculateFileAppendTxTotalTinybarsCost(fileAppendTx),
-          0,
-          callerName,
-          interactingEntity,
-        );
-      }
-
-      // Ensure that the calldata file is not empty
-      if (fileId) {
-        const fileSize = await (await new FileInfoQuery().setFileId(fileId).execute(client)).size;
-
-        if (callData.length > 0 && fileSize.isZero()) {
-          throw new SDKClientError({}, `${requestIdPrefix} Created file is empty. `);
-        }
-        this.logger.trace(`${requestIdPrefix} Created file with fileId: ${fileId} and file size ${fileSize}`);
-      }
-
-      return fileId;
-    } catch (error: any) {
-      const sdkClientError = new SDKClientError(error, error.message);
-      let transactionFee: number | Hbar = 0;
-
-      // if valid network error utilize transaction id
-      if (sdkClientError.isValidNetworkError()) {
-        try {
-          const transactionCreateRecord = await new TransactionRecordQuery()
-            .setTransactionId(fileCreateTx.transactionId!)
-            .setNodeAccountIds(fileCreateTx.nodeAccountIds!)
-            .setValidateReceiptStatus(false)
-            .execute(this.clientMain);
-          transactionFee = transactionCreateRecord.transactionFee;
-          this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
-
-          this.captureMetrics(
-            SDKClient.transactionMode,
-            fileCreateTx.constructor.name,
-            sdkClientError.status,
-            transactionFee.toTinybars().toNumber(),
-            transactionCreateRecord?.contractFunctionResult?.gasUsed,
-            callerName,
-            interactingEntity,
-          );
-
-          this.logger.info(
-            `${requestIdPrefix} ${fileCreateTx.transactionId} ${callerName} ${fileCreateTx.constructor.name} status: ${sdkClientError.status} (${sdkClientError.status._code}), cost: ${transactionFee}`,
-          );
-
-          if (fileAppendTx) {
-            const transactionAppendRecord = await new TransactionRecordQuery()
-              .setTransactionId(fileAppendTx.transactionId!)
-              .setNodeAccountIds(fileAppendTx.nodeAccountIds!)
-              .setValidateReceiptStatus(false)
-              .execute(this.clientMain);
-            transactionFee = transactionAppendRecord.transactionFee;
-            this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
-
-            this.captureMetrics(
-              SDKClient.transactionMode,
-              fileCreateTx.constructor.name,
-              sdkClientError.status,
-              transactionFee.toTinybars().toNumber(),
-              transactionCreateRecord?.contractFunctionResult?.gasUsed,
-              callerName,
-              interactingEntity,
-            );
-
-            this.logger.info(
-              `${requestIdPrefix} ${fileAppendTx.transactionId} ${callerName} ${fileCreateTx.constructor.name} status: ${sdkClientError.status} (${sdkClientError.status._code}), cost: ${transactionFee}`,
-            );
-          }
-        } catch (err: any) {
-          const recordQueryError = new SDKClientError(err, err.message);
-          this.logger.error(
-            recordQueryError,
-            `${requestIdPrefix} Error raised during TransactionRecordQuery for ${fileCreateTx.transactionId}`,
-          );
-        }
-      }
-
-      this.logger.info(`${requestIdPrefix} HBAR_RATE_LIMIT_EXCEEDED cost: ${transactionFee}`);
-
-      if (error instanceof JsonRpcError) {
-        throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
-      }
-      throw sdkClientError;
     }
+
+    // Ensure that the calldata file is not empty
+    if (fileId) {
+      // @todo: figure out the relationship between query.getCost() with the actual HBAR operator get charged => capture in metrics
+      const fileSize = (await new FileInfoQuery().setFileId(fileId).execute(client)).size;
+      if (callData.length > 0 && fileSize.isZero())
+        throw new SDKClientError({}, `${requestId} Created file is empty. `);
+
+      this.logger.trace(`${requestId} Created file with fileId: ${fileId} and file size ${fileSize}`);
+    }
+
+    return fileId;
   };
 
   /**

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -672,72 +672,142 @@ export class SDKClient {
     callerName: string,
     interactingEntity: string,
   ) => {
+    const requestIdPrefix = formatRequestIdMessage(requestId);
     const hexedCallData = Buffer.from(callData).toString('hex');
     const currentDateNow = Date.now();
+    let fileCreateTx, fileAppendTx;
 
-    // check if should limit hbar
-    if (this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.transactionMode, callerName))
-      throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
+    try {
+      const shouldLimit = this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.transactionMode, callerName);
+      if (shouldLimit) {
+        throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
+      }
 
-    // prepare fileCreateTx
-    const fileCreateTx = new FileCreateTransaction()
-      .setContents(hexedCallData.substring(0, this.fileAppendChunkSize))
-      .setKeys(client.operatorPublicKey ? [client.operatorPublicKey] : []);
+      fileCreateTx = await new FileCreateTransaction()
+        .setContents(hexedCallData.substring(0, this.fileAppendChunkSize))
+        .setKeys(client.operatorPublicKey ? [client.operatorPublicKey] : []);
 
-    // execute fileCreateTx
-    const fileCreateTxResponse = await fileCreateTx.execute(client);
+      const fileCreateTxResponse = await fileCreateTx.execute(client);
+      const { fileId } = await fileCreateTxResponse.getReceipt(client);
 
-    // retrieve txFee for fileCreateTx and capture them in metrics and rate limitter
-    await this.retrieveAndCaptureChargedTxFee(
-      fileCreateTx.transactionId!.toString(),
-      0,
-      requestId,
-      currentDateNow,
-      fileCreateTx.constructor.name,
-      0,
-      callerName,
-      interactingEntity,
-    );
+      // get transaction fee and add expense to limiter
+      const createFileRecord = await fileCreateTxResponse.getRecord(this.clientMain);
+      let transactionFee = createFileRecord.transactionFee;
+      this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
 
-    // extract fileId
-    const { fileId } = await fileCreateTxResponse.getReceipt(client);
-
-    // fileAppend process
-    if (fileId && callData.length > this.fileAppendChunkSize) {
-      // prepare fileAppendTx
-      const fileAppendTx = new FileAppendTransaction()
-        .setFileId(fileId)
-        .setContents(hexedCallData.substring(this.fileAppendChunkSize, hexedCallData.length))
-        .setChunkSize(this.fileAppendChunkSize)
-        .setMaxChunks(this.maxChunks);
-
-      // execute fileAppendTx
-      await fileAppendTx.execute(client);
-
-      // retrieve txFee for fileAppendTx and capture them in metrics and rate limitter
-      await this.retrieveAndCaptureChargedTxFee(
-        fileAppendTx.transactionId!.toString(),
-        0,
-        requestId,
-        currentDateNow,
-        fileAppendTx.constructor.name,
-        0,
+      this.captureMetrics(
+        SDKClient.transactionMode,
+        fileCreateTx.constructor.name,
+        Status.Success,
+        createFileRecord.transactionFee.toTinybars().toNumber(),
+        createFileRecord?.contractFunctionResult?.gasUsed,
         callerName,
         interactingEntity,
       );
+
+      if (fileId && callData.length > this.fileAppendChunkSize) {
+        fileAppendTx = await new FileAppendTransaction()
+          .setFileId(fileId)
+          .setContents(hexedCallData.substring(this.fileAppendChunkSize, hexedCallData.length))
+          .setChunkSize(this.fileAppendChunkSize)
+          .setMaxChunks(this.maxChunks);
+        const fileAppendTxResponse = await fileAppendTx.execute(client);
+
+        // get transaction fee and add expense to limiter
+        const appendFileRecord = await fileAppendTxResponse.getRecord(this.clientMain);
+        transactionFee = appendFileRecord.transactionFee;
+        this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
+
+        this.captureMetrics(
+          SDKClient.transactionMode,
+          fileAppendTx.constructor.name,
+          Status.Success,
+          await this.calculateFileAppendTxTotalTinybarsCost(fileAppendTx),
+          0,
+          callerName,
+          interactingEntity,
+        );
+      }
+
+      // Ensure that the calldata file is not empty
+      if (fileId) {
+        const fileSize = await (await new FileInfoQuery().setFileId(fileId).execute(client)).size;
+
+        if (callData.length > 0 && fileSize.isZero()) {
+          throw new SDKClientError({}, `${requestIdPrefix} Created file is empty. `);
+        }
+        this.logger.trace(`${requestIdPrefix} Created file with fileId: ${fileId} and file size ${fileSize}`);
+      }
+
+      return fileId;
+    } catch (error: any) {
+      const sdkClientError = new SDKClientError(error, error.message);
+      let transactionFee: number | Hbar = 0;
+
+      // if valid network error utilize transaction id
+      if (sdkClientError.isValidNetworkError()) {
+        try {
+          const transactionCreateRecord = await new TransactionRecordQuery()
+            .setTransactionId(fileCreateTx.transactionId!)
+            .setNodeAccountIds(fileCreateTx.nodeAccountIds!)
+            .setValidateReceiptStatus(false)
+            .execute(this.clientMain);
+          transactionFee = transactionCreateRecord.transactionFee;
+          this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
+
+          this.captureMetrics(
+            SDKClient.transactionMode,
+            fileCreateTx.constructor.name,
+            sdkClientError.status,
+            transactionFee.toTinybars().toNumber(),
+            transactionCreateRecord?.contractFunctionResult?.gasUsed,
+            callerName,
+            interactingEntity,
+          );
+
+          this.logger.info(
+            `${requestIdPrefix} ${fileCreateTx.transactionId} ${callerName} ${fileCreateTx.constructor.name} status: ${sdkClientError.status} (${sdkClientError.status._code}), cost: ${transactionFee}`,
+          );
+
+          if (fileAppendTx) {
+            const transactionAppendRecord = await new TransactionRecordQuery()
+              .setTransactionId(fileAppendTx.transactionId!)
+              .setNodeAccountIds(fileAppendTx.nodeAccountIds!)
+              .setValidateReceiptStatus(false)
+              .execute(this.clientMain);
+            transactionFee = transactionAppendRecord.transactionFee;
+            this.hbarLimiter.addExpense(transactionFee.toTinybars().toNumber(), currentDateNow);
+
+            this.captureMetrics(
+              SDKClient.transactionMode,
+              fileCreateTx.constructor.name,
+              sdkClientError.status,
+              transactionFee.toTinybars().toNumber(),
+              transactionCreateRecord?.contractFunctionResult?.gasUsed,
+              callerName,
+              interactingEntity,
+            );
+
+            this.logger.info(
+              `${requestIdPrefix} ${fileAppendTx.transactionId} ${callerName} ${fileCreateTx.constructor.name} status: ${sdkClientError.status} (${sdkClientError.status._code}), cost: ${transactionFee}`,
+            );
+          }
+        } catch (err: any) {
+          const recordQueryError = new SDKClientError(err, err.message);
+          this.logger.error(
+            recordQueryError,
+            `${requestIdPrefix} Error raised during TransactionRecordQuery for ${fileCreateTx.transactionId}`,
+          );
+        }
+      }
+
+      this.logger.info(`${requestIdPrefix} HBAR_RATE_LIMIT_EXCEEDED cost: ${transactionFee}`);
+
+      if (error instanceof JsonRpcError) {
+        throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
+      }
+      throw sdkClientError;
     }
-
-    // Ensure that the calldata file is not empty
-    if (fileId) {
-      // @todo: figure out the relationship between query.getCost() with the actual HBAR operator get charged => capture in metrics
-      const fileSize = (await new FileInfoQuery().setFileId(fileId).execute(client)).size;
-      if (callData.length > 0 && fileSize.isZero())
-        throw new SDKClientError({}, `${requestId} Created file is empty. `);
-
-      this.logger.trace(`${requestId} Created file with fileId: ${fileId} and file size ${fileSize}`);
-    }
-
-    return fileId;
   };
 
   /**

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -96,7 +96,7 @@ export default class HAPIService {
       gasHistogram: this.consensusNodeClientHistogramGasFee,
     };
     this.cacheService = cacheService;
-    this.client = this.initSDKClient(logger, this.metrics);
+    this.client = this.initSDKClient(logger, this.metrics, register);
 
     const currentDateNow = Date.now();
     this.initialTransactionCount = parseInt(process.env.HAPI_CLIENT_TRANSACTION_RESET!) || 0;
@@ -172,7 +172,7 @@ export default class HAPIService {
       .inc(1);
 
     this.clientMain = this.initClient(this.logger, this.hederaNetwork);
-    this.client = this.initSDKClient(this.logger, this.metrics);
+    this.client = this.initSDKClient(this.logger, this.metrics, this.register);
     this.resetCounters();
   }
 
@@ -191,13 +191,14 @@ export default class HAPIService {
    * @param {Logger} logger
    * @returns SDK Client
    */
-  private initSDKClient(logger: Logger, metrics: any): SDKClient {
+  private initSDKClient(logger: Logger, metrics: any, register: Registry): SDKClient {
     return new SDKClient(
       this.clientMain,
       logger.child({ name: `consensus-node` }),
       this.hbarLimiter,
       metrics,
       this.cacheService,
+      register,
     );
   }
 


### PR DESCRIPTION
**Description**:
- Added an instance of Mirror Node client to the SDKClient class.

- Introduced the `retrieveAndCaptureChargedTxFee()` method to retrieve charged transaction fees by making repeated calls to the Mirror Node using the appropriate transactionId. This method is intended to replace the `getRecord()` methods called by the SDK to reduce costs.

- Refactored the createFile() method to implement the new `retrieveAndCaptureChargedTxFee` logic. The createFile() method now retrieves and captures transaction fees from FileCreateTx and FileAppendTx at the end of the flow, ensuring these fees are captured even if any SDK transactions (FileCreateTx, FileAppendTx) fail at any point.

- Refactored the deleteFile() method to implement the new `retrieveAndCaptureChargedTxFee` logic. The flow follows the same structure as createFile().

- Removed SDKClient's methods that are not utilized anywhere in the codebase.


**Related issue(s)**:

Fixes #2706 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
