### PR TITLE
fix: captured transactionFee in metrics and HBAR limiter class in executeTransaction and deleteFile

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -1263,6 +1263,9 @@ export class MirrorNodeClient {
   public getMirrorNodeWeb3Instance() {
     return this.web3Client;
   }
+  public getMirrorNodeRetryDelay() {
+    return this.MIRROR_NODE_RETRY_DELAY;
+  }
 
   /**
    * This method is intended to be used in cases when the default axios-retry settings do not provide

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -802,6 +802,7 @@ export class SDKClient {
    */
   public deleteFile = async (fileId: FileId, requestId?: string, callerName?: string, interactingEntity?: string) => {
     // format request ID msg
+    const currentDateNow = Date.now();
     const requestIdPrefix = formatRequestIdMessage(requestId);
 
     try {
@@ -817,7 +818,8 @@ export class SDKClient {
       // get fileDeleteTx's record
       const deleteFileRecord = await fileDeleteTxResponse.getRecord(this.clientMain);
 
-      // capture metrics
+      // capture transactionFee in metrics and HBAR limiter class
+      this.hbarLimiter.addExpense(deleteFileRecord.transactionFee.toTinybars().toNumber(), currentDateNow);
       this.captureMetrics(
         SDKClient.transactionMode,
         fileDeleteTx.constructor.name,

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -469,9 +469,16 @@ export class SDKClient {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     const currentDateNow = Date.now();
     try {
+      // check hbar limit before executing transaction
+      if (this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.recordMode, callerName)) {
+        throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
+      }
+
+      // execute transaction
       this.logger.info(`${requestIdPrefix} Execute ${transactionType} transaction`);
       const transactionResponse = await transaction.execute(this.clientMain);
 
+      // retrieve and capture transaction fee in metrics and rate limiter class
       await this.executeGetTransactionRecord(
         transactionResponse,
         callerName,

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -501,10 +501,11 @@ export class SDKClient {
         transactionFee = transactionRecord.transactionFee.toTinybars().toNumber();
         gasUsed = transactionRecord?.contractFunctionResult?.gasUsed.toNumber();
 
-        // throw error
         const sdkClientError = new SDKClientError(e, e.message);
         this.logger.warn(sdkClientError);
-        throw sdkClientError;
+
+        // Throw WRONG_NONCE error as more error handling logic for WRONG_NONCE is awaited in eth.sendRawTransactionErrorHandler(). Otherwise, still return transactionResponse.
+        if (e.status.toString() === constants.TRANSACTION_RESULT_STATUS.WRONG_NONCE) throw sdkClientError;
       } finally {
         /**
          * @note Retrieving and capturing the charged transaction fees at the end of the flow

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1438,6 +1438,7 @@ export class EthImpl implements Eth {
     transaction,
     transactionBuffer,
     txSubmitted,
+    parsedTx,
     requestIdPrefix,
   ): Promise<string | JsonRpcError> {
     this.logger.error(
@@ -1450,6 +1451,36 @@ export class EthImpl implements Eth {
 
     if (e instanceof SDKClientError) {
       this.hapiService.decrementErrorCounter(e.statusCode);
+      if (e.status.toString() === constants.TRANSACTION_RESULT_STATUS.WRONG_NONCE) {
+        // note: because this is a WRONG_NONCE error handler, the nonce of the account is expected to be different from the nonce of the parsedTx
+        //       running a polling loop to give mirror node enough time to update account nonce
+        let accountNonce: number | null = null;
+        for (let i = 0; i < this.MirrorNodeGetContractResultRetries; i++) {
+          const accountInfo = await this.mirrorNodeClient.getAccount(parsedTx.from!, requestIdPrefix);
+          if (accountInfo.ethereum_nonce !== parsedTx.nonce) {
+            accountNonce = accountInfo.ethereum_nonce;
+            break;
+          }
+
+          this.logger.trace(
+            `${requestIdPrefix} Repeating retry to poll for updated account nonce. Count ${i} of ${
+              this.MirrorNodeGetContractResultRetries
+            }. Waiting ${this.mirrorNodeClient.getMirrorNodeRetryDelay()} ms before initiating a new request`,
+          );
+          await new Promise((r) => setTimeout(r, this.mirrorNodeClient.getMirrorNodeRetryDelay()));
+        }
+
+        if (!accountNonce) {
+          this.logger.warn(`${requestIdPrefix} Cannot find updated account nonce.`);
+          throw predefined.INTERNAL_ERROR(`Cannot find updated account nonce for WRONT_NONCE error.`);
+        }
+
+        if (parsedTx.nonce > accountNonce) {
+          return predefined.NONCE_TOO_HIGH(parsedTx.nonce, accountNonce);
+        } else {
+          return predefined.NONCE_TOO_LOW(parsedTx.nonce, accountNonce);
+        }
+      }
     }
 
     if (!txSubmitted) {
@@ -1522,20 +1553,6 @@ export class EthImpl implements Eth {
 
       if (!contractResult) {
         this.logger.warn(`${requestIdPrefix} No record retrieved`);
-        const tx = await this.mirrorNodeClient.getTransactionById(txId, 0, requestIdPrefix);
-
-        if (tx?.transactions?.length) {
-          const result = tx.transactions[0].result;
-          if (result === constants.TRANSACTION_RESULT_STATUS.WRONG_NONCE) {
-            const accountInfo = await this.mirrorNodeClient.getAccount(parsedTx.from!, requestIdPrefix);
-            const accountNonce = accountInfo.ethereum_nonce;
-            if (parsedTx.nonce > accountNonce) {
-              throw predefined.NONCE_TOO_HIGH(parsedTx.nonce, accountNonce);
-            }
-
-            throw predefined.NONCE_TOO_LOW(parsedTx.nonce, accountNonce);
-          }
-        }
         throw predefined.INTERNAL_ERROR(`No matching record found for transaction id ${txId}`);
       }
 
@@ -1548,7 +1565,14 @@ export class EthImpl implements Eth {
 
       return contractResult.hash;
     } catch (e: any) {
-      return this.sendRawTransactionErrorHandler(e, transaction, transactionBuffer, txSubmitted, requestIdPrefix);
+      return this.sendRawTransactionErrorHandler(
+        e,
+        transaction,
+        transactionBuffer,
+        txSubmitted,
+        parsedTx,
+        requestIdPrefix,
+      );
     } finally {
       /**
        *  For transactions of type CONTRACT_CREATE, if the contract's bytecode (calldata) exceeds 5120 bytes, HFS is employed to temporarily store the bytecode on the network.

--- a/packages/server/tests/acceptance/rateLimiter.spec.ts
+++ b/packages/server/tests/acceptance/rateLimiter.spec.ts
@@ -166,7 +166,7 @@ describe('@ratelimiter Rate Limiters Acceptance Tests', function () {
           await expect(relay.call(testConstants.ETH_ENDPOINTS.ETH_SEND_RAW_TRANSACTION, [signedTx], requestId)).to.be
             .fulfilled;
           const remainingHbarsAfter = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
-          expect(remainingHbarsAfter).to.be.eq(remainingHbarsBefore);
+          expect(remainingHbarsAfter).to.be.lt(remainingHbarsBefore);
         });
 
         it('should deploy a large contract and decrease remaining HBAR in limiter when transaction data is large', async function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -810,7 +810,6 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     let storageContract: ethers.Contract;
     let storageContractAddress: string;
     const STORAGE_CONTRACT_UPDATE = '0x2de4e884';
-    const NEXT_STORAGE_CONTRACT_UPDATE = '0x160D6484';
 
     this.beforeEach(async () => {
       storageContract = await Utils.deployContract(
@@ -983,7 +982,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
       const transaction1 = {
         ...transaction,
         nonce: await relay.getAccountNonce(accounts[1].address),
-        data: NEXT_STORAGE_CONTRACT_UPDATE,
+        data: STORAGE_CONTRACT_UPDATE,
       };
 
       const signedTx1 = await accounts[1].wallet.signTransaction(transaction1);
@@ -1028,7 +1027,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
       const transaction1 = {
         ...transaction,
         nonce: await relay.getAccountNonce(accounts[1].address),
-        data: NEXT_STORAGE_CONTRACT_UPDATE,
+        data: STORAGE_CONTRACT_UPDATE,
       };
 
       const signedTx1 = await accounts[1].wallet.signTransaction(transaction1);


### PR DESCRIPTION
**Description**:
This PR is a hotfix for v0.51 that added steps to capture transactionFee in metrics and HBAR limiter class for executeTransaction and deleteFile.

To retrieve the `transactionFee` in `executeTransaction()`, the `getRecord()` method was utilized. The `getRecord()` method exposes and throws errors caused by invalid transactions on the network, which were previously ignored. These errors were typically discovered only after repeated lookups on the mirror node, with `MIRROR_NODE_GET_CONTRACT_RESULTS_RETRIES` (10) multiplied by `MIRROR_NODE_RETRY_DELAY` (2000ms), resulting in a total of 20000ms (20 seconds). This error exposure helps to reduce transaction time and ensures more accurate and secure handling of transactions.

This PR also tweaked and reused `executeGetTransactionRecord()` method to capture transactionFee of EthereumTransactions and add the fees to metrics and HBAR rate limiter class.

**Related issue(s)**:

Fixes #2707 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
