### PR TITLE
test: added E2E test for preemtive rate limit

### DIFF
--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -162,6 +162,26 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
         verifyRemainingLimit(expectedCost, remainingHbarsBefore, remainingHbarsAfter);
       });
 
+      it('Should preemtively check the rate limit before submitting EthereumTransaction', async function () {
+        const remainingHbarsBefore = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
+
+        process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = 'true';
+        process.env.HOT_FIX_FILE_APPEND_FEE = (remainingHbarsBefore - 100000000).toString();
+
+        try {
+          const largeContract = await Utils.deployContract(
+            largeContractJson.abi,
+            largeContractJson.bytecode,
+            accounts[0].wallet,
+          );
+          await largeContract.waitForDeployment();
+
+          expect(true).to.be.false;
+        } catch (e) {
+          expect(e.message).to.contain(predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED.message);
+        }
+      });
+
       it('multiple deployments of large contracts should eventually exhaust the remaining hbar limit', async function () {
         const remainingHbarsBefore = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
         expect(remainingHbarsBefore).to.be.gt(0);

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -180,6 +180,8 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
         } catch (e) {
           expect(e.message).to.contain(predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED.message);
         }
+
+        delete process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK;
       });
 
       it('multiple deployments of large contracts should eventually exhaust the remaining hbar limit', async function () {


### PR DESCRIPTION
**Description**:
[PR#2751](https://github.com/hashgraph/hedera-json-rpc-relay/pull/2751) added a preemptive check for the HBAR rate limit as a hotfix but did not include E2E test to cover the solution. This PR adds the necessary E2E test to ensure comprehensive coverage.

**Related issue(s)**:

Fixes #2745

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
