### PR TITLE
feat: Implement `shouldLimit` method of `HbarLimitService`

### DIFF
--- a/packages/relay/src/lib/services/hbarLimitService/IHbarLimitService.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/IHbarLimitService.ts
@@ -1,0 +1,36 @@
+/*
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+export interface IHbarLimitService {
+  /**
+   * Resets the Hbar limiter.
+   */
+  resetLimiter(): Promise<void>;
+
+  /**
+   * Determines if the Hbar limit should be applied based on the provided Ethereum address
+   * and optionally an IP address.
+   *
+   * @param {string} ethAddress - The Ethereum address to check.
+   * @param {string} [ipAddress] - The optional IP address to check.
+   * @returns {Promise<boolean>} - True if the limit should be applied, false otherwise.
+   */
+  shouldLimit(ethAddress: string, ipAddress?: string): Promise<boolean>;
+}

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -58,7 +58,7 @@ export class HbarLimitService implements IHbarLimitService {
       try {
         return await this.getSpendingPlanByEthAddress(ethAddress);
       } catch (error) {
-        this.logger.error(error);
+        this.logger.warn(error, `Failed to get spending plan for eth address '${ethAddress}'`);
       }
     }
     if (ipAddress) {

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -1,0 +1,80 @@
+/*
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { IHbarLimitService } from './IHbarLimitService';
+import { HbarLimitPlanRepository } from '../../db/repositories/hbarLimiter/HbarLimitPlanRepository';
+import { EthAddressPlanRepository } from '../../db/repositories/hbarLimiter/EthAddressPlanRepository';
+import { IDetailedHbarSpendingPlan } from '../../db/types/hbarLimiter/hbarSpendingPlan';
+import { SubscriptionType } from '../../db/types/hbarLimiter/subscriptionType';
+import { Logger } from 'pino';
+
+export class HbarLimitService implements IHbarLimitService {
+  // TODO: Replace with actual values
+  private static readonly DAILY_LIMITS: Record<SubscriptionType, number> = {
+    BASIC: parseInt(process.env.HBAR_DAILY_LIMIT_BASIC ?? '1000'),
+    EXTENDED: parseInt(process.env.HBAR_DAILY_LIMIT_EXTENDED ?? '10000'),
+    PRIVILEGED: parseInt(process.env.HBAR_DAILY_LIMIT_PRIVILEGED ?? '100000'),
+  };
+
+  constructor(
+    private readonly hbarSpendingPlanRepository: HbarLimitPlanRepository,
+    private readonly ethAddressHbarSpendingPlanRepository: EthAddressPlanRepository,
+    private readonly logger: Logger,
+  ) {}
+
+  async resetLimiter(): Promise<void> {
+    // TODO: Implement this
+    throw new Error('Not implemented');
+  }
+
+  async shouldLimit(ethAddress: string, ipAddress?: string): Promise<boolean> {
+    let spendingPlan = await this.getSpendingPlan(ethAddress, ipAddress);
+    if (!spendingPlan) {
+      // Create a basic spending plan if none exists for the eth address or ip address
+      spendingPlan = await this.createBasicSpendingPlan(ethAddress);
+    }
+    return spendingPlan.spentToday >= HbarLimitService.DAILY_LIMITS[spendingPlan.subscriptionType];
+  }
+
+  private async getSpendingPlan(ethAddress: string, ipAddress?: string): Promise<IDetailedHbarSpendingPlan | null> {
+    if (ethAddress) {
+      try {
+        return await this.getSpendingPlanByEthAddress(ethAddress);
+      } catch (error) {
+        this.logger.error(error);
+      }
+    }
+    if (ipAddress) {
+      // TODO: Implement this
+    }
+    return null;
+  }
+
+  private async getSpendingPlanByEthAddress(ethAddress: string): Promise<IDetailedHbarSpendingPlan> {
+    const ethAddressPlan = await this.ethAddressHbarSpendingPlanRepository.findByAddress(ethAddress);
+    return this.hbarSpendingPlanRepository.findByIdWithDetails(ethAddressPlan.planId);
+  }
+
+  private async createBasicSpendingPlan(ethAddress: string): Promise<IDetailedHbarSpendingPlan> {
+    const spendingPlan = await this.hbarSpendingPlanRepository.create(SubscriptionType.BASIC);
+    await this.ethAddressHbarSpendingPlanRepository.save({ ethAddress, planId: spendingPlan.id });
+    return spendingPlan;
+  }
+}

--- a/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
+++ b/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
@@ -1,0 +1,119 @@
+/*
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { HbarLimitService } from '../../../../src/lib/services/hbarLimitService';
+import { HbarLimitPlanRepository } from '../../../../src/lib/db/repositories/hbarLimiter/HbarLimitPlanRepository';
+import { EthAddressPlanRepository } from '../../../../src/lib/db/repositories/hbarLimiter/EthAddressPlanRepository';
+import pino from 'pino';
+import { SubscriptionType } from '../../../../src/lib/db/types/hbarLimiter/subscriptionType';
+import { EthAddressPlanNotFoundError } from '../../../../src/lib/db/types/hbarLimiter/errors';
+import { HbarSpendingPlan } from '../../../../src/lib/db/entities/hbarLimiter/hbarSpendingPlan';
+
+describe('HbarLimitService', function () {
+  const logger = pino();
+  let hbarLimitService: HbarLimitService;
+  let hbarSpendingPlanRepositoryStub: sinon.SinonStubbedInstance<HbarLimitPlanRepository>;
+  let ethAddressHbarSpendingPlanRepositoryStub: sinon.SinonStubbedInstance<EthAddressPlanRepository>;
+
+  beforeEach(function () {
+    hbarSpendingPlanRepositoryStub = sinon.createStubInstance(HbarLimitPlanRepository);
+    ethAddressHbarSpendingPlanRepositoryStub = sinon.createStubInstance(EthAddressPlanRepository);
+    hbarLimitService = new HbarLimitService(
+      hbarSpendingPlanRepositoryStub,
+      ethAddressHbarSpendingPlanRepositoryStub,
+      logger,
+    );
+  });
+
+  it('should return true if the limit should be applied based on ethAddress', async function () {
+    const ethAddress = '0x123';
+    const spendingPlan = new HbarSpendingPlan({
+      id: 'plan1',
+      subscriptionType: SubscriptionType.BASIC,
+      createdAt: new Date(),
+      active: true,
+      spendingHistory: [],
+      spentToday: 1000,
+    });
+    ethAddressHbarSpendingPlanRepositoryStub.findByAddress.resolves({ ethAddress, planId: 'plan1' });
+    hbarSpendingPlanRepositoryStub.findByIdWithDetails.resolves(spendingPlan);
+
+    const result = await hbarLimitService.shouldLimit(ethAddress);
+
+    expect(result).to.be.true;
+  });
+
+  it('should return false if the limit should not be applied based on ethAddress', async function () {
+    const ethAddress = '0x123';
+    const spendingPlan = new HbarSpendingPlan({
+      id: 'plan1',
+      subscriptionType: SubscriptionType.BASIC,
+      createdAt: new Date(),
+      active: true,
+      spendingHistory: [],
+      spentToday: 500,
+    });
+    ethAddressHbarSpendingPlanRepositoryStub.findByAddress.resolves({ ethAddress, planId: 'plan1' });
+    hbarSpendingPlanRepositoryStub.findByIdWithDetails.resolves(spendingPlan);
+
+    const result = await hbarLimitService.shouldLimit(ethAddress);
+
+    expect(result).to.be.false;
+  });
+
+  it('should create a basic spending plan if none exists for the ethAddress', async function () {
+    const newSpendingPlan = new HbarSpendingPlan({
+      id: 'plan1',
+      subscriptionType: SubscriptionType.BASIC,
+      createdAt: new Date(),
+      active: true,
+      spendingHistory: [],
+      spentToday: 0,
+    });
+    const ethAddress = '0x123';
+    const error = new EthAddressPlanNotFoundError(ethAddress);
+    ethAddressHbarSpendingPlanRepositoryStub.findByAddress.rejects(error);
+    hbarSpendingPlanRepositoryStub.create.resolves(newSpendingPlan);
+    ethAddressHbarSpendingPlanRepositoryStub.save.resolves();
+    const warnSpy = sinon.spy(logger, 'warn');
+
+    const result = await hbarLimitService.shouldLimit(ethAddress);
+
+    expect(result).to.be.false;
+    expect(hbarSpendingPlanRepositoryStub.create.calledOnce).to.be.true;
+    expect(ethAddressHbarSpendingPlanRepositoryStub.save.calledOnce).to.be.true;
+    expect(
+      warnSpy.calledWithMatch(
+        sinon.match.instanceOf(EthAddressPlanNotFoundError),
+        `Failed to get spending plan for eth address '${ethAddress}'`,
+      ),
+    ).to.be.true;
+  });
+
+  it('should throw an error when resetLimiter is called', async function () {
+    try {
+      await hbarLimitService.resetLimiter();
+    } catch (error: any) {
+      expect(error.message).to.equal('Not implemented');
+    }
+  });
+});


### PR DESCRIPTION
**Description**:

Adds a skeleton for the `HbarLimitService` and implements the `shouldLimit` method.

**NOTE:** IP address limiting will be handled in a separate PR after #2867 is merged

**Related issue(s)**:

Fixes #2865

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
