### PR TITLE
feat: improved preemtive rate limit for file transactions

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -911,14 +911,15 @@ export class MirrorNodeClient {
     return { limit: limit, order: order };
   }
 
-  public async getNetworkExchangeRate(timestamp?: string, requestIdPrefix?: string) {
+  public async getNetworkExchangeRate(requestId: string, timestamp?: string) {
+    const formattedRequestId = formatRequestIdMessage(requestId);
     const queryParamObject = {};
     this.setQueryParam(queryParamObject, 'timestamp', timestamp);
     const queryParams = this.getQueryParams(queryParamObject);
     return this.get(
       `${MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT}${queryParams}`,
       MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT,
-      requestIdPrefix,
+      formattedRequestId,
     );
   }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -381,6 +381,7 @@ export class SDKClient {
     callerName: string,
     requestId: string,
     originalCallerAddress: string,
+    currentNetworkExchangeRateInCents: number,
   ): Promise<{ txResponse: TransactionResponse; fileId: FileId | null }> {
     const ethereumTransactionData: EthereumTransactionData = EthereumTransactionData.fromBytes(transactionBuffer);
     const ethereumTransaction = new EthereumTransaction();
@@ -395,10 +396,11 @@ export class SDKClient {
       const isPreemtiveCheckOn = process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK === 'true';
 
       if (isPreemtiveCheckOn) {
-        this.hbarLimiter.shouldPreemtivelyLimit(
+        this.hbarLimiter.shouldPreemtivelyLimitFileTransactions(
           originalCallerAddress,
           ethereumTransactionData.toString().length,
           this.fileAppendChunkSize,
+          currentNetworkExchangeRateInCents,
           requestId,
         );
       }
@@ -1023,7 +1025,7 @@ export class SDKClient {
   public calculateTxRecordChargeAmount(exchangeRate: ExchangeRate): number {
     const exchangeRateInCents = exchangeRate.exchangeRateInCents;
     const hbarToTinybar = Hbar.from(1, HbarUnit.Hbar).toTinybars().toNumber();
-    return Math.round((constants.TX_RECORD_QUERY_COST_IN_CENTS / exchangeRateInCents) * hbarToTinybar);
+    return Math.round((constants.NETWORK_FEES_IN_CENTS.TRANSACTION_GET_RECORD / exchangeRateInCents) * hbarToTinybar);
   }
 
   /**

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -397,7 +397,7 @@ export class SDKClient {
       if (isPreemtiveCheckOn) {
         this.hbarLimiter.shouldPreemtivelyLimit(
           originalCallerAddress,
-          ethereumTransactionData.callData.length,
+          ethereumTransactionData.toString().length,
           this.fileAppendChunkSize,
           requestId,
         );

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -189,8 +189,13 @@ export default {
   // computed hash of an empty Trie object
   DEFAULT_ROOT_HASH: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 
-  // @source: https://docs.hedera.com/hedera/networks/mainnet/fees
-  TX_RECORD_QUERY_COST_IN_CENTS: 0.01,
+  // note: The maximum fileAppendChunkSize is currently set to 5KB by default; therefore, the estimated fees for FileCreate and FileAppend below are based on a file size of 5KB.
+  // The fee is calculated via the fee calculator: https://docs.hedera.com/hedera/networks/mainnet/fees
+  NETWORK_FEES_IN_CENTS: {
+    TRANSACTION_GET_RECORD: 0.01,
+    FILE_CREATE_PER_5_KB: 9.51,
+    FILE_APPEND_PER_5_KB: 9.55,
+  },
 
   EVENTS: {
     EXECUTE_TRANSACTION: 'execute_transaction',

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -877,7 +877,28 @@ export const defaultErrorMessageHex =
   '0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d53657420746f2072657665727400000000000000000000000000000000000000';
 
 export const calculateTxRecordChargeAmount = (exchangeRateIncents: number) => {
-  const txQueryCostInCents = constants.TX_RECORD_QUERY_COST_IN_CENTS;
+  const txQueryCostInCents = constants.NETWORK_FEES_IN_CENTS.TRANSACTION_GET_RECORD;
   const hbarToTinybar = Hbar.from(1, HbarUnit.Hbar).toTinybars().toNumber();
   return Math.round((txQueryCostInCents / exchangeRateIncents) * hbarToTinybar);
+};
+
+export const estimateFileTransactionsFee = (
+  callDataSize: number,
+  fileChunkSize: number,
+  exchangeRateInCents: number,
+) => {
+  const numFileCreateTxs = 1;
+  const numFileAppendTxs = Math.floor(callDataSize / fileChunkSize);
+  const fileCreateFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_CREATE_PER_5_KB;
+  const fileAppendFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_PER_5_KB;
+
+  const hbarToTinybar = Hbar.from(1, HbarUnit.Hbar).toTinybars().toNumber();
+  const totalRequestFeeInCents = numFileCreateTxs * fileCreateFeeInCents + numFileAppendTxs * fileAppendFeeInCents;
+
+  const totalFeeInTinyBar = Math.round((totalRequestFeeInCents / exchangeRateInCents) * hbarToTinybar);
+  return {
+    numFileCreateTxs,
+    numFileAppendTxs,
+    totalFeeInTinyBar,
+  };
 };

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -847,7 +847,7 @@ describe('MirrorNodeClient', async function () {
 
     mock.onGet(`network/exchangerate`).reply(200, exchangerate);
 
-    const result = await mirrorNodeInstance.getNetworkExchangeRate();
+    const result = await mirrorNodeInstance.getNetworkExchangeRate(getRequestId());
     expect(result).to.exist;
     expect(result.current_rate).to.exist;
     expect(result.next_rate).to.exist;

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -934,7 +934,6 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             const expectedNonceTooLowError = predefined.NONCE_TOO_LOW(0, signerNonce);
             const errObj = JSON.parse(error.info.responseBody).error;
             expect(errObj.code).to.eq(expectedNonceTooLowError.code);
-            expect(errObj.name).to.eq(expectedNonceTooLowError.name);
             expect(errObj.message).to.contain(expectedNonceTooLowError.message);
           }
         }

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -82,7 +82,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
   const signSendAndConfirmTransaction = async (transaction, accounts, requestId) => {
     const signedTx = await accounts.wallet.signTransaction(transaction);
-    const txHash = await relay.sendRawTransaction(signedTx);
+    const txHash = await relay.sendRawTransaction(signedTx, requestId);
     await mirrorNode.get(`/contracts/results/${txHash}`, requestId);
     await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH, [txHash]);
     await new Promise((r) => setTimeout(r, 2000));


### PR DESCRIPTION
**Description**:
A preemptive rate limit was introduced as a hotfix in version 0.52.1, using a logic that preemptively rate-limited file transactions by comparing a hard-coded amount of tinybars that was assumed to be the cost for `FileCreate` and `FileAppend` transactions. However, this logic was incorrect and the tinybar amount was a random figure agreed among the team for the purposes of the hotfix.

This PR improves the rate-limiting logic by leveraging the [Hedera Fee Calculator](https://hedera.com/fee) to estimate fees for `FileCreate` and `FileAppend` transactions based on a file size of `FILE_APPEND_CHUNK_SIZE` bytes. This approach ensures the estimated fees more closely align with the actual transaction fees charged for these transactions.

**Related issue(s)**:

Fixes #2849

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
