### PR TITLE
feat: replaced getRecord network calls with calls to mirror node to avoid SDK costs 

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -53,7 +53,7 @@ import {
 } from '@hashgraph/sdk';
 import { BigNumber } from '@hashgraph/sdk/lib/Transfer';
 import { Logger } from 'pino';
-import { formatRequestIdMessage } from '../../formatters';
+import { formatRequestIdMessage, formatTransactionId, parseNumericEnvVar } from '../../formatters';
 import HbarLimit from '../hbarlimiter';
 import constants from './../constants';
 import { SDKClientError } from './../errors/SDKClientError';
@@ -860,6 +860,62 @@ export class SDKClient {
       }
     } catch (error: any) {
       this.logger.warn(`${requestIdPrefix} ${error['message']} `);
+    }
+  };
+
+  /**
+   * /**
+   * @dev retrieves charged transaction fee by making repeated calls to Mirror Node. Eventually capture the fee in metrics and rate limitter class.
+   * @param transactionId
+   * @param nonce
+   * @param requestId
+   * @param currentDateNow
+   * @param txConstructorName
+   * @param gasFee
+   * @param callerName
+   * @param interactingEntity
+   */
+  private retrieveAndCaptureChargedTxFee = async (
+    transactionId: string,
+    nonce: number,
+    requestId: string,
+    currentDateNow: number,
+    txConstructorName: string,
+    gasFee: number,
+    callerName: string,
+    interactingEntity: any,
+  ) => {
+    // note: getting transaction record using mirror node instead of the SDK to avoid transaction costs
+    const transactionRecord = await this.mirrorNodeClient.repeatedRequest(
+      this.mirrorNodeClient.getTransactionById.name,
+      [transactionId, nonce],
+      this.MirrorNodeRetries,
+      requestId,
+    );
+
+    if (!transactionRecord) {
+      this.logger.warn(
+        `${requestId} No transaction record retrieved: transactionId=${transactionId}, txConstructorName=${txConstructorName}, callerName=${callerName}`,
+      );
+      throw predefined.INTERNAL_ERROR(
+        `No transaction record retrieved: transactionId=${transactionId}, txConstructorName=${txConstructorName}, callerName=${callerName}`,
+        // extract charged transaction fee from transaction record
+      );
+
+      // capture charged transaction fee in metrics and rate limitter class
+      this.logger.trace(
+        `${requestId} Capturing HBAR charged transaction fee: transactionId=${transactionId}, txConstructorName=${txConstructorName}, callerName=${callerName}, txChargedFee=${txChargedFee} tinybars`,
+      );
+      this.hbarLimiter.addExpense(txChargedFee, currentDateNow);
+      this.captureMetrics(
+        SDKClient.transactionMode,
+        txConstructorName,
+        Status.Success,
+        txChargedFee,
+        gasFee,
+        callerName,
+        interactingEntity,
+      );
     }
   };
 }

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -96,7 +96,7 @@ export default class HAPIService {
       gasHistogram: this.consensusNodeClientHistogramGasFee,
     };
     this.cacheService = cacheService;
-    this.client = this.initSDKClient(logger, this.metrics);
+    this.client = this.initSDKClient(logger, this.metrics, register);
 
     const currentDateNow = Date.now();
     this.initialTransactionCount = parseInt(process.env.HAPI_CLIENT_TRANSACTION_RESET!) || 0;
@@ -172,7 +172,7 @@ export default class HAPIService {
       .inc(1);
 
     this.clientMain = this.initClient(this.logger, this.hederaNetwork);
-    this.client = this.initSDKClient(this.logger, this.metrics);
+    this.client = this.initSDKClient(this.logger, this.metrics, this.register);
     this.resetCounters();
   }
 
@@ -191,13 +191,14 @@ export default class HAPIService {
    * @param {Logger} logger
    * @returns SDK Client
    */
-  private initSDKClient(logger: Logger, metrics: any): SDKClient {
+  private initSDKClient(logger: Logger, metrics: any, register: Registry): SDKClient {
     return new SDKClient(
       this.clientMain,
       logger.child({ name: `consensus-node` }),
       this.hbarLimiter,
       metrics,
       this.cacheService,
+      register,
     );
   }
 


### PR DESCRIPTION
**Description**:
- Added an instance of Mirror Node client to the SDKClient class.

- Added the `retrieveAndCaptureChargedTxFee()` method to retrieve charged transaction fees by making repeated calls to the Mirror Node using the appropriate transactionId. This method is intended to replace the `getRecord()` methods called by the SDK to reduce costs.

- Refactored the createFile() and deleteFile() method to implement the new `retrieveAndCaptureChargedTxFee` logic.

**Related issue(s)**:

Fixes #2706 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
