### PR TITLE
feat: reused executetransaction for methods in sdkclient and improved…

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -38,7 +38,10 @@ const generateRandomHex = (bytesLength = 16) => {
  * Format message prefix for logger.
  */
 const formatRequestIdMessage = (requestId?: string): string => {
-  return requestId ? `[${constants.REQUEST_ID_STRING}${requestId}]` : '';
+  if (!requestId) {
+    return '';
+  }
+  return requestId.includes(constants.REQUEST_ID_STRING) ? requestId : `[${constants.REQUEST_ID_STRING}${requestId}]`;
 };
 
 function hexToASCII(str: string): string {

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -38,11 +38,32 @@ import {
   trimPrecedingZeros,
   isHex,
   ASCIIToHex,
+  formatRequestIdMessage,
 } from '../../src/formatters';
 import constants from '../../src/lib/constants';
 import { BigNumber as BN } from 'bignumber.js';
 
 describe('Formatters', () => {
+  describe('formatRequestIdMessage', () => {
+    const exampleRequestId = '46530e63-e33a-4f42-8e44-b125f99f1a9b';
+    const expectedFormattedId = '[Request ID: 46530e63-e33a-4f42-8e44-b125f99f1a9b]';
+
+    it('Should format request ID message', () => {
+      const result = formatRequestIdMessage(exampleRequestId);
+      expect(result).to.eq(expectedFormattedId);
+    });
+
+    it('Should return formated request ID if already formatted request ID is passed in', () => {
+      const result = formatRequestIdMessage(expectedFormattedId);
+      expect(result).to.eq(expectedFormattedId);
+    });
+
+    it('Should return an empty string if undefined is passed in', () => {
+      const result = formatRequestIdMessage(undefined);
+      expect(result).to.eq('');
+    });
+  });
+
   describe('hexToASCII', () => {
     const inputs = ['4C6F72656D20497073756D', '466F6F', '426172'];
 

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -2168,8 +2168,8 @@ describe('SdkClient', async function () {
 
       hbarLimitMock.expects('shouldLimit').thrice().returns(false);
       hbarLimitMock.expects('addExpense').withArgs(fileCreateFee).once();
-      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).atLeast(fileAppendChunks);
       hbarLimitMock.expects('addExpense').withArgs(defaultTransactionFee).once();
+      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).exactly(fileAppendChunks);
 
       await sdkClient.submitEthereumTransaction(transactionBuffer, callerName, requestId);
 
@@ -2192,8 +2192,8 @@ describe('SdkClient', async function () {
         .resolves(Array.from({ length: fileAppendChunks }, () => getTransactionResponse('FileAppendTransaction')));
 
       hbarLimitMock.expects('addExpense').withArgs(fileCreateFee).once();
-      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).thrice();
-      hbarLimitMock.expects('shouldLimit').once().returns(false);
+      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).exactly(fileAppendChunks);
+      hbarLimitMock.expects('shouldLimit').twice().returns(false);
 
       const response = await sdkClient.createFile(callData, client, requestId, callerName, interactingEntity);
 
@@ -2201,6 +2201,54 @@ describe('SdkClient', async function () {
       expect(queryStub.called).to.be.true;
       expect(createFileStub.called).to.be.true;
       expect(appendFileStub.called).to.be.true;
+    });
+
+    it('should execute executeAllTransaction and add expenses to limiter', async () => {
+      const callData = new Uint8Array(FILE_APPEND_CHUNK_SIZE * 2 + 1);
+      const fileAppendChunks = Math.min(MAX_CHUNKS, Math.ceil(callData.length / FILE_APPEND_CHUNK_SIZE));
+
+      const appendFileStub = sinon
+        .stub(FileAppendTransaction.prototype, 'executeAll')
+        .resolves(Array.from({ length: fileAppendChunks }, () => getTransactionResponse('FileAppendTransaction')));
+
+      hbarLimitMock.expects('shouldLimit').once().returns(false);
+      hbarLimitMock.expects('addExpense').withArgs(fileAppendFee).exactly(fileAppendChunks);
+
+      await sdkClient.executeAllTransaction(
+        new FileAppendTransaction(),
+        callerName,
+        interactingEntity,
+        requestId,
+        true,
+      );
+
+      expect(appendFileStub.called).to.be.true;
+    });
+
+    it('should rate limit before executing executeAllTransaction', async () => {
+      const callData = new Uint8Array(FILE_APPEND_CHUNK_SIZE * 2 + 1);
+      const fileAppendChunks = Math.min(MAX_CHUNKS, Math.ceil(callData.length / FILE_APPEND_CHUNK_SIZE));
+
+      const appendFileStub = sinon
+        .stub(FileAppendTransaction.prototype, 'executeAll')
+        .resolves(Array.from({ length: fileAppendChunks }, () => getTransactionResponse('FileAppendTransaction')));
+
+      hbarLimitMock.expects('shouldLimit').once().returns(true);
+
+      try {
+        await sdkClient.executeAllTransaction(
+          new FileAppendTransaction(),
+          callerName,
+          interactingEntity,
+          requestId,
+          true,
+        );
+        expect.fail(`Expected an error but nothing was thrown`);
+      } catch (error: any) {
+        expect(error.message).to.equal('HBAR Rate limit exceeded');
+      }
+
+      expect(appendFileStub.called).to.be.false;
     });
 
     it('should execute FileCreateTransaction with callData.length <= fileAppendChunkSize and add expenses to limiter', async () => {
@@ -2295,8 +2343,8 @@ describe('SdkClient', async function () {
       hbarLimitMock.expects('addExpense').withArgs(defaultTransactionFee).once();
       hbarLimitMock
         .expects('shouldLimit')
-        .withArgs(sinon.match.any, SDKClient.recordMode, callerName)
-        .twice()
+        .withArgs(sinon.match.any, SDKClient.transactionMode, callerName)
+        .once()
         .returns(false);
 
       const response = await sdkClient.executeTransaction(
@@ -2304,21 +2352,18 @@ describe('SdkClient', async function () {
         callerName,
         interactingEntity,
         requestId,
+        true,
       );
 
       expect(response).to.eq(transactionResponse);
       expect(transactionStub.called).to.be.true;
     });
 
-    it('should execute TransactionRecordQuery and add expenses to limiter', async () => {
+    it('should execute TransactionRecordQuery and do not add expenses to limiter', async () => {
       const transactionResponse = getTransactionResponse('EthereumTransaction');
 
       hbarLimitMock.expects('addExpense').never();
-      hbarLimitMock
-        .expects('shouldLimit')
-        .withArgs(sinon.match.any, SDKClient.recordMode, callerName)
-        .once()
-        .returns(false);
+      hbarLimitMock.expects('shouldLimit').never();
 
       await sdkClient.executeGetTransactionRecord(transactionResponse, callerName, requestId);
     });


### PR DESCRIPTION
cherry-pick #2749
* fix: reused executeTransaction() in deleteFile() method



* fix: reworked executeTransaction() to accept executeAll



* feat: fix: reused executeTransaction() in fileCreate() method



* fix: removed check rate limit in executeGetTransactionRecord



* fix: fixed SDK HBAR limiter tests



* fix: reverted rework executeTransaction()



* fix: reworked formatRequestIdMessage



* feat: added executeAllTransaction() method



* fix: made shouldLimit optional in executeTransaction()



* Update packages/relay/src/lib/clients/sdkClient.ts






* fix: addressed comments



* fix: extracted handleExecuteAllError()



* fix: renamed handleExecuteAllError to getTransactionMetrics and reuse it in executeTransaction



---------

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
