### PR TITLE
feat: reused executetransaction for methods in sdkclient and improved logging

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -38,7 +38,10 @@ const generateRandomHex = (bytesLength = 16) => {
  * Format message prefix for logger.
  */
 const formatRequestIdMessage = (requestId?: string): string => {
-  return requestId ? `[${constants.REQUEST_ID_STRING}${requestId}]` : '';
+  if (!requestId) {
+    return '';
+  }
+  return requestId.includes(constants.REQUEST_ID_STRING) ? requestId : `[${constants.REQUEST_ID_STRING}${requestId}]`;
 };
 
 function hexToASCII(str: string): string {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -650,15 +650,9 @@ export class SDKClient {
   }
 
   async executeGetTransactionRecord(transactionResponse: TransactionResponse, callerName: string, requestId: string) {
-    const currentDateNow = Date.now();
     let gasUsed: any = 0;
     let transactionFee: number = 0;
     const transactionId: string = transactionResponse.transactionId.toString();
-
-    const shouldLimit = this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.recordMode, callerName);
-    if (shouldLimit) {
-      throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
-    }
 
     try {
       if (!transactionResponse.getRecord) {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -782,13 +782,13 @@ export class SDKClient {
       .setKeys(client.operatorPublicKey ? [client.operatorPublicKey] : []);
 
     // use executeTransaction() to execute fileCreateTx -> handle errors -> capture HBAR burned in metrics and hbar rate limit class
-    const fileCreateTxResponse = (await this.executeTransaction(
+    const fileCreateTxResponse = await this.executeTransaction(
       fileCreateTx,
       callerName,
       interactingEntity,
       formattedRequestId,
       true,
-    )) as TransactionResponse;
+    );
 
     const { fileId } = await fileCreateTxResponse.getReceipt(client);
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -525,7 +525,7 @@ export class SDKClient {
     let transactionResponse: TransactionResponse | TransactionResponse[] | null = null;
     try {
       // check hbar limit before executing transaction
-      const shouldLimit = this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.recordMode, callerName);
+      const shouldLimit = this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.transactionMode, callerName);
       if (shouldLimit) {
         throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
       }

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -807,7 +807,7 @@ export class SDKClient {
     if (fileId) {
       const fileSize = (await new FileInfoQuery().setFileId(fileId).execute(client)).size;
 
-      if (callData.length > 0 && fileSize.isZero()) {
+      if (fileSize.isZero()) {
         throw new SDKClientError({}, `${formattedRequestId} Created file is empty. `);
       }
       this.logger.trace(`${formattedRequestId} Created file with fileId: ${fileId} and file size ${fileSize}`);

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -313,7 +313,12 @@ export class SDKClient {
 
     return {
       fileId,
-      txResponse: await this.executeTransaction(ethereumTransaction, callerName, interactingEntity, requestId),
+      txResponse: (await this.executeTransaction(
+        ethereumTransaction,
+        callerName,
+        interactingEntity,
+        requestId,
+      )) as TransactionResponse,
     };
   }
 
@@ -498,45 +503,90 @@ export class SDKClient {
     }
   }
 
+  /**
+   * Executes transaction -> handle errors -> capture burned HBAR in metrics and HBAR rate limit class.
+   * @param transaction
+   * @param callerName
+   * @param interactingEntity
+   * @param requestId
+   * @returns
+   */
   async executeTransaction(
     transaction: Transaction,
     callerName: string,
     interactingEntity: string,
     requestId: string,
-  ): Promise<TransactionResponse> {
+  ): Promise<TransactionResponse | TransactionResponse[]> {
     const transactionType = transaction.constructor.name;
     const currentDateNow = Date.now();
     let gasUsed: number = 0;
     let transactionFee: number = 0;
-    let transactionResponse: TransactionResponse | null = null;
+    let transactionId = [] as string[];
+    let transactionResponse: TransactionResponse | TransactionResponse[] | null = null;
     try {
       // check hbar limit before executing transaction
-      if (this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.recordMode, callerName)) {
+      const shouldLimit = this.hbarLimiter.shouldLimit(currentDateNow, SDKClient.recordMode, callerName);
+      if (shouldLimit) {
         throw predefined.HBAR_RATE_LIMIT_EXCEEDED;
       }
 
       // execute transaction
+      // logic: if transaction is typed FileAppendTransaction, use executeAll() to retrieve all fileAppend transaction responses
+      // logic: if transaction is any other type, use execute() to get the only transaction response
       this.logger.info(`${requestId} Execute ${transactionType} transaction`);
-      transactionResponse = await transaction.execute(this.clientMain);
+      if (transactionType === FileAppendTransaction.name) {
+        // execute transaction
+        transactionResponse = await (transaction as FileAppendTransaction).executeAll(this.clientMain);
 
-      // retrieve and capture transaction fee in metrics and rate limiter class
-      const getRecordResult = await this.executeGetTransactionRecord(transactionResponse, callerName, requestId);
-      gasUsed = getRecordResult.gasUsed;
-      transactionFee = getRecordResult.transactionFee;
+        // retrieve transaction fee
+        for (let txResp of transactionResponse) {
+          // get transactionId - mainly for logging purposes when capture metrics
+          transactionId.push(txResp.transactionId.toString());
 
-      this.logger.info(
-        `${requestId} Successfully execute ${transactionType} transaction: transactionId=${transactionResponse.transactionId}, callerName=${callerName}, transactionType=${transactionType}, status=${Status.Success}(${Status.Success._code}), cost=${transactionFee} tinybars, gasUsed=${gasUsed}`,
-      );
+          // get transaction fee
+          const getRecordResult = await this.executeGetTransactionRecord(txResp, callerName, requestId);
+          gasUsed += getRecordResult.gasUsed;
+          transactionFee += getRecordResult.transactionFee;
+
+          this.logger.info(
+            `${requestId} Successfully execute ${transactionType} transaction: transactionId=${txResp.transactionId}, callerName=${callerName}, transactionType=${transactionType}, status=${Status.Success}(${Status.Success._code}), cost=${getRecordResult.transactionFee} tinybars, gasUsed=${getRecordResult.gasUsed}`,
+          );
+        }
+      } else {
+        // execute transaction
+        transactionResponse = await transaction.execute(this.clientMain);
+
+        // get transactionId after execution
+        transactionId = [transactionResponse.transactionId.toString()];
+
+        // retrieve and capture transaction fee in metrics and rate limiter class
+        const getRecordResult = await this.executeGetTransactionRecord(transactionResponse, callerName, requestId);
+        gasUsed = getRecordResult.gasUsed;
+        transactionFee = getRecordResult.transactionFee;
+
+        this.logger.info(
+          `${requestId} Successfully execute ${transactionType} transaction: transactionId=${transactionId[0]}, callerName=${callerName}, transactionType=${transactionType}, status=${Status.Success}(${Status.Success._code}), cost=${transactionFee} tinybars, gasUsed=${gasUsed}`,
+        );
+      }
+
       return transactionResponse;
     } catch (e: any) {
+      // throw e right away if it's a rate limit exceeded error
+      if (e === predefined.HBAR_RATE_LIMIT_EXCEEDED) {
+        throw e;
+      }
+
       // declare main error
       const sdkClientError = new SDKClientError(e, e.message);
+
+      // get transactionId from error
+      transactionId = [e.transactionId];
 
       // if valid network error utilize transaction id to get transactionFee and gasUsed for metrics
       if (sdkClientError.isValidNetworkError()) {
         try {
           const transactionRecord = await new TransactionRecordQuery()
-            .setTransactionId(transaction.transactionId!)
+            .setTransactionId(transactionId[0]) // transactionId attached in error
             .setNodeAccountIds(transaction.nodeAccountIds!)
             .setValidateReceiptStatus(false)
             .execute(this.clientMain);
@@ -550,14 +600,16 @@ export class SDKClient {
           const recordQueryError = new SDKClientError(err, err.message);
           this.logger.error(
             recordQueryError,
-            `${requestId} Error raised during TransactionRecordQuery for ${transaction.transactionId}`,
+            `${requestId} Error raised during TransactionRecordQuery for ${transactionId}`,
           );
         }
       }
 
-      // log and throw
+      // log main error
       this.logger.debug(
-        `${requestId} Fail to execute ${transactionType} transaction: transactionId=${transaction.transactionId}, callerName=${callerName}, transactionType=${transactionType}, status=${sdkClientError.status}(${sdkClientError.status._code}), cost=${transactionFee} tinybars, gasUsed=${gasUsed}`,
+        `${requestId} Fail to execute ${transactionType} transaction: transactionId=${transactionId.flat()}, callerName=${callerName}, transactionType=${transactionType}, status=${
+          sdkClientError.status
+        }(${sdkClientError.status._code}), cost=${transactionFee} tinybars, gasUsed=${gasUsed}`,
       );
 
       // Throw WRONG_NONCE error as more error handling logic for WRONG_NONCE is awaited in eth.sendRawTransactionErrorHandler(). Otherwise, move on and return transactionResponse eventually.
@@ -565,8 +617,9 @@ export class SDKClient {
         throw sdkClientError;
       } else {
         if (!transactionResponse) {
+          this.logger.error(`${requestId} Transaction execution returns a null value for transaction ${transactionId}`);
           throw predefined.INTERNAL_ERROR(
-            `${requestId} Transaction execution returns a null value for transaction ${transaction.transactionId}`,
+            `${requestId} Transaction execution returns a null value for transaction ${transactionId}`,
           );
         }
         return transactionResponse;
@@ -578,7 +631,7 @@ export class SDKClient {
        */
       if (transactionFee !== 0) {
         this.logger.trace(
-          `${requestId} Capturing HBAR charged transaction fee: transactionId=${transaction.transactionId}, txConstructorName=${transactionType}, callerName=${callerName}, txChargedFee=${transactionFee} tinybars`,
+          `${requestId} Capturing HBAR charged transaction fee: transactionId=${transactionId.flat()}, transactionType=${transactionType}, callerName=${callerName}, txChargedFee=${transactionFee} tinybars`,
         );
         this.hbarLimiter.addExpense(transactionFee, currentDateNow);
         this.captureMetrics(
@@ -631,11 +684,10 @@ export class SDKClient {
       return { transactionFee, gasUsed };
     } catch (e: any) {
       // log error from getRecord
-      const sdkClientError = new SDKClientError(e, e.message);
       this.logger.debug(
-        `${requestId} Error raised during transactionResponse.getRecord: transactionId=${transactionId} callerName=${callerName} recordStatus=${sdkClientError.status} (${sdkClientError.status._code}), cost=${transactionFee}, gasUsed=${gasUsed}`,
+        `${requestId} Error raised during transactionResponse.getRecord: transactionId=${transactionId} callerName=${callerName} recordStatus=${e.status} (${e.status._code}), cost=${transactionFee}, gasUsed=${gasUsed}`,
       );
-      throw sdkClientError;
+      throw e;
     }
   }
 

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -38,11 +38,32 @@ import {
   trimPrecedingZeros,
   isHex,
   ASCIIToHex,
+  formatRequestIdMessage,
 } from '../../src/formatters';
 import constants from '../../src/lib/constants';
 import { BigNumber as BN } from 'bignumber.js';
 
 describe('Formatters', () => {
+  describe('formatRequestIdMessage', () => {
+    const exampleRequestId = '46530e63-e33a-4f42-8e44-b125f99f1a9b';
+    const expectedFormattedId = '[Request ID: 46530e63-e33a-4f42-8e44-b125f99f1a9b]';
+
+    it('Should format request ID message', () => {
+      const result = formatRequestIdMessage(exampleRequestId);
+      expect(result).to.eq(expectedFormattedId);
+    });
+
+    it('Should return formated request ID if already formatted request ID is passed in', () => {
+      const result = formatRequestIdMessage(expectedFormattedId);
+      expect(result).to.eq(expectedFormattedId);
+    });
+
+    it('Should return an empty string if undefined is passed in', () => {
+      const result = formatRequestIdMessage(undefined);
+      expect(result).to.eq('');
+    });
+  });
+
   describe('hexToASCII', () => {
     const inputs = ['4C6F72656D20497073756D', '466F6F', '426172'];
 

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -2168,8 +2168,8 @@ describe('SdkClient', async function () {
 
       hbarLimitMock.expects('shouldLimit').thrice().returns(false);
       hbarLimitMock.expects('addExpense').withArgs(fileCreateFee).once();
-      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).atLeast(fileAppendChunks);
       hbarLimitMock.expects('addExpense').withArgs(defaultTransactionFee).once();
+      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).exactly(fileAppendChunks);
 
       await sdkClient.submitEthereumTransaction(transactionBuffer, callerName, requestId);
 
@@ -2192,7 +2192,7 @@ describe('SdkClient', async function () {
         .resolves(Array.from({ length: fileAppendChunks }, () => getTransactionResponse('FileAppendTransaction')));
 
       hbarLimitMock.expects('addExpense').withArgs(fileCreateFee).once();
-      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).atLeast(fileAppendChunks);
+      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).exactly(fileAppendChunks);
       hbarLimitMock.expects('shouldLimit').twice().returns(false);
 
       const response = await sdkClient.createFile(callData, client, requestId, callerName, interactingEntity);
@@ -2212,7 +2212,7 @@ describe('SdkClient', async function () {
         .resolves(Array.from({ length: fileAppendChunks }, () => getTransactionResponse('FileAppendTransaction')));
 
       hbarLimitMock.expects('shouldLimit').once().returns(false);
-      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).atLeast(fileAppendChunks);
+      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).exactly(fileAppendChunks);
 
       await sdkClient.executeAllTransaction(
         new FileAppendTransaction(),

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -2280,11 +2280,7 @@ describe('SdkClient', async function () {
         .resolves(getTransactionResponse('FileDeleteTransaction'));
 
       hbarLimitMock.expects('addExpense').withArgs(fileDeleteFee).once();
-      hbarLimitMock
-        .expects('shouldLimit')
-        .withArgs(sinon.match.any, SDKClient.transactionMode, callerName)
-        .once()
-        .returns(false);
+      hbarLimitMock.expects('shouldLimit').never();
 
       await sdkClient.deleteFile(fileId, requestId, callerName, interactingEntity);
 
@@ -2356,6 +2352,7 @@ describe('SdkClient', async function () {
         callerName,
         interactingEntity,
         requestId,
+        true,
       );
 
       expect(response).to.eq(transactionResponse);


### PR DESCRIPTION
**Description**:
- updated `executeTransaction()` so it can perform executeAll() for type FileAppend transactions 
- reused executeTransaction() for fileCreate, fileAppend, and fileDeelete so they can share the same workflow
- improve logging so it can be descriptive for each transactions. Add logs that contain requestId, transactionId, transactionType, transactionCost, gasUsed, etc.

**Related issue(s)**:

Fixes #2746

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
