### PR TITLE
chore: Remove and Refactor redundant logic in `eth_sendRawTransaction`

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -258,27 +258,6 @@ const toNullIfEmptyHex = (value: string): string | null => {
   return value === EMPTY_HEX ? null : value;
 };
 
-const stringToHex = (str) => {
-  let hex = '';
-  for (let i = 0; i < str.length; i++) {
-    const charCode = str.charCodeAt(i);
-    const hexValue = charCode.toString(16);
-
-    // Pad with zeros to ensure two-digit representation
-    hex += hexValue.padStart(2, '0');
-  }
-  return hex;
-};
-
-const toHexString = (byteArray) => {
-  if (typeof byteArray !== 'object') {
-    byteArray = Buffer.from(byteArray?.toString() ?? '', 'hex');
-  }
-
-  const encoded = Buffer.from(byteArray, 'utf8').toString('hex');
-  return encoded;
-};
-
 const isValidEthereumAddress = (address: string | null | undefined): boolean => {
   if (!address) {
     return false;
@@ -321,9 +300,7 @@ export {
   trimPrecedingZeros,
   stripLeadingZeroForSignatures,
   weibarHexToTinyBarInt,
-  stringToHex,
   strip0x,
-  toHexString,
   isValidEthereumAddress,
   isHex,
   ASCIIToHex,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1507,23 +1507,9 @@ export class EthImpl implements Eth {
     let fileId: FileId | null = null;
     let txSubmitted = false;
     try {
-      const sendRawTransactionResult = await this.sendRawTransactionWithRetry(
-        async () =>
-          await this.hapiService
-            .getSDKClient()
-            .submitEthereumTransaction(transactionBuffer, EthImpl.ethSendRawTransaction, requestIdPrefix),
-        {
-          canRetry: (e: unknown) => {
-            return e instanceof SDKClientError && (e.isConnectionDropped() || e.isTimeoutExceeded());
-          },
-          onError: (e: SDKClientError) => {
-            this.logger.warn(
-              `${requestIdPrefix} SDK Client has probably timed out, trying again with a new instance...`,
-            );
-            this.hapiService.decrementErrorCounter(e.statusCode);
-          },
-        },
-      );
+      const sendRawTransactionResult = await this.hapiService
+        .getSDKClient()
+        .submitEthereumTransaction(transactionBuffer, EthImpl.ethSendRawTransaction, requestIdPrefix);
 
       txSubmitted = true;
       fileId = sendRawTransactionResult!.fileId;
@@ -1575,47 +1561,6 @@ export class EthImpl implements Eth {
         this.hapiService
           .getSDKClient()
           .deleteFile(fileId, requestIdPrefix, EthImpl.ethSendRawTransaction, fileId.toString());
-      }
-    }
-  }
-
-  /**
-   * Sends a raw transaction with retry logic.
-   *
-   * @template T The type of the result returned by the sendRawTransaction function.
-   * @param {Function} sendRawTransaction The function responsible for sending the raw transaction.
-   * @param {object} options The options for retrying the transaction.
-   * @param {number} [options.maxAttempts=2] The maximum number of attempts to send the transaction.
-   * @param {number} [options.backOff=500] The backoff period in milliseconds between retry attempts.
-   * @param {(error: unknown) => boolean} [options.canRetry=(error) => true] A function that determines whether a retry attempt can be made based on the error received.
-   * @param {(error: SDKClientError) => void} [options.onError=(error) => {}] A function to handle errors that occur during retry attempts.
-   * @returns {Promise<T | undefined>} A promise resolving to the result of the transaction, or undefined if all retry attempts fail.
-   */
-  private async sendRawTransactionWithRetry<T>(
-    sendRawTransaction: () => Promise<T>,
-    {
-      maxAttempts = 2,
-      backOff = 500,
-      canRetry = (e: unknown) => true,
-      onError = (e: SDKClientError) => {},
-    }: {
-      maxAttempts?: number;
-      backOff?: number;
-      canRetry?: (error: unknown) => boolean;
-      onError?: (error: SDKClientError) => void;
-    },
-  ): Promise<T | undefined> {
-    const delay = async (backOff: number) => new Promise<void>((resolve) => setTimeout(resolve, backOff));
-    for (let count = 0; count < maxAttempts; count++) {
-      try {
-        return await sendRawTransaction();
-      } catch (e: unknown) {
-        if (!canRetry(e) || count === maxAttempts - 1) {
-          throw e;
-        }
-        onError(e as SDKClientError);
-        // eslint-disable-next-line no-await-in-loop
-        await delay(backOff);
       }
     }
   }

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -187,25 +187,6 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       sinon.assert.calledOnce(sdkClientStub.submitEthereumTransaction);
     });
 
-    it('should send second transaction upon time out', async function () {
-      restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
-
-      sdkClientStub.submitEthereumTransaction.onCall(0).throws(new SDKClientError({ status: 21 }, 'timeout exceeded'));
-
-      sdkClientStub.submitEthereumTransaction.onCall(1).returns({
-        txResponse: {
-          transactionId: TransactionId.fromString(transactionIdServicesFormat),
-        },
-        fileId: null,
-      });
-
-      const signed = await signTransaction(transaction);
-
-      const resultingHash = await ethImpl.sendRawTransaction(signed, getRequestId());
-      expect(resultingHash).to.equal(ethereumHash);
-      sinon.assert.calledTwice(sdkClientStub.submitEthereumTransaction);
-    });
-
     it('should not send second transaction on error different from timeout', async function () {
       sdkClientStub.submitEthereumTransaction
         .onCall(0)

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -39,6 +39,7 @@ import {
   isHex,
   ASCIIToHex,
   formatRequestIdMessage,
+  strip0x,
 } from '../../src/formatters';
 import constants from '../../src/lib/constants';
 import { BigNumber as BN } from 'bignumber.js';
@@ -90,6 +91,10 @@ describe('Formatters', () => {
       for (let i = 0; i < inputs.length; i++) {
         expect(decodeErrorMessage(inputs[i])).to.eq(outputs[i]);
       }
+    });
+
+    it('should return empty string when we dont pass params', async function () {
+      expect(decodeErrorMessage()).to.equal('');
     });
   });
 
@@ -325,6 +330,16 @@ describe('Formatters', () => {
       const formattedResult: any = formatContractResult({ ...contractResult, chain_id: '0x' });
       expect(formattedResult.chainId).to.be.undefined;
     });
+
+    it('Should return legacy EIP155 transaction when null type', () => {
+      const formattedResult: any = formatContractResult({ ...contractResult, type: null });
+      expect(formattedResult.type).to.be.eq('0x0');
+    });
+
+    it('Should return null when contract result type is undefined', async function () {
+      const formattedResult = formatContractResult({ ...contractResult, type: undefined });
+      expect(formattedResult).to.be.null;
+    });
   });
 
   describe('prepend0x', () => {
@@ -504,6 +519,7 @@ describe('Formatters', () => {
       expect(isValidEthereumAddress(address)).to.equal(false);
     });
   });
