### PR TITLE
fix: error thrown when setting value in redis cache

### DIFF
--- a/packages/relay/src/lib/clients/cache/redisCache.ts
+++ b/packages/relay/src/lib/clients/cache/redisCache.ts
@@ -150,9 +150,9 @@ export class RedisCache implements IRedisCacheClient {
   ): Promise<void> {
     const client = await this.getConnectedClient();
     const serializedValue = JSON.stringify(value);
-    const resolvedTtl = (ttl ?? this.options.ttl) / 1000; // convert to seconds
+    const resolvedTtl = ttl ?? this.options.ttl; // in milliseconds
 
-    await client.setEx(key, resolvedTtl, serializedValue);
+    await client.set(key, serializedValue, { PX: resolvedTtl });
     this.logger.trace(`${requestIdPrefix} caching ${key}: ${serializedValue} on ${callingMethod} for ${resolvedTtl} s`);
     // TODO: add metrics
   }
@@ -201,13 +201,13 @@ export class RedisCache implements IRedisCacheClient {
     requestIdPrefix?: string,
   ): Promise<void> {
     const client = await this.getConnectedClient();
-    const resolvedTtl = (ttl ?? this.options.ttl) / 1000; // convert to seconds
+    const resolvedTtl = ttl ?? this.options.ttl; // in milliseconds
 
     const pipeline = client.multi();
 
     for (const [key, value] of Object.entries(keyValuePairs)) {
       const serializedValue = JSON.stringify(value);
-      pipeline.setEx(key, resolvedTtl, serializedValue);
+      pipeline.set(key, serializedValue, { PX: resolvedTtl });
     }
 
     // Execute pipeline operation

--- a/packages/relay/tests/lib/clients/redisCache.spec.ts
+++ b/packages/relay/tests/lib/clients/redisCache.spec.ts
@@ -42,11 +42,6 @@ describe('RedisCache Test Suite', async function () {
     redisCache = new RedisCache(logger.child({ name: `cache` }), registry);
   });
 
-  this.beforeEach(() => {
-    mock.stub(redisCache, 'set').returns(true);
-    mock.stub(redisCache, 'delete').returns(true);
-  });
-
   this.afterEach(() => {
     mock.restore();
   });
@@ -58,7 +53,6 @@ describe('RedisCache Test Suite', async function () {
 
   describe('Get and Set Test Suite', async function () {
     it('should get null on empty cache', async function () {
-      mock.stub(redisCache, 'get').returns(null);
       const cacheValue = await redisCache.get('test', callingMethod);
       expect(cacheValue).to.be.null;
     });
@@ -67,7 +61,6 @@ describe('RedisCache Test Suite', async function () {
       const key = 'int';
       const value = 1;
 
-      mock.stub(redisCache, 'get').returns(value);
       await redisCache.set(key, value, callingMethod);
 
       const cachedValue = await redisCache.get(key, callingMethod);
@@ -78,7 +71,6 @@ describe('RedisCache Test Suite', async function () {
       const key = 'boolean';
       const value = false;
 
-      mock.stub(redisCache, 'get').returns(value);
       await redisCache.set(key, value, callingMethod);
 
       const cachedValue = await redisCache.get(key, callingMethod);
@@ -89,22 +81,52 @@ describe('RedisCache Test Suite', async function () {
       const key = 'array';
       const value = ['false'];
 
-      mock.stub(redisCache, 'get').returns(value);
       await redisCache.set(key, value, callingMethod);
 
       const cachedValue = await redisCache.get(key, callingMethod);
-      expect(cachedValue).equal(value);
+      expect(cachedValue).deep.equal(value);
     });
 
     it('should get valid object cache', async function () {
       const key = 'object';
       const value = { result: true };
 
-      mock.stub(redisCache, 'get').returns(value);
       await redisCache.set(key, value, callingMethod);
 
       const cachedValue = await redisCache.get(key, callingMethod);
+      expect(cachedValue).deep.equal(value);
+    });
+
+    it('should be able to set cache with TTL less than 1000 milliseconds', async () => {
+      const key = 'int';
+      const value = 1;
+      const ttl = 500;
+
+      await redisCache.set(key, value, callingMethod, ttl);
+
+      const cachedValue = await redisCache.get(key, callingMethod);
       expect(cachedValue).equal(value);
+
+      await new Promise((resolve) => setTimeout(resolve, ttl));
+
+      const expiredValue = await redisCache.get(key, callingMethod);
+      expect(expiredValue).to.be.null;
+    });
+
+    it('should be able to set cache with TTL greater than 1000 milliseconds', async () => {
+      const key = 'int';
+      const value = 1;
+      const ttl = 1500;
+
+      await redisCache.set(key, value, callingMethod, ttl);
+
+      const cachedValue = await redisCache.get(key, callingMethod);
+      expect(cachedValue).equal(value);
+
+      await new Promise((resolve) => setTimeout(resolve, ttl));
+
+      const expiredValue = await redisCache.get(key, callingMethod);
+      expect(expiredValue).to.be.null;
     });
   });
 
@@ -116,7 +138,6 @@ describe('RedisCache Test Suite', async function () {
       await redisCache.set(key, value, callingMethod);
       await redisCache.delete(key, callingMethod);
 
-      mock.stub(redisCache, 'get').returns(null);
       const cachedValue = await redisCache.get(key, callingMethod);
       expect(cachedValue).to.be.null;
     });
@@ -128,7 +149,6 @@ describe('RedisCache Test Suite', async function () {
       await redisCache.set(key, value, callingMethod);
       await redisCache.delete(key, callingMethod);
 
-      mock.stub(redisCache, 'get').returns(null);
       const cachedValue = await redisCache.get(key, callingMethod);
       expect(cachedValue).to.be.null;
     });
@@ -140,7 +160,6 @@ describe('RedisCache Test Suite', async function () {
       await redisCache.set(key, value, callingMethod);
       await redisCache.delete(key, callingMethod);
 
-      mock.stub(redisCache, 'get').returns(null);
       const cachedValue = await redisCache.get(key, callingMethod);
       expect(cachedValue).to.be.null;
     });
@@ -152,7 +171,6 @@ describe('RedisCache Test Suite', async function () {
       await redisCache.set(key, value, callingMethod);
       await redisCache.delete(key, callingMethod);
 
-      mock.stub(redisCache, 'get').returns(null);
       const cachedValue = await redisCache.get(key, callingMethod);
       expect(cachedValue).to.be.null;
     });

--- a/packages/relay/tests/lib/clients/redisCache.spec.ts
+++ b/packages/relay/tests/lib/clients/redisCache.spec.ts
@@ -166,6 +166,30 @@ describe('RedisCache Test Suite', async function () {
         expect(cachedValue).deep.equal(keyValuePairs[key]);
       }
     });
+
+    it('should set multiple key-value pairs in cache with TTL', async function () {
+      const keyValuePairs = {
+        int: 1,
+        string: 'test',
+        boolean: false,
+        array: ['false'],
+        object: { result: true },
+      };
+
+      await redisCache.pipelineSet(keyValuePairs, callingMethod, 500);
+
+      for (const key in keyValuePairs) {
+        const cachedValue = await redisCache.get(key, callingMethod);
+        expect(cachedValue).deep.equal(keyValuePairs[key]);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      for (const key in keyValuePairs) {
+        const expiredValue = await redisCache.get(key, callingMethod);
+        expect(expiredValue).to.be.null;
+      }
+    });
   });
 
   describe('Delete Test Suite', async function () {

--- a/packages/relay/tests/lib/clients/redisCache.spec.ts
+++ b/packages/relay/tests/lib/clients/redisCache.spec.ts
@@ -130,6 +130,44 @@ describe('RedisCache Test Suite', async function () {
     });
   });
 
+  describe('MultiSet Test Suite', async function () {
+    it('should set multiple key-value pairs in cache', async function () {
+      const keyValuePairs = {
+        int: 1,
+        string: 'test',
+        boolean: false,
+        array: ['false'],
+        object: { result: true },
+      };
+
+      await redisCache.multiSet(keyValuePairs, callingMethod);
+
+      for (const key in keyValuePairs) {
+        const cachedValue = await redisCache.get(key, callingMethod);
+        expect(cachedValue).deep.equal(keyValuePairs[key]);
+      }
+    });
+  });
+
+  describe('PipelineSet Test Suite', async function () {
+    it('should set multiple key-value pairs in cache', async function () {
+      const keyValuePairs = {
+        int: 1,
+        string: 'test',
+        boolean: false,
+        array: ['false'],
+        object: { result: true },
+      };
+
+      await redisCache.pipelineSet(keyValuePairs, callingMethod);
+
+      for (const key in keyValuePairs) {
+        const cachedValue = await redisCache.get(key, callingMethod);
+        expect(cachedValue).deep.equal(keyValuePairs[key]);
+      }
+    });
+  });
+
   describe('Delete Test Suite', async function () {
     it('should delete int cache', async function () {
       const key = 'int';


### PR DESCRIPTION
**Description**:

```bash
ERROR (cache-service/7325): Error occurred while setting the cache to Redis. Fallback to internal cache. Error is: Error: ERR value is not an integer or out of range
```

This error is appearing multiple times in the logs of multiple workflows in the CI, right after doing the getAccount query from the mirror node.

After doing some investigation, it looks like when we transform the passed TTL to seconds, it was possible that we get a floating point number (`ETH_GET_TRANSACTION_COUNT_CACHE_TTL: 500`) => which resolves to `resolvedTtl = 0.5`
```typescript
const resolvedTtl = (ttl ?? this.options.ttl) / 1000; // convert to seconds
```

And the `setEx` method of Redis expects an integer, hence why this error is thrown.

This PR:
- modifies the `RedisCache#set` method to use `set` (with `PX` option which allows us to directly pass milliseconds as argument for TTL) instead of using `setEx` to avoid this issue.

**Related issue(s)**:

Fixes #2838

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
