### PR TITLE
fix: stabilized sdkClient test by bumping total timeout to 30000ms

### DIFF
--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -63,7 +63,7 @@ const registry = new Registry();
 const logger = pino();
 
 describe('SdkClient', async function () {
-  this.timeout(20000);
+  this.timeout(30000);
 
   let client: Client;
   let mock: MockAdapter;

--- a/packages/relay/tests/lib/services/transactionService/transactionService.spec.ts
+++ b/packages/relay/tests/lib/services/transactionService/transactionService.spec.ts
@@ -153,6 +153,11 @@ describe('Transaction Service', function () {
     mock = new MockAdapter(instance);
   });
 
+  afterEach(() => {
+    sinon.restore();
+    mock.restore();
+  });
+
   describe('getTransactionStatusAndMetrics', () => {
     it('Should execute getTransactionStatusAndMetrics() and redirect calls to MIRROR NODE client', async () => {
       process.env.GET_RECORD_DEFAULT_TO_CONSENSUS_NODE = 'false';


### PR DESCRIPTION
**Description**:
 -stabilized sdkClient test by bumping total timeout to 30000ms

**Related issue(s)**:

Fixes #2816 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
