### PR TITLE
chore: bump local node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "root",
       "dependencies": {
-        "@hashgraph/hedera-local": "^2.27.0",
+        "@hashgraph/hedera-local": "^2.28.0",
         "@open-rpc/schema-utils-js": "^1.16.1",
         "@types/find-config": "^1.0.4",
         "@types/sinon": "^10.0.20",
@@ -2113,21 +2113,21 @@
       }
     },
     "node_modules/@hashgraph/hedera-local": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.27.0.tgz",
-      "integrity": "sha512-K9TOLJ33GE90TRUK7matQkCsQ+HrkhhpUjGQw1L2gguTKwpaJDCiiu2M3R64MQyhjINc7e5eQYZvvKJtvFlHIw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.28.0.tgz",
+      "integrity": "sha512-RoCanG69B47kwvr9jUGhXsYWiibhEpG8HBlNhybpt00RuupdSWgv+yfb49CL7c8AiAf+6HKou490wv9k5Bj9Pg==",
       "dependencies": {
-        "@hashgraph/sdk": "^2.47.0",
+        "@hashgraph/sdk": "^2.48.1",
         "blessed": "^0.1.81",
         "blessed-terminal": "^0.1.22",
         "csv-parser": "^3.0.0",
-        "detect-port": "^1.5.1",
+        "detect-port": "^1.6.1",
         "dockerode": "^4.0.2",
         "dotenv": "^16.4.5",
-        "ethers": "^6.13.1",
+        "ethers": "^6.13.2",
         "js-yaml": "^4.1.0",
-        "rimraf": "^5.0.5",
-        "semver": "^7.6.2",
+        "rimraf": "^6.0.1",
+        "semver": "^7.6.3",
         "shelljs": "^0.8.5",
         "ts-mocha": "^10.0.0",
         "yargs": "^17.7.2"
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/@hashgraph/hedera-local/node_modules/ethers": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.1.tgz",
-      "integrity": "sha512-hdJ2HOxg/xx97Lm9HdCWk949BfYqYWpyw4//78SiwOLgASyfrNszfMUNB2joKjvGUdwhHfaiMMFFwacVVoLR9A==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.2.tgz",
+      "integrity": "sha512-9VkriTTed+/27BGuY1s0hf441kqwHJ1wtN2edksEtiRvXx+soxRX3iSXTfFqq2+YwrOqbDoTHjIhQnjJRlzKmg==",
       "funding": [
         {
           "type": "individual",
@@ -2201,9 +2201,9 @@
       }
     },
     "node_modules/@hashgraph/hedera-local/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -2216,52 +2216,102 @@
       }
     },
     "node_modules/@hashgraph/hedera-local/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@hashgraph/hedera-local/node_modules/jackspeak": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
+      "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@hashgraph/hedera-local/node_modules/lru-cache": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
+      "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@hashgraph/hedera-local/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@hashgraph/hedera-local/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@hashgraph/hedera-local/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@hashgraph/hedera-local/node_modules/rimraf": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-      "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dependencies": {
-        "glob": "^10.3.7"
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": ">=14"
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -7354,9 +7404,9 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/detect-port": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-      "integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
+      "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
       "dependencies": {
         "address": "^1.0.1",
         "debug": "4"
@@ -7364,6 +7414,9 @@
       "bin": {
         "detect": "bin/detect-port.js",
         "detect-port": "bin/detect-port.js"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/diff": {
@@ -15920,6 +15973,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+    },
     "node_modules/pacote": {
       "version": "17.0.6",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-17.0.6.tgz",
@@ -20922,7 +20980,7 @@
         "uuid": "^3.3.2"
       },
       "devDependencies": {
-        "@hashgraph/hedera-local": "^2.27.0",
+        "@hashgraph/hedera-local": "^2.28.0",
         "@hashgraph/sdk": "^2.48.1",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
@@ -21235,7 +21293,7 @@
         "pnpm": "8.15.8"
       },
       "devDependencies": {
-        "@hashgraph/hedera-local": "^2.27.0",
+        "@hashgraph/hedera-local": "^2.28.0",
         "@hashgraph/sdk": "^2.48.1",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
@@ -22976,20 +23034,20 @@
       }
     },
     "@hashgraph/hedera-local": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.27.0.tgz",
-      "integrity": "sha512-K9TOLJ33GE90TRUK7matQkCsQ+HrkhhpUjGQw1L2gguTKwpaJDCiiu2M3R64MQyhjINc7e5eQYZvvKJtvFlHIw==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/hedera-local/-/hedera-local-2.28.0.tgz",
+      "integrity": "sha512-RoCanG69B47kwvr9jUGhXsYWiibhEpG8HBlNhybpt00RuupdSWgv+yfb49CL7c8AiAf+6HKou490wv9k5Bj9Pg==",
       "requires": {
-        "@hashgraph/sdk": "^2.47.0",
+        "@hashgraph/sdk": "^2.48.1",
         "blessed": "^0.1.81",
         "blessed-terminal": "^0.1.22",
         "csv-parser": "^3.0.0",
-        "detect-port": "^1.5.1",
+        "detect-port": "^1.6.1",
         "dockerode": "^4.0.2",
         "dotenv": "^16.4.5",
-        "ethers": "^6.13.1",
+        "ethers": "^6.13.2",
         "js-yaml": "^4.1.0",
-        "rimraf": "^5.0.5",
+        "rimraf": "^6.0.1",
         "semver": "^7.5.3",
         "shelljs": "^0.8.5",
         "ts-mocha": "^10.0.0",
@@ -23028,9 +23086,9 @@
           "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
         },
         "ethers": {
-          "version": "6.13.1",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.1.tgz",
-          "integrity": "sha512-hdJ2HOxg/xx97Lm9HdCWk949BfYqYWpyw4//78SiwOLgASyfrNszfMUNB2joKjvGUdwhHfaiMMFFwacVVoLR9A==",
+          "version": "6.13.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.2.tgz",
+          "integrity": "sha512-9VkriTTed+/27BGuY1s0hf441kqwHJ1wtN2edksEtiRvXx+soxRX3iSXTfFqq2+YwrOqbDoTHjIhQnjJRlzKmg==",
           "requires": {
             "@adraffy/ens-normalize": "1.10.1",
             "@noble/curves": "1.2.0",
@@ -23042,40 +23100,70 @@
           }
         },
         "foreground-child": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-          "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
+          "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
           "requires": {
             "cross-spawn": "^7.0.0",
             "signal-exit": "^4.0.1"
           }
         },
         "glob": {
-          "version": "10.3.10",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-          "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+          "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
           "requires": {
             "foreground-child": "^3.1.0",
-            "jackspeak": "^2.3.5",
-            "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-            "path-scurry": "^1.10.1"
+            "jackspeak": "^4.0.1",
+            "minimatch": "^10.0.0",
+            "minipass": "^7.1.2",
+            "package-json-from-dist": "^1.0.0",
+            "path-scurry": "^2.0.0"
           }
         },
