### PR TITLE
fix: The relay metrics are not exposed in the websocket server

### DIFF
--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -24,7 +24,7 @@ import pino from 'pino';
 import dotenv from 'dotenv';
 import { v4 as uuid } from 'uuid';
 import websockify from 'koa-websocket';
-import { Registry } from 'prom-client';
+import { collectDefaultMetrics, Registry } from 'prom-client';
 import { getRequestResult } from './controllers';
 import { WS_CONSTANTS } from './utils/constants';
 import { formatIdMessage } from './utils/formatters';
@@ -202,6 +202,8 @@ app.ws.use(async (ctx) => {
 });
 
 const httpApp = new KoaJsonRpc(logger, register).getKoaApp();
+collectDefaultMetrics({ register, prefix: 'rpc_relay_' });
+
 httpApp.use(async (ctx, next) => {
   // prometheus metrics exposure
   if (ctx.url === '/metrics') {


### PR DESCRIPTION
**Description**:

The websockset specific metrics are available on 8547 port, but the relay's metrics are not. The import of the relay is the same as the in the server, but the relay metrics are available in the RPC server but not the websocket server.

**Steps to reproduce:**

1. Run the RPC server.
2. Run the WebSocket server.
3. Look at the metrics at the http://localhost:8547/ end point.
4. Notice the relay metrics are not exposed.

This PR adds a small change to the WebSocket server to collect the relay metrics (same way it is done in the RPC server):
```diff
+ collectDefaultMetrics({ register, prefix: 'rpc_relay_' });
```

**Related issue(s)**:

Fixes #2694

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
