### PR TITLE
docs: Add class diagram for the database schema of the hbar limiter redesign

### DIFF
--- a/docs/design/hbar-limiter.md
+++ b/docs/design/hbar-limiter.md
@@ -78,6 +78,7 @@ classDiagram
         -ipAddressHbarSpendingPlanRepository: IpAddressHbarSpendingPlanRepository
         +shouldLimit(txFrom: string, ip?: string) boolean
         +resetLimiter() void
+        +addExpense(amount: number, txFrom: string, ip?: string) void
         -getSpendingPlanOfEthAddress(address: string): HbarSpendingPlan
         -getSpendingPlanOfIpAddress(ip: string): HbarSpendingPlan
         -checkTotalSpent() boolean
@@ -88,6 +89,7 @@ classDiagram
     <<interface>> IHBarLimitService
     IHBarLimitService : shouldLimit() boolean
     IHBarLimitService : resetLimiter() void
+    IHBarLimitService : addExpense() void
 
     SdkClient --> MetricService : uses
     SdkClient --> IHBarLimitService : uses


### PR DESCRIPTION
**Description**:

This PR adds a class diagram to the documentation for the database schema of the Hbar Limiter redesign. The diagram provides a visual representation of the classes and their relationships, which are used to manage Hbar spending plans and records.

**Changes**:
- `docs/design/hbar-limiter.md`:
  - Wrapped the current diagram into a "Service Layer" section
  - Added a new "Database Layer" section with a class diagram for the DB entities + repositories

**Checklist**

- [x] Documented (Code comments, README, etc.)