+        "jackspeak": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
+          "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
+          "requires": {
+            "@isaacs/cliui": "^8.0.2",
+            "@pkgjs/parseargs": "^0.11.0"
+          }
+        },
+        "lru-cache": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
+          "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA=="
+        },
         "minimatch": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-          "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+          "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
-        "rimraf": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.5.tgz",
-          "integrity": "sha512-CqDakW+hMe/Bz202FPEymy68P+G50RfMQK+Qo5YUqc9SPipvbGjCGKd0RSKEelbsfQuw3g5NZDSrlZZAJurH1A==",
+        "minipass": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+          "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
+        },
+        "path-scurry": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+          "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
           "requires": {
-            "glob": "^10.3.7"
+            "lru-cache": "^11.0.0",
+            "minipass": "^7.1.2"
+          }
+        },
+        "rimraf": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+          "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+          "requires": {
+            "glob": "^11.0.0",
+            "package-json-from-dist": "^1.0.0"
           }
         },
         "signal-exit": {
@@ -23213,7 +23301,7 @@
     "@hashgraph/json-rpc-server": {
       "version": "file:packages/server",
       "requires": {
-        "@hashgraph/hedera-local": "^2.27.0",
+        "@hashgraph/hedera-local": "^2.28.0",
         "@hashgraph/json-rpc-relay": "file:../relay",
         "@hashgraph/sdk": "^2.48.1",
         "@koa/cors": "^5.0.0",
@@ -23446,7 +23534,7 @@
     "@hashgraph/json-rpc-ws-server": {
       "version": "file:packages/ws-server",
       "requires": {
-        "@hashgraph/hedera-local": "^2.27.0",
+        "@hashgraph/hedera-local": "^2.28.0",
         "@hashgraph/json-rpc-relay": "file:../relay",
         "@hashgraph/json-rpc-server": "file:../server",
         "@hashgraph/sdk": "^2.48.1",
@@ -27417,9 +27505,9 @@
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "detect-port": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.5.1.tgz",
-      "integrity": "sha512-aBzdj76lueB6uUst5iAs7+0H/oOjqI5D16XUWxlWMIMROhcM0rfsNVk93zTngq1dDNpoXRr++Sus7ETAExppAQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
+      "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
       "requires": {
         "address": "^1.0.1",
         "debug": "4"
@@ -33707,6 +33795,11 @@
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
       }
+    },
+    "package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
     },
     "pacote": {
       "version": "17.0.6",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@hashgraph/hedera-local": "^2.27.0",
+    "@hashgraph/hedera-local": "^2.28.0",
     "@open-rpc/schema-utils-js": "^1.16.1",
     "@types/find-config": "^1.0.4",
     "@types/sinon": "^10.0.20",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -22,7 +22,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@hashgraph/hedera-local": "^2.27.0",
+    "@hashgraph/hedera-local": "^2.28.0",
     "@hashgraph/sdk": "^2.48.1",
     "@koa/cors": "^5.0.0",
     "@types/chai": "^4.3.0",

--- a/packages/ws-server/package.json
+++ b/packages/ws-server/package.json
@@ -23,7 +23,7 @@
     "pnpm": "8.15.8"
   },
   "devDependencies": {
-    "@hashgraph/hedera-local": "^2.27.0",
+    "@hashgraph/hedera-local": "^2.28.0",
     "@hashgraph/sdk": "^2.48.1",
     "@koa/cors": "^5.0.0",
     "@types/chai": "^4.3.0",


### PR DESCRIPTION
**Description**:
Bumps the version of @hashgraph/hedera-local to `2.28.0`

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
