### PR TITLE
fix: `eth_estimateGas` opts to fallback estimation for contract revert

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -33,12 +33,20 @@ export class JsonRpcError {
 }
 
 export const predefined = {
-  CONTRACT_REVERT: (errorMessage?: string, data: string = '') =>
-    new JsonRpcError({
+  CONTRACT_REVERT: (errorMessage?: string, data: string = '') => {
+    let message: string;
+    if (errorMessage?.length) {
+      message = `execution reverted: ${decodeErrorMessage(errorMessage)}`;
+    } else {
+      const decodedData = decodeErrorMessage(data);
+      message = decodedData.length ? `execution reverted: ${decodedData}` : 'execution reverted';
+    }
+    return new JsonRpcError({
       code: 3,
-      message: `execution reverted: ${decodeErrorMessage(errorMessage)}`,
-      data: data,
-    }),
+      message,
+      data,
+    });
+  },
   GAS_LIMIT_TOO_HIGH: (gasLimit, maxGas) =>
     new JsonRpcError({
       code: -32005,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -601,12 +601,17 @@ export class EthImpl implements Eth {
         this.logger.info(`${requestIdPrefix} Returning gas: ${response.result}`);
         return prepend0x(trimPrecedingZeros(response.result));
       } else {
+        this.logger.error(`${requestIdPrefix} No gas estimate returned from mirror-node: ${JSON.stringify(response)}`);
         return this.predefinedGasForTransaction(transaction, requestIdPrefix);
       }
     } catch (e: any) {
       this.logger.error(
         `${requestIdPrefix} Error raised while fetching estimateGas from mirror-node: ${JSON.stringify(e)}`,
       );
+      // in case of contract revert, we don't want to return a predefined gas but the actual error with the reason
+      if (e instanceof MirrorNodeClientError && e.isContractReverted()) {
+        return predefined.CONTRACT_REVERT(e.detail || e.message, e.data);
+      }
       return this.predefinedGasForTransaction(transaction, requestIdPrefix, e);
     }
   }

--- a/packages/relay/tests/lib/errors/JsonRpcError.spec.ts
+++ b/packages/relay/tests/lib/errors/JsonRpcError.spec.ts
@@ -19,7 +19,8 @@
  */
 
 import { expect } from 'chai';
-import { JsonRpcError } from '../../../src/lib/errors/JsonRpcError';
+import { JsonRpcError, predefined } from '../../../src';
+import { AbiCoder, keccak256 } from 'ethers';
 
 describe('Errors', () => {
   describe('JsonRpcError', () => {
@@ -49,6 +50,85 @@ describe('Errors', () => {
       expect(err.data).to.eq('some data');
       // Check that request ID is prefixed
       expect(err.message).to.eq('[Request ID: abcd-1234] test error: foo');
+    });
+
+    describe('predefined.CONTRACT_REVERT', () => {
+      const defaultErrorSignature = keccak256(Buffer.from('Error(string)')).slice(0, 10); // 0x08c379a0
+      const customErrorSignature = keccak256(Buffer.from('CustomError(string)')).slice(0, 10); // 0x8d6ea8be
+      const decodedMessage = 'Some error message';
+      const encodedMessage = new AbiCoder().encode(['string'], [decodedMessage]).replace('0x', '');
+      const encodedCustomError = customErrorSignature + encodedMessage;
+      const encodedDefaultError = defaultErrorSignature + encodedMessage;
+
+      it('Returns decoded message when decoded message is provided as errorMessage and encoded default error is provided as data', () => {
+        const error = predefined.CONTRACT_REVERT(decodedMessage, encodedDefaultError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when decoded message is provided as errorMessage and encoded custom error is provided as data', () => {
+        const error = predefined.CONTRACT_REVERT(decodedMessage, encodedCustomError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when encoded default error is provided as errorMessage and data', () => {
+        const error = predefined.CONTRACT_REVERT(encodedDefaultError, encodedDefaultError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when encoded custom error is provided as errorMessage and data', () => {
+        const error = predefined.CONTRACT_REVERT(encodedCustomError, encodedCustomError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when decoded errorMessage is provided', () => {
+        const error = predefined.CONTRACT_REVERT(decodedMessage);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when encoded default error is provided as errorMessage', () => {
+        const error = predefined.CONTRACT_REVERT(encodedDefaultError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when encoded custom error is provided as errorMessage', () => {
+        const error = predefined.CONTRACT_REVERT(encodedCustomError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when encoded default error is provided as data', () => {
+        const error = predefined.CONTRACT_REVERT(undefined, encodedDefaultError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when encoded custom error is provided as data', () => {
+        const error = predefined.CONTRACT_REVERT(undefined, encodedCustomError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when message is empty and encoded default error is provided as data', () => {
+        const error = predefined.CONTRACT_REVERT('', encodedDefaultError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns decoded message when message is empty and encoded custom error is provided as data', () => {
+        const error = predefined.CONTRACT_REVERT('', encodedCustomError);
+        expect(error.message).to.eq(`execution reverted: ${decodedMessage}`);
+      });
+
+      it('Returns default message when errorMessage is empty', () => {
+        const error = predefined.CONTRACT_REVERT('');
+        expect(error.message).to.eq('execution reverted');
+      });
+
+      it('Returns default message when data is empty', () => {
+        const error = predefined.CONTRACT_REVERT(undefined, '');
+        expect(error.message).to.eq('execution reverted');
+      });
+
+      it('Returns default message when neither errorMessage nor data is provided', () => {
+        const error = predefined.CONTRACT_REVERT();
+        expect(error.message).to.eq('execution reverted');
+      });
     });
   });
 });

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -44,6 +44,7 @@ import {
 } from '../../src/formatters';
 import constants from '../../src/lib/constants';
 import { BigNumber as BN } from 'bignumber.js';
+import { AbiCoder, keccak256 } from 'ethers';
 
 describe('Formatters', () => {
   describe('formatRequestIdMessage', () => {
@@ -639,6 +640,17 @@ describe('Formatters', () => {
         const hexErrorMessage =
           '0x08c379a000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000';
         expect(decodeErrorMessage(hexErrorMessage)).to.equal('');
+      });
+
+      it('should return empty string for custom error message without parameters', () => {
+        expect(decodeErrorMessage('0x858d70bd')).to.equal('');
+      });
+
+      it('should return the message of custom error with string parameter', () => {
+        const signature = keccak256(Buffer.from('CustomError(string)')).slice(0, 10); // 0x8d6ea8be
+        const message = new AbiCoder().encode(['string'], ['Some error message']).replace('0x', '');
+        const hexErrorMessage = signature + message;
+        expect(decodeErrorMessage(hexErrorMessage)).to.equal('Some error message');
       });
     });
   });


### PR DESCRIPTION
**Description**:

This PR modifies the `EthImpl` class to improve error handling for gas estimation.
* Add logic to return `predefined.CONTRACT_REVERT` JSON-RPC error with the revert reason in case of contract revert
* Extend `predefined.CONTRACT_REVERT` to cover more edge cases when decoding error messages
* Extend tests for `decodeErrorMessage` and `predefined.CONTRACT_REVERT`

**Related issue(s)**:

Fixes #2830 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)