### PR TITLE
feat: added logging to the HBAR rate limit class for more descriptive information.

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -54,14 +54,16 @@ export const predefined = {
       code: -32009,
       message: `Gas price '${gasPrice}' is below configured minimum gas price '${minGasPrice}'`,
     }),
-  HBAR_RATE_LIMIT_EXCEEDED: new JsonRpcError({
-    code: -32606,
-    message: 'HBAR Rate limit exceeded',
-  }),
-  HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED: new JsonRpcError({
-    code: -32606,
-    message: 'The HBAR rate limit was preemptively exceeded due to an excessively large callData size.',
-  }),
+  HBAR_RATE_LIMIT_EXCEEDED: (remainingBudget?, resetTimeStamp?) =>
+    new JsonRpcError({
+      code: -32606,
+      message: `HBAR Rate limit exceeded: remainingBudget=${remainingBudget}, resetTimeStamp=${resetTimeStamp}`,
+    }),
+  HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED: (remainingBudget?, expense?, resetTimeStamp?) =>
+    new JsonRpcError({
+      code: -32606,
+      message: `The HBAR rate limit was preemptively exceeded due to an excessively large callData size: remainingBudget=${remainingBudget}, expense=${expense}, resetTimeStamp=${resetTimeStamp}`,
+    }),
   INSUFFICIENT_ACCOUNT_BALANCE: new JsonRpcError({
     code: -32000,
     message: 'Insufficient funds for transfer',

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -20,6 +20,7 @@
 
 import { Logger } from 'pino';
 import { Registry, Counter, Gauge } from 'prom-client';
+import { formatRequestIdMessage } from '../../formatters';
 
 export default class HbarLimit {
   private enabled: boolean = false;
@@ -43,9 +44,9 @@ export default class HbarLimit {
       this.duration = duration;
     }
     this.remainingBudget = this.total;
-    this.logger.trace(`this.remainingBudget: ${this.remainingBudget}`);
-
     this.reset = currentDateNow + this.duration;
+
+    this.logger.trace(`remainingBudget=${this.remainingBudget} tℏ, resetTimeStamp=${this.reset}`);
 
     const metricCounterName = 'rpc_relay_hbar_rate_limit';
     register.removeSingleMetric(metricCounterName);
@@ -70,22 +71,28 @@ export default class HbarLimit {
   /**
    * Decides whether we should limit expenses, based on remaining budget.
    */
-  shouldLimit(currentDateNow: number, mode: string, methodName: string): boolean {
+  shouldLimit(currentDateNow: number, mode: string, methodName: string, requestId?: string): boolean {
+    const requestIdPrefix = formatRequestIdMessage(requestId);
+
     if (!this.enabled) {
       return false;
     }
 
     if (this.shouldResetLimiter(currentDateNow)) {
-      this.resetLimiter(currentDateNow);
+      this.resetLimiter(currentDateNow, requestIdPrefix);
     }
 
     if (this.remainingBudget <= 0) {
       this.hbarLimitCounter.labels(mode, methodName).inc(1);
       this.logger.warn(
-        `Rate limit incoming calls, ${this.remainingBudget} out of ${this.total} tℏ left in relay budget until ${this.reset}`,
+        `${requestIdPrefix} Rate limit incoming call: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp: ${this.reset}`,
       );
       return true;
     }
+
+    this.logger.trace(
+      `${requestIdPrefix} Rate limit not reached. ${this.remainingBudget} out of ${this.total} tℏ left in relay budget until ${this.reset}.`,
+    );
 
     return false;
   }
@@ -95,24 +102,29 @@ export default class HbarLimit {
    * @param {number} transactionFee - The transaction fee to be evaluated.
    * @returns {boolean} A boolean indicating whether the transaction fee should be preemptively limited.
    */
-
   shouldPreemtivelyLimit(transactionFee: number): boolean {
-    return this.remainingBudget - transactionFee <= 0;
+    return this.remainingBudget - transactionFee < 0;
   }
 
   /**
    * Add expense to the remaining budget.
    */
-  addExpense(cost: number, currentDateNow: number) {
+  addExpense(cost: number, currentDateNow: number, requestId?: string) {
+    const requestIdPrefix = formatRequestIdMessage(requestId);
+
     if (!this.enabled) {
       return;
     }
 
     if (this.shouldResetLimiter(currentDateNow)) {
-      this.resetLimiter(currentDateNow);
+      this.resetLimiter(currentDateNow, requestIdPrefix);
     }
     this.remainingBudget -= cost;
     this.hbarLimitRemainingGauge.set(this.remainingBudget);
+
+    this.logger.trace(
+      `${requestIdPrefix} HBAR rate limit expense update: cost=${cost}, remainingBudget=${this.remainingBudget}, resetTimeStamp=${this.reset}`,
+    );
   }
 
   /**
@@ -146,8 +158,11 @@ export default class HbarLimit {
   /**
    * Reset budget to the total allowed and reset timer to current time plus duration.
    */
-  private resetLimiter(currentDateNow: number) {
+  private resetLimiter(currentDateNow: number, requestIdPrefix: string) {
     this.reset = currentDateNow + this.duration;
     this.remainingBudget = this.total;
+    this.logger.trace(
+      `${requestIdPrefix} HBAR Rate Limit reset: remainingBudget= ${this.remainingBudget}, newResetTimestamp= ${this.reset}`,
+    );
   }
 }

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -164,6 +164,8 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
 
       it('Should preemtively check the rate limit before submitting EthereumTransaction', async function () {
         const remainingHbarsBefore = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
+        const rateLimitErrorMessage =
+          'The HBAR rate limit was preemptively exceeded due to an excessively large callData size';
 
         process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = 'true';
         process.env.HOT_FIX_FILE_APPEND_FEE = (remainingHbarsBefore - 100000000).toString();
@@ -178,7 +180,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
 
           expect(true).to.be.false;
         } catch (e) {
-          expect(e.message).to.contain(predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED.message);
+          expect(e.message).to.contain(rateLimitErrorMessage);
         }
 
         delete process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK;
@@ -186,6 +188,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
 
       it('multiple deployments of large contracts should eventually exhaust the remaining hbar limit', async function () {
         const remainingHbarsBefore = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
+        const rateLimitErrorMessage = 'HBAR Rate limit exceeded';
         expect(remainingHbarsBefore).to.be.gt(0);
         try {
           for (let i = 0; i < 50; i++) {
@@ -193,7 +196,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
           }
           expect.fail(`Expected an error but nothing was thrown`);
         } catch (e: any) {
-          expect(e.message).to.contain(predefined.HBAR_RATE_LIMIT_EXCEEDED.message);
+          expect(e.message).to.contain(rateLimitErrorMessage);
         }
 
         const remainingHbarsAfter = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));


### PR DESCRIPTION
**Description**:
 - added logging to HBARLimit class
 - updated HBAR_RATE_LIMIT_EXCEEDED  and HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED errors to accept arguments ((remainingBalance, expense, and resetTimestamp))

**Related issue(s)**:

Fixes #2736 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