+
   describe('isHex Function', () => {
     it('should return true for valid lowercase hexadecimal string', () => {
       expect(isHex('0x1a3f')).to.be.true;
@@ -541,6 +557,7 @@ describe('Formatters', () => {
       expect(isHex('0x58')).to.be.true;
     });
   });
+
   describe('ASCIIToHex Function', () => {
     const inputs = ['Lorem Ipsum', 'Foo', 'Bar'];
     const outputs = ['4c6f72656d20497073756d', '466f6f', '426172'];
@@ -561,6 +578,38 @@ describe('Formatters', () => {
       for (let i = 0; i < inputs.length; i++) {
         expect(ASCIIToHex(inputs[i])).to.eq(outputs[i]);
       }
+    });
+  });
+
+  describe('strip0x', () => {
+    it('should strip "0x" from the beginning of a string', () => {
+      const input = '0x123abc';
+      const result = strip0x(input);
+      expect(result).to.equal('123abc');
+    });
+
+    it('should return the same string if it does not start with "0x"', () => {
+      const input = '123abc';
+      const result = strip0x(input);
+      expect(result).to.equal('123abc');
+    });
+
+    it('should return an empty string if input is an empty string', () => {
+      const input = '';
+      const result = strip0x(input);
+      expect(result).to.equal('');
+    });
+
+    it('should handle input that only contains "0x"', () => {
+      const input = '0x';
+      const result = strip0x(input);
+      expect(result).to.equal('');
+    });
+
+    it('should not modify a string that contains "0x" not at the start', () => {
+      const input = '1230xabc';
+      const result = strip0x(input);
+      expect(result).to.equal('1230xabc');
     });
   });
 });


### PR DESCRIPTION
**Description**:
This PR aims to remove redundant logic in the eth_sendRawTransaction, which was responsible for retyring transaction if timeout error occurs. However the underlying problem in the SDK was fixed, therefore this is no longer needed. Removing it to increase readability and maintainability mostly.

Also removed unused methods in the formatter class and added some additional unit tests.

**Related issue(s)**:

Fixes #2794 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
