### PR TITLE
fix: Bump timeout up due to many test runs timing out in the current CI

### DIFF
--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -15,7 +15,7 @@ jobs:
   setup-local-hedera:
     name: Dapp Tests
     runs-on: [self-hosted, Linux, medium, ephemeral]
-    timeout-minutes: 35 # Set to 35 minutes for now
+    timeout-minutes: 45 # Set to 45 minutes for now
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Bumped up Dapp test timeout as many test runs are now timing out on the current runners.



**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
