### PR TITLE
feat: improved preemtive rate limit for file transactions

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -136,7 +136,7 @@ export interface Eth {
 
   protocolVersion(requestId?: string): JsonRpcError;
 
-  sendRawTransaction(transaction: string, requestId?: string): Promise<string | JsonRpcError>;
+  sendRawTransaction(transaction: string, requestId: string): Promise<string | JsonRpcError>;
 
   sendTransaction(requestId?: string): JsonRpcError;
 

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -912,14 +912,15 @@ export class MirrorNodeClient {
     return { limit: limit, order: order };
   }
 
-  public async getNetworkExchangeRate(timestamp?: string, requestIdPrefix?: string) {
+  public async getNetworkExchangeRate(requestId: string, timestamp?: string) {
+    const formattedRequestId = formatRequestIdMessage(requestId);
     const queryParamObject = {};
     this.setQueryParam(queryParamObject, 'timestamp', timestamp);
     const queryParams = this.getQueryParams(queryParamObject);
     return this.get(
       `${MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT}${queryParams}`,
       MirrorNodeClient.GET_NETWORK_EXCHANGERATE_ENDPOINT,
-      requestIdPrefix,
+      formattedRequestId,
     );
   }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -402,7 +402,7 @@ export class SDKClient {
       if (isPreemtiveCheckOn) {
         this.hbarLimiter.shouldPreemtivelyLimit(
           originalCallerAddress,
-          ethereumTransactionData.callData.length,
+          ethereumTransactionData.toString().length,
           this.fileAppendChunkSize,
           requestId,
         );

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -399,9 +399,9 @@ export class SDKClient {
     if (ethereumTransactionData.callData.length <= this.fileAppendChunkSize) {
       ethereumTransaction.setEthereumData(ethereumTransactionData.toBytes());
     } else {
-      const isPreemtiveCheckOn = process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK === 'true';
+      const isPreemptiveCheckOn = process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK === 'true';
 
-      if (isPreemtiveCheckOn) {
+      if (isPreemptiveCheckOn) {
         const shouldPreemptivelyLimit = this.hbarLimiter.shouldPreemptivelyLimitFileTransactions(
           originalCallerAddress,
           ethereumTransactionData.toString().length,

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -376,6 +376,7 @@ export class SDKClient {
    * @param {string} callerName - The name of the caller initiating the transaction.
    * @param {string} originalCallerAddress - The address of the original caller making the request.
    * @param {number} networkGasPriceInWeiBars - The predefined gas price of the network in weibar.
+   * @param {number} currentNetworkExchangeRateInCents - The exchange rate in cents of the current network.
    * @param {string} requestId - The unique identifier for the request.
    * @returns {Promise<{ txResponse: TransactionResponse; fileId: FileId | null }>}
    * @throws {SDKClientError} Throws an error if no file ID is created or if the preemptive fee check fails.

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -402,13 +402,17 @@ export class SDKClient {
       const isPreemtiveCheckOn = process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK === 'true';
 
       if (isPreemtiveCheckOn) {
-        this.hbarLimiter.shouldPreemtivelyLimitFileTransactions(
+        const shouldPreemptivelyLimit = this.hbarLimiter.shouldPreemptivelyLimitFileTransactions(
           originalCallerAddress,
           ethereumTransactionData.toString().length,
           this.fileAppendChunkSize,
           currentNetworkExchangeRateInCents,
           requestId,
         );
+
+        if (shouldPreemptivelyLimit) {
+          throw predefined.HBAR_RATE_LIMIT_PREEMPTIVE_EXCEEDED;
+        }
       }
 
       fileId = await this.createFile(

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -385,6 +385,7 @@ export class SDKClient {
     callerName: string,
     originalCallerAddress: string,
     networkGasPriceInWeiBars: number,
+    currentNetworkExchangeRateInCents: number,
     requestId: string,
   ): Promise<{ txResponse: TransactionResponse; fileId: FileId | null }> {
     const ethereumTransactionData: EthereumTransactionData = EthereumTransactionData.fromBytes(transactionBuffer);
@@ -400,10 +401,11 @@ export class SDKClient {
       const isPreemtiveCheckOn = process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK === 'true';
 
       if (isPreemtiveCheckOn) {
-        this.hbarLimiter.shouldPreemtivelyLimit(
+        this.hbarLimiter.shouldPreemtivelyLimitFileTransactions(
           originalCallerAddress,
           ethereumTransactionData.toString().length,
           this.fileAppendChunkSize,
+          currentNetworkExchangeRateInCents,
           requestId,
         );
       }
@@ -1030,7 +1032,7 @@ export class SDKClient {
   public calculateTxRecordChargeAmount(exchangeRate: ExchangeRate): number {
     const exchangeRateInCents = exchangeRate.exchangeRateInCents;
     const hbarToTinybar = Hbar.from(1, HbarUnit.Hbar).toTinybars().toNumber();
-    return Math.round((constants.TX_RECORD_QUERY_COST_IN_CENTS / exchangeRateInCents) * hbarToTinybar);
+    return Math.round((constants.NETWORK_FEES_IN_CENTS.TRANSACTION_GET_RECORD / exchangeRateInCents) * hbarToTinybar);
   }
 
   /**

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -402,9 +402,10 @@ export class SDKClient {
       const isPreemptiveCheckOn = process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK === 'true';
 
       if (isPreemptiveCheckOn) {
+        const hexCallDataLength = Buffer.from(ethereumTransactionData.callData).toString('hex').length;
         const shouldPreemptivelyLimit = this.hbarLimiter.shouldPreemptivelyLimitFileTransactions(
           originalCallerAddress,
-          ethereumTransactionData.toString().length,
+          hexCallDataLength,
           this.fileAppendChunkSize,
           currentNetworkExchangeRateInCents,
           requestId,

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -397,30 +397,15 @@ export class SDKClient {
     if (ethereumTransactionData.callData.length <= this.fileAppendChunkSize) {
       ethereumTransaction.setEthereumData(ethereumTransactionData.toBytes());
     } else {
-      // notice: this solution is temporary and subject to change.
-      const isPreemtiveCheckOn = process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK
-        ? process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK === 'true'
-        : false;
+      const isPreemtiveCheckOn = process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK === 'true';
 
       if (isPreemtiveCheckOn) {
-        const numFileCreateTxs = 1;
-        const numFileAppendTxs = Math.ceil(ethereumTransactionData.callData.length / this.fileAppendChunkSize);
-        const fileCreateFee = Number(process.env.HOT_FIX_FILE_CREATE_FEE || 100000000); // 1 hbar
-        const fileAppendFee = Number(process.env.HOT_FIX_FILE_APPEND_FEE || 120000000); // 1.2 hbar
-
-        const totalPreemtiveTransactionFee = numFileCreateTxs * fileCreateFee + numFileAppendTxs * fileAppendFee;
-
-        const shouldPreemtivelyLimit = this.hbarLimiter.shouldPreemtivelyLimit(
+        this.hbarLimiter.shouldPreemtivelyLimit(
           originalCallerAddress,
-          totalPreemtiveTransactionFee,
+          ethereumTransactionData.callData.length,
+          this.fileAppendChunkSize,
           requestId,
         );
-        if (shouldPreemtivelyLimit) {
-          this.logger.trace(
-            `${requestIdPrefix} The total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: numFileCreateTxs=${numFileCreateTxs}, numFileAppendTxs=${numFileAppendTxs}, totalPreemtiveTransactionFee=${totalPreemtiveTransactionFee}, callDataSize=${ethereumTransactionData.callData.length}`,
-          );
-          throw predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED;
-        }
       }
 
       fileId = await this.createFile(

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -67,6 +67,7 @@ export enum CallType {
 }
 
 export default {
+  HBAR_TO_TINYBAR_COEF: 100_000_000,
   TINYBAR_TO_WEIBAR_COEF: 10_000_000_000,
   // 131072 bytes are 128kbytes
   SEND_RAW_TRANSACTION_SIZE_LIMIT: process.env.SEND_RAW_TRANSACTION_SIZE_LIMIT

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -189,8 +189,13 @@ export default {
   // computed hash of an empty Trie object
   DEFAULT_ROOT_HASH: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 
-  // @source: https://docs.hedera.com/hedera/networks/mainnet/fees
-  TX_RECORD_QUERY_COST_IN_CENTS: 0.01,
+  // note: The maximum fileAppendChunkSize is currently set to 5KB by default; therefore, the estimated fees for FileCreate and FileAppend below are based on a file size of 5KB.
+  // The fee is calculated via the fee calculator: https://docs.hedera.com/hedera/networks/mainnet/fees
+  NETWORK_FEES_IN_CENTS: {
+    TRANSACTION_GET_RECORD: 0.01,
+    FILE_CREATE_PER_5_KB: 9.51,
+    FILE_APPEND_PER_5_KB: 9.55,
+  },
 
   EVENTS: {
     EXECUTE_TRANSACTION: 'execute_transaction',

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -191,12 +191,21 @@ export default {
   // computed hash of an empty Trie object
   DEFAULT_ROOT_HASH: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 
-  // note: The maximum fileAppendChunkSize is currently set to 5KB by default; therefore, the estimated fees for FileCreate and FileAppend below are based on a file size of 5KB.
   // The fee is calculated via the fee calculator: https://docs.hedera.com/hedera/networks/mainnet/fees
+  // The maximum fileAppendChunkSize is currently set to 5KB by default; therefore, the estimated fees for FileCreate below are based on a file size of 5KB.
+  // FILE_APPEND_BASE_FEE & FILE_APPEND_RATE_PER_BYTE are calculated based on data colelction from the fee calculator:
+  // - 0 bytes = 3.9 cents
+  // - 100 bytes = 4.01 cents = 3.9 + (100 * 0.0011)
+  // - 500 bytes = 4.45 cents = 3.9 + (500 * 0.0011)
+  // - 1000 bytes = 5.01 cents = 3.9 + (1000 * 0.0011)
+  // - 5120 bytes = 9.53 cents = 3.9 + (5120 * 0.0011)
+  // final equation: cost_in_cents = base_cost + (bytes × rate_per_byte)
   NETWORK_FEES_IN_CENTS: {
     TRANSACTION_GET_RECORD: 0.01,
     FILE_CREATE_PER_5_KB: 9.51,
     FILE_APPEND_PER_5_KB: 9.55,
+    FILE_APPEND_BASE_FEE: 3.9,
+    FILE_APPEND_RATE_PER_BYTE: 0.0011,
   },
 
   EVENTS: {

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -40,6 +40,7 @@ enum CACHE_KEY {
   RESOLVE_ENTITY_TYPE = 'resolveEntityType',
   SYNTHETIC_LOG_TRANSACTION_HASH = 'syntheticLogTransactionHash',
   FILTERID = 'filterId',
+  CURRENT_NETWORK_EXCHANGE_RATE = 'currentNetworkExchangeRate',
 }
 
 enum CACHE_TTL {

--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -66,7 +66,7 @@ export const predefined = {
     code: -32606,
     message: 'HBAR Rate limit exceeded',
   }),
-  HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED: new JsonRpcError({
+  HBAR_RATE_LIMIT_PREEMPTIVE_EXCEEDED: new JsonRpcError({
     code: -32606,
     message: 'The HBAR rate limit was preemptively exceeded due to an excessively large callData size.',
   }),

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2534,7 +2534,7 @@ export class EthImpl implements Eth {
 
     if (!currentNetworkExchangeRate) {
       currentNetworkExchangeRate = (await this.mirrorNodeClient.getNetworkExchangeRate(requestId)).current_rate;
-      this.cacheService.set(cacheKey, currentNetworkExchangeRate, callingMethod, cacheTTL, requestIdPrefix);
+      await this.cacheService.set(cacheKey, currentNetworkExchangeRate, callingMethod, cacheTTL, requestIdPrefix);
     }
 
     const exchangeRateInCents = currentNetworkExchangeRate.cent_equivalent / currentNetworkExchangeRate.hbar_equivalent;

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -55,6 +55,7 @@ import {
   formatContractResult,
   weibarHexToTinyBarInt,
   isValidEthereumAddress,
+  formatRequestIdMessage,
   formatTransactionIdWithoutQueryParams,
   getFunctionSelector,
 } from '../formatters';
@@ -1509,7 +1510,7 @@ export class EthImpl implements Eth {
 
         if (!accountNonce) {
           this.logger.warn(`${requestIdPrefix} Cannot find updated account nonce.`);
-          throw predefined.INTERNAL_ERROR(`Cannot find updated account nonce for WRONT_NONCE error.`);
+          throw predefined.INTERNAL_ERROR(`Cannot find updated account nonce for WRONG_NONCE error.`);
         }
 
         if (parsedTx.nonce > accountNonce) {
@@ -1538,9 +1539,10 @@ export class EthImpl implements Eth {
    * Submits a transaction to the network for execution.
    *
    * @param transaction
-   * @param requestIdPrefix
+   * @param requestId
    */
-  async sendRawTransaction(transaction: string, requestIdPrefix: string): Promise<string | JsonRpcError> {
+  async sendRawTransaction(transaction: string, requestId: string): Promise<string | JsonRpcError> {
+    const requestIdPrefix = formatRequestIdMessage(requestId);
     if (transaction?.length >= constants.FUNCTION_SELECTOR_CHAR_LENGTH)
       this.ethExecutionsCounter
         .labels(EthImpl.ethSendRawTransaction, transaction.substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH))
@@ -1563,6 +1565,7 @@ export class EthImpl implements Eth {
           EthImpl.ethSendRawTransaction,
           originalCallerAddress,
           networkGasPriceInWeiBars,
+          await this.getCurrentNetworkExchangeRateInCents(requestIdPrefix),
           requestIdPrefix,
         );
 
@@ -2513,5 +2516,17 @@ export class EthImpl implements Eth {
       .reduce((total, amount) => {
         return total + amount;
       }, 0);
+  }
+
+  /**
+   * Retrieves the current network exchange rate of HBAR to USD in cents.
+   *
+   * @param {string} requestId - The unique identifier for the request.
+   * @returns {Promise<number>} - A promise that resolves to the current exchange rate in cents.
+   */
+  private async getCurrentNetworkExchangeRateInCents(requestId: string): Promise<number> {
+    const currentNetworkExchangeRate = (await this.mirrorNodeClient.getNetworkExchangeRate(requestId)).current_rate;
+    const exchangeRateInCents = currentNetworkExchangeRate.cent_equivalent / currentNetworkExchangeRate.hbar_equivalent;
+    return exchangeRateInCents;
   }
 }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2527,7 +2527,7 @@ export class EthImpl implements Eth {
   private async getCurrentNetworkExchangeRateInCents(requestId: string): Promise<number> {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     const cacheKey = constants.CACHE_KEY.CURRENT_NETWORK_EXCHANGE_RATE;
-    const callingMethod = this.mirrorNodeClient.getNetworkExchangeRate.name;
+    const callingMethod = this.getCurrentNetworkExchangeRateInCents.name;
     const cacheTTL = 15 * 60 * 1000; // 15 minutes
 
     let currentNetworkExchangeRate = await this.cacheService.getAsync(cacheKey, callingMethod, requestIdPrefix);

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -132,7 +132,7 @@ export default class HbarLimit {
    * @param {number} callDataSize - The size of the call data that will be used in the transaction.
    * @param {number} fileChunkSize - The chunk size used for file append transactions.
    * @param {string} requestId - The request ID for tracing the request flow.
-   * @throws {Error} Throws an error if the total estimated transaction fee exceeds the remaining HBAR budget.
+   * @throws {JsonRpcError} Throws an error if the total estimated transaction fee exceeds the remaining HBAR budget.
    */
   shouldPreemtivelyLimitFileTransactions(
     originalCallerAddress: string,

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -240,21 +240,21 @@ export default class HbarLimit {
     const fileCreateFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_CREATE_PER_5_KB;
 
     // The first chunk goes in with FileCreateTransaciton, the rest are FileAppendTransactions
-    const fileAppend5kbTransactions = Math.floor(callDataSize / fileChunkSize) - 1;
-    const fileAppendfinalChunkSize = callDataSize % fileChunkSize;
+    const fileAppendTransactions = Math.floor(callDataSize / fileChunkSize) - 1;
+    const lastFileAppendChunkSize = callDataSize % fileChunkSize;
 
-    const fileAppendTxFeeInCents_5kb = constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_PER_5_KB;
-    const fileAppendTxFeeInCents_finalChunk =
+    const fileAppendFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_PER_5_KB;
+    const lastFileAppendChunkFeeInCents =
       constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_BASE_FEE +
-      fileAppendfinalChunkSize * constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_RATE_PER_BYTE;
+      lastFileAppendChunkSize * constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_RATE_PER_BYTE;
 
-    const totalFileTransactionFeeInCents =
+    const totalTxFeeInCents =
       fileCreateTransactions * fileCreateFeeInCents +
-      fileAppendTxFeeInCents_5kb * fileAppend5kbTransactions +
-      fileAppendTxFeeInCents_finalChunk;
+      fileAppendFeeInCents * fileAppendTransactions +
+      lastFileAppendChunkFeeInCents;
 
     const estimatedTxFee = Math.round(
-      (totalFileTransactionFeeInCents / currentNetworkExchangeRateInCents) * constants.HBAR_TO_TINYBAR_COEF,
+      (totalTxFeeInCents / currentNetworkExchangeRateInCents) * constants.HBAR_TO_TINYBAR_COEF,
     );
 
     return estimatedTxFee;

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -149,20 +149,20 @@ export default class HbarLimit {
       );
       return false;
     } else {
-      const { numFileCreateTxs, numFileAppendTxs, totalFeeInTinyBar } = this.estimateFileTransactionFee(
+      const { fileCreateTransactions, fileAppendTransactions, transactionFee } = this.estimateFileTransactionFee(
         callDataSize,
         fileChunkSize,
         currentNetworkExchangeRateInCents,
       );
 
-      if (this.remainingBudget - totalFeeInTinyBar < 0) {
+      if (this.remainingBudget - transactionFee < 0) {
         this.logger.warn(
-          `${requestIdPrefix} HBAR preemptive rate limit incoming call - the total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, numFileCreateTxs=${numFileCreateTxs}, numFileAppendTxs=${numFileAppendTxs}, totalFeeInTinyBar=${totalFeeInTinyBar}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
+          `${requestIdPrefix} HBAR preemptive rate limit incoming call - the total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, fileCreateTransactions=${fileCreateTransactions}, fileAppendTransactions=${fileAppendTransactions}, transactionFee=${transactionFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
         );
         return true;
       } else {
         this.logger.trace(
-          `${requestIdPrefix} HBAR preemptive rate limit not reached: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, numFileCreateTxs=${numFileCreateTxs}, numFileAppendTxs=${numFileAppendTxs}, totalFeeInTinyBar=${totalFeeInTinyBar}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
+          `${requestIdPrefix} HBAR preemptive rate limit not reached: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, fileCreateTransactions=${fileCreateTransactions}, fileAppendTransactions=${fileAppendTransactions}, transactionFee=${transactionFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
         );
         return false;
       }
@@ -229,34 +229,35 @@ export default class HbarLimit {
    * @param {number} fileChunkSize - The size of each file chunk in bytes.
    * @param {number} currentNetworkExchangeRateInCents - The current exchange rate of HBAR to USD cents.
    * @returns An object containing:
-   *   - `numFileCreateTxs` (number): The number of file creation transactions.
-   *   - `numFileAppendTxs` (number): The number of file append transactions.
-   *   - `totalFeeInTinyBar` (number): The estimated total transaction fee in tinybars.
+   *   - `fileCreateTransactions` (number): The number of file creation transactions.
+   *   - `fileAppendTransactions` (number): The number of file append transactions.
+   *   - `transactionFee` (number): The estimated total transaction fee in tinybars.
    */
   estimateFileTransactionFee(
     callDataSize: number,
     fileChunkSize: number,
     currentNetworkExchangeRateInCents: number,
   ): {
-    numFileCreateTxs: number;
-    numFileAppendTxs: number;
-    totalFeeInTinyBar: number;
+    fileCreateTransactions: number;
+    fileAppendTransactions: number;
+    transactionFee: number;
   } {
-    const numFileCreateTxs = 1;
-    const numFileAppendTxs = Math.floor(callDataSize / fileChunkSize);
+    const fileCreateTransactions = 1;
+    const fileAppendTransactions = Math.floor(callDataSize / fileChunkSize);
     const fileCreateFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_CREATE_PER_5_KB;
     const fileAppendFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_PER_5_KB;
 
-    const totalRequestFeeInCents = numFileCreateTxs * fileCreateFeeInCents + numFileAppendTxs * fileAppendFeeInCents;
+    const totalRequestFeeInCents =
+      fileCreateTransactions * fileCreateFeeInCents + fileAppendTransactions * fileAppendFeeInCents;
 
-    const totalFeeInTinyBar = Math.round(
+    const transactionFee = Math.round(
       (totalRequestFeeInCents / currentNetworkExchangeRateInCents) * constants.HBAR_TO_TINYBAR_COEF,
     );
 
     return {
-      numFileCreateTxs,
-      numFileAppendTxs,
-      totalFeeInTinyBar,
+      fileCreateTransactions,
+      fileAppendTransactions,
+      transactionFee,
     };
   }
 

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -134,7 +134,7 @@ export default class HbarLimit {
    * @returns {boolean} - Return true if the transaction should be preemptively rate limited, otherwise return false.
    * @throws {JsonRpcError} Throws an error if the total estimated transaction fee exceeds the remaining HBAR budget.
    */
-  shouldPreemtivelyLimitFileTransactions(
+  shouldPreemptivelyLimitFileTransactions(
     originalCallerAddress: string,
     callDataSize: number,
     fileChunkSize: number,

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -148,25 +148,25 @@ export default class HbarLimit {
         `${requestIdPrefix} HBAR preemptive rate limit bypassed - the caller is a whitelisted account: originalCallerAddress=${originalCallerAddress}`,
       );
       return false;
-    } else {
-      const { fileCreateTransactions, fileAppendTransactions, transactionFee } = this.estimateFileTransactionFee(
-        callDataSize,
-        fileChunkSize,
-        currentNetworkExchangeRateInCents,
-      );
-
-      if (this.remainingBudget - transactionFee < 0) {
-        this.logger.warn(
-          `${requestIdPrefix} HBAR preemptive rate limit incoming call - the total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, fileCreateTransactions=${fileCreateTransactions}, fileAppendTransactions=${fileAppendTransactions}, transactionFee=${transactionFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
-        );
-        return true;
-      } else {
-        this.logger.trace(
-          `${requestIdPrefix} HBAR preemptive rate limit not reached: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, fileCreateTransactions=${fileCreateTransactions}, fileAppendTransactions=${fileAppendTransactions}, transactionFee=${transactionFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
-        );
-        return false;
-      }
     }
+
+    const { fileCreateTransactions, fileAppendTransactions, transactionFee } = this.estimateFileTransactionFee(
+      callDataSize,
+      fileChunkSize,
+      currentNetworkExchangeRateInCents,
+    );
+
+    if (this.remainingBudget - transactionFee < 0) {
+      this.logger.warn(
+        `${requestIdPrefix} HBAR preemptive rate limit incoming call - the total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, fileCreateTransactions=${fileCreateTransactions}, fileAppendTransactions=${fileAppendTransactions}, transactionFee=${transactionFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
+      );
+      return true;
+    }
+
+    this.logger.trace(
+      `${requestIdPrefix} HBAR preemptive rate limit not reached: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, fileCreateTransactions=${fileCreateTransactions}, fileAppendTransactions=${fileAppendTransactions}, transactionFee=${transactionFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
+    );
+    return false;
   }
 
   /**

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -150,21 +150,21 @@ export default class HbarLimit {
       return false;
     }
 
-    const estimatedTxFeeForFileTransactions = this.estimateFileTransactionsFee(
+    const estimatedTxFee = this.estimateFileTransactionsFee(
       callDataSize,
       fileChunkSize,
       currentNetworkExchangeRateInCents,
     );
 
-    if (this.remainingBudget - estimatedTxFeeForFileTransactions < 0) {
+    if (this.remainingBudget - estimatedTxFee < 0) {
       this.logger.warn(
-        `${requestIdPrefix} HBAR preemptive rate limit incoming call - the total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, estimatedTxFeeForFileTransactions=${estimatedTxFeeForFileTransactions}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
+        `${requestIdPrefix} HBAR preemptive rate limit incoming call - the total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, estimatedTxFee=${estimatedTxFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
       );
       return true;
     }
 
     this.logger.trace(
-      `${requestIdPrefix} HBAR preemptive rate limit not reached: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, estimatedTxFeeForFileTransactions=${estimatedTxFeeForFileTransactions}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
+      `${requestIdPrefix} HBAR preemptive rate limit not reached: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, estimatedTxFee=${estimatedTxFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
     );
     return false;
   }
@@ -253,11 +253,11 @@ export default class HbarLimit {
       fileAppendTxFeeInCents_5kb * fileAppend5kbTransactions +
       fileAppendTxFeeInCents_finalChunk;
 
-    const estimatedTxFeeForFileTransactions = Math.round(
+    const estimatedTxFee = Math.round(
       (totalFileTransactionFeeInCents / currentNetworkExchangeRateInCents) * constants.HBAR_TO_TINYBAR_COEF,
     );
 
-    return estimatedTxFeeForFileTransactions;
+    return estimatedTxFee;
   }
 
   /**

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -145,7 +145,7 @@ export default class HbarLimit {
 
     if (this.isAccountWhiteListed(originalCallerAddress)) {
       this.logger.trace(
-        `${requestIdPrefix} HBAR preemptive rate limit bypassed - the caller is a whitelisted account: originalCallerAddress=${originalCallerAddress}`,
+        `${requestIdPrefix} Request bypasses the preemptive limit check - the caller is a whitelisted account: originalCallerAddress=${originalCallerAddress}`,
       );
       return false;
     }
@@ -158,13 +158,13 @@ export default class HbarLimit {
 
     if (this.remainingBudget - estimatedTxFee < 0) {
       this.logger.warn(
-        `${requestIdPrefix} HBAR preemptive rate limit incoming call - the total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, estimatedTxFee=${estimatedTxFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
+        `${requestIdPrefix} Request fails the preemptive limit check - the remaining HBAR budget was not enough to accommodate the estimated transaction fee: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, estimatedTxFee=${estimatedTxFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
       );
       return true;
     }
 
     this.logger.trace(
-      `${requestIdPrefix} HBAR preemptive rate limit not reached: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, estimatedTxFee=${estimatedTxFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
+      `${requestIdPrefix} Request passes the preemptive limit check - the remaining HBAR budget is enough to accommodate the estimated transaction fee: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, estimatedTxFee=${estimatedTxFee}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,
     );
     return false;
   }

--- a/packages/relay/src/lib/hbarlimiter/index.ts
+++ b/packages/relay/src/lib/hbarlimiter/index.ts
@@ -154,9 +154,6 @@ export default class HbarLimit {
         currentNetworkExchangeRateInCents,
       );
 
-      console.log(`remainingBudget: ${this.remainingBudget}`);
-      console.log(`totalFeeInTinyBar: ${totalFeeInTinyBar}`);
-
       if (this.remainingBudget - totalFeeInTinyBar < 0) {
         this.logger.trace(
           `${requestIdPrefix} HBAR preemtive rate limit incoming call - the total preemptive transaction fee exceeds the current remaining HBAR budget due to an excessively large callData size: remainingBudget=${this.remainingBudget}, total=${this.total}, resetTimestamp=${this.reset}, callDataSize=${callDataSize}, numFileCreateTxs=${numFileCreateTxs}, numFileAppendTxs=${numFileAppendTxs}, totalFeeInTinyBar=${totalFeeInTinyBar}, exchangeRateInCents=${currentNetworkExchangeRateInCents}`,

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -879,7 +879,7 @@ export const defaultErrorMessageHex =
   '0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000d53657420746f2072657665727400000000000000000000000000000000000000';
 
 export const calculateTxRecordChargeAmount = (exchangeRateIncents: number) => {
-  const txQueryCostInCents = constants.TX_RECORD_QUERY_COST_IN_CENTS;
+  const txQueryCostInCents = constants.NETWORK_FEES_IN_CENTS.TRANSACTION_GET_RECORD;
   const hbarToTinybar = Hbar.from(1, HbarUnit.Hbar).toTinybars().toNumber();
   return Math.round((txQueryCostInCents / exchangeRateIncents) * hbarToTinybar);
 };
@@ -919,4 +919,25 @@ export const stopRedisInMemoryServer = async (
   process.env.TEST = envsToReset.TEST;
   process.env.REDIS_ENABLED = envsToReset.REDIS_ENABLED;
   process.env.REDIS_URL = envsToReset.REDIS_URL;
+};
+
+export const estimateFileTransactionsFee = (
+  callDataSize: number,
+  fileChunkSize: number,
+  exchangeRateInCents: number,
+) => {
+  const numFileCreateTxs = 1;
+  const numFileAppendTxs = Math.floor(callDataSize / fileChunkSize);
+  const fileCreateFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_CREATE_PER_5_KB;
+  const fileAppendFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_PER_5_KB;
+
+  const hbarToTinybar = Hbar.from(1, HbarUnit.Hbar).toTinybars().toNumber();
+  const totalRequestFeeInCents = numFileCreateTxs * fileCreateFeeInCents + numFileAppendTxs * fileAppendFeeInCents;
+
+  const totalFeeInTinyBar = Math.round((totalRequestFeeInCents / exchangeRateInCents) * hbarToTinybar);
+  return {
+    numFileCreateTxs,
+    numFileAppendTxs,
+    totalFeeInTinyBar,
+  };
 };

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -926,18 +926,19 @@ export const estimateFileTransactionsFee = (
   fileChunkSize: number,
   exchangeRateInCents: number,
 ) => {
-  const numFileCreateTxs = 1;
-  const numFileAppendTxs = Math.floor(callDataSize / fileChunkSize);
+  const fileCreateTransactions = 1;
+  const fileAppendTransactions = Math.floor(callDataSize / fileChunkSize);
   const fileCreateFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_CREATE_PER_5_KB;
   const fileAppendFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_PER_5_KB;
 
   const hbarToTinybar = Hbar.from(1, HbarUnit.Hbar).toTinybars().toNumber();
-  const totalRequestFeeInCents = numFileCreateTxs * fileCreateFeeInCents + numFileAppendTxs * fileAppendFeeInCents;
+  const totalRequestFeeInCents =
+    fileCreateTransactions * fileCreateFeeInCents + fileAppendTransactions * fileAppendFeeInCents;
 
-  const totalFeeInTinyBar = Math.round((totalRequestFeeInCents / exchangeRateInCents) * hbarToTinybar);
+  const transactionFee = Math.round((totalRequestFeeInCents / exchangeRateInCents) * hbarToTinybar);
   return {
-    numFileCreateTxs,
-    numFileAppendTxs,
-    totalFeeInTinyBar,
+    fileCreateTransactions,
+    fileAppendTransactions,
+    transactionFee,
   };
 };

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -943,9 +943,9 @@ export const estimateFileTransactionsFee = (
     fileAppendTxFeeInCents_5kb * fileAppend5kbTransactions +
     fileAppendTxFeeInCents_finalChunk;
 
-  const estimatedTxFeeForFileTransactions = Math.round(
+  const estimatedTxFee = Math.round(
     (totalFileTransactionFeeInCents / exchangeRateInCents) * constants.HBAR_TO_TINYBAR_COEF,
   );
 
-  return estimatedTxFeeForFileTransactions;
+  return estimatedTxFee;
 };

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -930,22 +930,20 @@ export const estimateFileTransactionsFee = (
   const fileCreateFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_CREATE_PER_5_KB;
 
   // The first chunk goes in with FileCreateTransaciton, the rest are FileAppendTransactions
-  const fileAppend5kbTransactions = Math.floor(callDataSize / fileChunkSize) - 1;
-  const fileAppendfinalChunkSize = callDataSize % fileChunkSize;
+  const fileAppendTransactions = Math.floor(callDataSize / fileChunkSize) - 1;
+  const lastFileAppendChunkSize = callDataSize % fileChunkSize;
 
-  const fileAppendTxFeeInCents_5kb = constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_PER_5_KB;
-  const fileAppendTxFeeInCents_finalChunk =
+  const fileAppendFeeInCents = constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_PER_5_KB;
+  const lastFileAppendChunkFeeInCents =
     constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_BASE_FEE +
-    fileAppendfinalChunkSize * constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_RATE_PER_BYTE;
+    lastFileAppendChunkSize * constants.NETWORK_FEES_IN_CENTS.FILE_APPEND_RATE_PER_BYTE;
 
-  const totalFileTransactionFeeInCents =
+  const totalTxFeeInCents =
     fileCreateTransactions * fileCreateFeeInCents +
-    fileAppendTxFeeInCents_5kb * fileAppend5kbTransactions +
-    fileAppendTxFeeInCents_finalChunk;
+    fileAppendFeeInCents * fileAppendTransactions +
+    lastFileAppendChunkFeeInCents;
 
-  const estimatedTxFee = Math.round(
-    (totalFileTransactionFeeInCents / exchangeRateInCents) * constants.HBAR_TO_TINYBAR_COEF,
-  );
+  const estimatedTxFee = Math.round((totalTxFeeInCents / exchangeRateInCents) * constants.HBAR_TO_TINYBAR_COEF);
 
   return estimatedTxFee;
 };

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -98,6 +98,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       sdkClientStub = sinon.createStubInstance(SDKClient);
       sinon.stub(hapiServiceInstance, 'getSDKClient').returns(sdkClientStub);
       restMock.onGet(accountEndpoint).reply(200, ACCOUNT_RES);
+      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
     });
 
     this.afterEach(() => {
@@ -121,7 +122,6 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       const signed = await signTransaction(transaction);
 
       restMock.onGet(`transactions/${transactionId}`).reply(200, null);
-      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
 
       const resultingHash = await ethImpl.sendRawTransaction(signed, getRequestId());
       expect(resultingHash).to.equal(ethereumHash);
@@ -166,7 +166,6 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
 
     it('should return hash from ContractResult mirror node api', async function () {
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
-      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
 
       sdkClientStub.submitEthereumTransaction.returns({
         txResponse: {
@@ -182,7 +181,6 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
 
     it('should not send second transaction upon succession', async function () {
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
-      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
 
       sdkClientStub.submitEthereumTransaction.returns({
         txResponse: {
@@ -202,7 +200,6 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       sdkClientStub.submitEthereumTransaction
         .onCall(0)
         .throws(new SDKClientError({ status: 50 }, 'wrong transaction body'));
-      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
 
       const signed = await signTransaction(transaction);
 

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -69,6 +69,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
     const transactionId = '0.0.902-1684375868-230217103';
     const value = '0x511617DE831B9E173';
     const contractResultEndpoint = `contracts/results/${transactionId}`;
+    const networkExchangeRateEndpoint = 'network/exchangerate';
     const ethereumHash = '0x6d20b034eecc8d455c4c040fb3763082d499353a8b7d318b1085ad8d7de15f7e';
     const mockedExchangeRate = {
       current_rate: {
@@ -120,7 +121,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       const signed = await signTransaction(transaction);
 
       restMock.onGet(`transactions/${transactionId}`).reply(200, null);
-      restMock.onGet(`network/exchangerate`).reply(200, mockedExchangeRate);
+      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
 
       const resultingHash = await ethImpl.sendRawTransaction(signed, getRequestId());
       expect(resultingHash).to.equal(ethereumHash);
@@ -165,7 +166,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
 
     it('should return hash from ContractResult mirror node api', async function () {
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
-      restMock.onGet(`network/exchangerate`).reply(200, mockedExchangeRate);
+      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
 
       sdkClientStub.submitEthereumTransaction.returns({
         txResponse: {
@@ -181,7 +182,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
 
     it('should not send second transaction upon succession', async function () {
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
-      restMock.onGet(`network/exchangerate`).reply(200, mockedExchangeRate);
+      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
 
       sdkClientStub.submitEthereumTransaction.returns({
         txResponse: {
@@ -201,7 +202,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       sdkClientStub.submitEthereumTransaction
         .onCall(0)
         .throws(new SDKClientError({ status: 50 }, 'wrong transaction body'));
-      restMock.onGet(`network/exchangerate`).reply(200, mockedExchangeRate);
+      restMock.onGet(networkExchangeRateEndpoint).reply(200, mockedExchangeRate);
 
       const signed = await signTransaction(transaction);
 

--- a/packages/relay/tests/lib/hbarLimiter.spec.ts
+++ b/packages/relay/tests/lib/hbarLimiter.spec.ts
@@ -323,8 +323,6 @@ describe('HBAR Rate Limiter', async function () {
     rateLimiter = new HbarLimit(logger, currentDateNow, validTotal, validDuration, registry);
     const result = rateLimiter.estimateFileTransactionFee(callDataSize, fileChunkSize, mockedExchangeRateInCents);
     const expectedResult = estimateFileTransactionsFee(callDataSize, fileChunkSize, mockedExchangeRateInCents);
-    expect(result.numFileCreateTxs).to.eq(expectedResult.numFileCreateTxs);
-    expect(result.numFileAppendTxs).to.eq(expectedResult.numFileAppendTxs);
-    expect(result.totalFeeInTinyBar).to.eq(expectedResult.totalFeeInTinyBar);
+    expect(result).to.deep.eq(expectedResult);
   });
 });

--- a/packages/relay/tests/lib/hbarLimiter.spec.ts
+++ b/packages/relay/tests/lib/hbarLimiter.spec.ts
@@ -223,7 +223,7 @@ describe('HBAR Rate Limiter', async function () {
         mockedExchangeRateInCents,
         getRequestId(),
       );
-      expect.fail('The rate limiter will throw HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED error');
+      expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
     } catch (error) {
       expect(error).to.eq(expectedError);
     }
@@ -241,7 +241,7 @@ describe('HBAR Rate Limiter', async function () {
         mockedExchangeRateInCents,
         getRequestId(),
       );
-      expect.fail('The rate limiter did not throw HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED error');
+      expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
     } catch (error) {
       expect(error).to.not.eq(expectedError);
     }
@@ -295,7 +295,7 @@ describe('HBAR Rate Limiter', async function () {
         mockedExchangeRateInCents,
         getRequestId(),
       );
-      expect.fail('The rate limiter did not throw HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED error');
+      expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
     } catch (error) {
       expect(error).to.not.eq(expectedError);
     }
@@ -313,7 +313,7 @@ describe('HBAR Rate Limiter', async function () {
         mockedExchangeRateInCents,
         getRequestId(),
       );
-      expect.fail('The rate limiter will throw HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED error');
+      expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
     } catch (error) {
       expect(error).to.eq(expectedError);
     }

--- a/packages/relay/tests/lib/hbarLimiter.spec.ts
+++ b/packages/relay/tests/lib/hbarLimiter.spec.ts
@@ -31,7 +31,7 @@ describe('HBAR Rate Limiter', async function () {
   this.timeout(20000);
   let rateLimiter: HbarLimit;
   let currentDateNow: number;
-  let rateLimiterWithInvalidTotal: HbarLimit;
+  let rateLimiterWithEmptyBudget: HbarLimit;
 
   const callDataSize = 6000;
   const invalidTotal: number = 0;
@@ -47,7 +47,7 @@ describe('HBAR Rate Limiter', async function () {
     currentDateNow = Date.now();
     process.env.HBAR_RATE_LIMIT_WHITELIST = `[${randomWhiteListedAccountAddress}]`;
     rateLimiter = new HbarLimit(logger, currentDateNow, validTotal, validDuration, registry);
-    rateLimiterWithInvalidTotal = new HbarLimit(logger, currentDateNow, invalidTotal, validDuration, registry);
+    rateLimiterWithEmptyBudget = new HbarLimit(logger, currentDateNow, invalidTotal, validDuration, registry);
   });
 
   this.beforeAll(() => {
@@ -59,16 +59,16 @@ describe('HBAR Rate Limiter', async function () {
   });
 
   it('should be disabled, if we pass invalid total', async function () {
-    const isEnabled = rateLimiterWithInvalidTotal.isEnabled();
-    const limiterResetTime = rateLimiterWithInvalidTotal.getResetTime();
-    const limiterRemainingBudget = rateLimiterWithInvalidTotal.getRemainingBudget();
-    const shouldRateLimit = rateLimiterWithInvalidTotal.shouldLimit(
+    const isEnabled = rateLimiterWithEmptyBudget.isEnabled();
+    const limiterResetTime = rateLimiterWithEmptyBudget.getResetTime();
+    const limiterRemainingBudget = rateLimiterWithEmptyBudget.getRemainingBudget();
+    const shouldRateLimit = rateLimiterWithEmptyBudget.shouldLimit(
       currentDateNow,
       'QUERY',
       'eth_call',
       randomAccountAddress,
     );
-    rateLimiterWithInvalidTotal.addExpense(validTotal, currentDateNow);
+    rateLimiterWithEmptyBudget.addExpense(validTotal, currentDateNow);
 
     expect(isEnabled).to.equal(false);
     expect(shouldRateLimit).to.equal(false);
@@ -214,7 +214,7 @@ describe('HBAR Rate Limiter', async function () {
   });
 
   it('Should execute shouldPreemptivelyLimitFileTransactions() and return TRUE if expected transactionFee is greater than remaining balance', () => {
-    const result = rateLimiterWithInvalidTotal.shouldPreemptivelyLimitFileTransactions(
+    const result = rateLimiterWithEmptyBudget.shouldPreemptivelyLimitFileTransactions(
       randomAccountAddress,
       callDataSize,
       fileChunkSize,
@@ -236,8 +236,8 @@ describe('HBAR Rate Limiter', async function () {
   });
 
   it('Should verify if an account is whitelisted', () => {
-    const shoulNotdBeWhiteListed = rateLimiterWithInvalidTotal.isAccountWhiteListed(randomAccountAddress);
-    const shouldBeWhiteListed = rateLimiterWithInvalidTotal.isAccountWhiteListed(randomWhiteListedAccountAddress);
+    const shoulNotdBeWhiteListed = rateLimiterWithEmptyBudget.isAccountWhiteListed(randomAccountAddress);
+    const shouldBeWhiteListed = rateLimiterWithEmptyBudget.isAccountWhiteListed(randomWhiteListedAccountAddress);
 
     expect(shoulNotdBeWhiteListed).to.be.false;
     expect(shouldBeWhiteListed).to.be.true;
@@ -268,7 +268,7 @@ describe('HBAR Rate Limiter', async function () {
   });
 
   it('Should execute shouldPreemptivelyLimitFileTransactions() and return FALSE if the original caller is a white listed account', () => {
-    const result = rateLimiterWithInvalidTotal.shouldPreemptivelyLimitFileTransactions(
+    const result = rateLimiterWithEmptyBudget.shouldPreemptivelyLimitFileTransactions(
       randomWhiteListedAccountAddress,
       callDataSize,
       fileChunkSize,
@@ -279,7 +279,7 @@ describe('HBAR Rate Limiter', async function () {
   });
 
   it('Should execute shouldPreemptivelyLimitFileTransactions() and return TRUE if the original caller is NOT a white listed account', () => {
-    const result = rateLimiterWithInvalidTotal.shouldPreemptivelyLimitFileTransactions(
+    const result = rateLimiterWithEmptyBudget.shouldPreemptivelyLimitFileTransactions(
       randomAccountAddress,
       callDataSize,
       fileChunkSize,

--- a/packages/relay/tests/lib/hbarLimiter.spec.ts
+++ b/packages/relay/tests/lib/hbarLimiter.spec.ts
@@ -22,7 +22,6 @@ import pino from 'pino';
 import { expect } from 'chai';
 import { Registry } from 'prom-client';
 import HbarLimit from '../../src/lib/hbarlimiter';
-import { predefined } from '../../src/lib/errors/JsonRpcError';
 import { estimateFileTransactionsFee, getRequestId, random20BytesAddress } from '../helpers';
 
 const registry = new Registry();
@@ -214,38 +213,26 @@ describe('HBAR Rate Limiter', async function () {
     expect(limiterRemainingBudget).to.equal(validTotal - 100);
   });
 
-  it('Should preemtively limit while expected transactionFee is greater than remaining balance', () => {
-    const expectedError = predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED;
-
-    try {
-      rateLimiterWithInvalidTotal.shouldPreemtivelyLimitFileTransactions(
-        randomAccountAddress,
-        callDataSize,
-        fileChunkSize,
-        mockedExchangeRateInCents,
-        getRequestId(),
-      );
-      expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
-    } catch (error) {
-      expect(error).to.eq(expectedError);
-    }
+  it('Should execute shouldPreemptivelyLimitFileTransactions() and return TRUE if expected transactionFee is greater than remaining balance', () => {
+    const result = rateLimiterWithInvalidTotal.shouldPreemptivelyLimitFileTransactions(
+      randomAccountAddress,
+      callDataSize,
+      fileChunkSize,
+      mockedExchangeRateInCents,
+      getRequestId(),
+    );
+    expect(result).to.be.true;
   });
 
-  it('Should NOT preemtively limit while expected transactionFee is less than remaining balance', () => {
-    const expectedError = predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED;
-
-    try {
-      rateLimiter.shouldPreemtivelyLimitFileTransactions(
-        randomAccountAddress,
-        callDataSize,
-        fileChunkSize,
-        mockedExchangeRateInCents,
-        getRequestId(),
-      );
-      expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
-    } catch (error) {
-      expect(error).to.not.eq(expectedError);
-    }
+  it('Shouldexecute shouldPreemptivelyLimitFileTransactions() and return FALSE if expected transactionFee is less than remaining balance', () => {
+    const result = rateLimiter.shouldPreemptivelyLimitFileTransactions(
+      randomAccountAddress,
+      callDataSize,
+      fileChunkSize,
+      mockedExchangeRateInCents,
+      getRequestId(),
+    );
+    expect(result).to.be.false;
   });
 
   it('Should verify if an account is whitelisted', () => {
@@ -280,38 +267,26 @@ describe('HBAR Rate Limiter', async function () {
     expect(shouldNOTByPassRateLimit).to.equal(true);
   });
 
-  it('Should bypass preemtively limit if original caller is a white listed account', () => {
-    const expectedError = predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED;
-
-    try {
-      rateLimiterWithInvalidTotal.shouldPreemtivelyLimitFileTransactions(
-        randomWhiteListedAccountAddress,
-        callDataSize,
-        fileChunkSize,
-        mockedExchangeRateInCents,
-        getRequestId(),
-      );
-      expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
-    } catch (error) {
-      expect(error).to.not.eq(expectedError);
-    }
+  it('Should execute shouldPreemptivelyLimitFileTransactions() and return FALSE if the original caller is a white listed account', () => {
+    const result = rateLimiterWithInvalidTotal.shouldPreemptivelyLimitFileTransactions(
+      randomWhiteListedAccountAddress,
+      callDataSize,
+      fileChunkSize,
+      mockedExchangeRateInCents,
+      getRequestId(),
+    );
+    expect(result).to.be.false;
   });
 
-  it('Should NOT bypass preemtively limit if original caller is a white listed account', () => {
-    const expectedError = predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED;
-
-    try {
-      rateLimiterWithInvalidTotal.shouldPreemtivelyLimitFileTransactions(
-        randomAccountAddress,
-        callDataSize,
-        fileChunkSize,
-        mockedExchangeRateInCents,
-        getRequestId(),
-      );
-      expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
-    } catch (error) {
-      expect(error).to.eq(expectedError);
-    }
+  it('Should execute shouldPreemptivelyLimitFileTransactions() and return TRUE if the original caller is NOT a white listed account', () => {
+    const result = rateLimiterWithInvalidTotal.shouldPreemptivelyLimitFileTransactions(
+      randomAccountAddress,
+      callDataSize,
+      fileChunkSize,
+      mockedExchangeRateInCents,
+      getRequestId(),
+    );
+    expect(result).to.be.true;
   });
 
   it('Should execute estimateFileTransactionFee() to estimate total fee of file transactions', async () => {

--- a/packages/relay/tests/lib/hbarLimiter.spec.ts
+++ b/packages/relay/tests/lib/hbarLimiter.spec.ts
@@ -290,8 +290,8 @@ describe('HBAR Rate Limiter', async function () {
   });
 
   it('Should execute estimateFileTransactionFee() to estimate total fee of file transactions', async () => {
-    const result = rateLimiter.estimateFileTransactionFee(callDataSize, fileChunkSize, mockedExchangeRateInCents);
+    const result = rateLimiter.estimateFileTransactionsFee(callDataSize, fileChunkSize, mockedExchangeRateInCents);
     const expectedResult = estimateFileTransactionsFee(callDataSize, fileChunkSize, mockedExchangeRateInCents);
-    expect(result).to.deep.eq(expectedResult);
+    expect(result).to.eq(expectedResult);
   });
 });

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -847,7 +847,7 @@ describe('MirrorNodeClient', async function () {
 
     mock.onGet(`network/exchangerate`).reply(200, exchangerate);
 
-    const result = await mirrorNodeInstance.getNetworkExchangeRate();
+    const result = await mirrorNodeInstance.getNetworkExchangeRate(getRequestId());
     expect(result).to.exist;
     expect(result.current_rate).to.exist;
     expect(result.next_rate).to.exist;

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -131,14 +131,6 @@ describe('Open RPC Specification', function () {
     const hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, registry);
     const eventEmitter = new EventEmitter();
 
-    const mockedExchangeRate = {
-      current_rate: {
-        cent_equivalent: 12,
-        expiration_time: 4102444800,
-        hbar_equivalent: 1,
-      },
-    };
-
     clientServiceInstance = new ClientService(logger, registry, hbarLimiter, cacheService, eventEmitter);
     sdkClientStub = sinon.createStubInstance(SDKClient);
     sinon.stub(clientServiceInstance, 'getSDKClient').returns(sdkClientStub);
@@ -199,7 +191,13 @@ describe('Open RPC Specification', function () {
       .onGet(`accounts/0xbC989b7b17d18702663F44A6004cB538b9DfcBAc?limit=100`)
       .reply(200, { account: '0xbC989b7b17d18702663F44A6004cB538b9DfcBAc' });
 
-    mock.onGet(`network/exchangerate`).reply(200, mockedExchangeRate);
+    mock.onGet(`network/exchangerate`).reply(200, {
+      current_rate: {
+        cent_equivalent: 12,
+        expiration_time: 4102444800,
+        hbar_equivalent: 1,
+      },
+    });
 
     mock.onGet(`accounts/${defaultFromLongZeroAddress}${noTransactions}`).reply(200, {
       from: `${defaultEvmAddress}`,

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -2127,9 +2127,9 @@ describe('SdkClient', async function () {
       124, 18, 190, 114, 79, 189, 99, 27, 157, 117, 227, 107, 74, 255, 111, 74, 166, 7, 78, 25, 35, 131, 85, 47, 52,
       120, 20,
     ]);
-    const fileCreateFee = Number(process.env.HOT_FIX_FILE_CREATE_FEE || 100000000); // 1 hbar
-    const fileDeleteFee = Number(process.env.HOT_FIX_FILE_DELETE_FEE || 11000000); // 0.11 hbar
-    const fileAppendFee = Number(process.env.HOT_FIX_FILE_APPEND_FEE || 120000000); // 1.2 hbar
+    const fileCreateFee = 100000000; // 1 hbar
+    const fileDeleteFee = 11000000; // 0.11 hbar
+    const fileAppendFee = 120000000; // 1.2 hbar
     const mockedExchangeRateIncents = 12;
     const mockedTransactionRecordFee = calculateTxRecordChargeAmount(mockedExchangeRateIncents);
     const defaultTransactionFee = 1000;
@@ -2139,7 +2139,7 @@ describe('SdkClient', async function () {
     const fileId = FileId.fromString('0.0.1234');
     const transactionReceipt = { fileId, status: Status.Success };
     const gasUsed = Long.fromNumber(10000);
-    const mockedNetworkGasPrice = '0xa54f4c3c00';
+    const mockedNetworkGasPrice = 710000;
 
     const randomAccountAddress = random20BytesAddress();
 
@@ -2277,6 +2277,7 @@ describe('SdkClient', async function () {
           mockedCallerName,
           randomAccountAddress,
           mockedNetworkGasPrice,
+          mockedExchangeRateIncents,
           requestId,
         );
         expect.fail(`Expected an error but nothing was thrown`);
@@ -2335,6 +2336,7 @@ describe('SdkClient', async function () {
         mockedCallerName,
         randomAccountAddress,
         mockedNetworkGasPrice,
+        mockedExchangeRateIncents,
         requestId,
       );
 

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -2461,7 +2461,7 @@ describe('SdkClient', async function () {
 
     it('should preemtively rate limit before executing file transactions', async () => {
       const expectedError = predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED;
-      hbarLimitMock.expects('shouldPreemtivelyLimitFileTransactions').once().throws(expectedError);
+      hbarLimitMock.expects('shouldPreemptivelyLimitFileTransactions').once().returns(true);
 
       try {
         await sdkClient.submitEthereumTransaction(

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -2252,8 +2252,8 @@ describe('SdkClient', async function () {
       hbarLimitMock = sinon.mock(hbarLimiter);
       sdkClientMock = sinon.mock(sdkClient);
       mock = new MockAdapter(instance);
-      hbarRateLimitPreemptiveCheck = process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK;
-      process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = 'true';
+      hbarRateLimitPreemptiveCheck = process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK;
+      process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK = 'true';
     });
 
     afterEach(() => {
@@ -2261,7 +2261,7 @@ describe('SdkClient', async function () {
       sinon.restore();
       sdkClientMock.restore();
       hbarLimitMock.restore();
-      process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = hbarRateLimitPreemptiveCheck;
+      process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK = hbarRateLimitPreemptiveCheck;
     });
 
     it('should rate limit before creating file', async () => {
@@ -2459,8 +2459,8 @@ describe('SdkClient', async function () {
       expect(appendFileStub.called).to.be.false;
     });
 
-    it('should preemtively rate limit before executing file transactions', async () => {
-      const expectedError = predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED;
+    it('should preemptively rate limit before executing file transactions', async () => {
+      const expectedError = predefined.HBAR_RATE_LIMIT_PREEMPTIVE_EXCEEDED;
       hbarLimitMock.expects('shouldPreemptivelyLimitFileTransactions').once().returns(true);
 
       try {

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -244,10 +244,10 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
         let hbarRateLimitPreemptiveCheck: string | undefined;
 
         beforeEach(() => {
-          hbarRateLimitPreemptiveCheck = process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK;
+          hbarRateLimitPreemptiveCheck = process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK;
         });
         afterEach(() => {
-          process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = hbarRateLimitPreemptiveCheck;
+          process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK = hbarRateLimitPreemptiveCheck;
         });
 
         it('HBAR limiter is updated within acceptable tolerance range in relation to actual spent amount by the relay operator', async function () {
@@ -275,8 +275,8 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
           Assertions.expectWithinTolerance(amountPaidByOperator, totalOperatorFees, TOLERANCE);
         });
 
-        it('Should preemtively check the rate limit before submitting EthereumTransaction', async function () {
-          process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = 'true';
+        it('Should preemptively check the rate limit before submitting EthereumTransaction', async function () {
+          process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK = 'true';
 
           try {
             for (let i = 0; i < 50; i++) {
@@ -289,12 +289,12 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
             }
             expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
           } catch (e) {
-            expect(e.message).to.contain(predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED.message);
+            expect(e.message).to.contain(predefined.HBAR_RATE_LIMIT_PREEMPTIVE_EXCEEDED.message);
           }
         });
 
         it('multiple deployments of large contracts should eventually exhaust the remaining hbar limit', async function () {
-          process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = 'false';
+          process.env.HBAR_RATE_LIMIT_PREEMPTIVE_CHECK = 'false';
 
           const remainingHbarsBefore = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
           let lastRemainingHbars = remainingHbarsBefore;

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -277,7 +277,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
               );
               await largeContract.waitForDeployment();
             }
-            expect.fail('The rate limiter will throw HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED error');
+            expect.fail('Expected an error, but no error was thrown from the hbar rate limiter');
           } catch (e) {
             console.log(`asdaksjdhuqwiyeiqwuyhdkajshdkajhsiduuqywe`);
             console.log(e);

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -241,28 +241,6 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
       });
 
       describe('Rate Limit', () => {
-        it('Should preemtively check the rate limit before submitting EthereumTransaction', async function () {
-          const remainingHbarsBefore = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
-
-          process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = 'true';
-          process.env.HOT_FIX_FILE_APPEND_FEE = (remainingHbarsBefore - 100000000).toString();
-
-          try {
-            const largeContract = await Utils.deployContract(
-              largeContractJson.abi,
-              largeContractJson.bytecode,
-              accounts[0].wallet,
-            );
-            await largeContract.waitForDeployment();
-
-            expect(true).to.be.false;
-          } catch (e) {
-            expect(e.message).to.contain(predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED.message);
-          }
-
-          delete process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK;
-        });
-
         it('HBAR limiter is updated within acceptable tolerance range in relation to actual spent amount by the relay operator', async function () {
           const TOLERANCE = 0.02;
           const remainingHbarsBefore = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
@@ -286,6 +264,28 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
           expect(remainingHbarsAfter).to.be.lt(remainingHbarsBefore);
           Assertions.expectWithinTolerance(amountPaidByOperator, hbarLimitReducedAmount, TOLERANCE);
           Assertions.expectWithinTolerance(amountPaidByOperator, totalOperatorFees, TOLERANCE);
+        });
+
+        it('Should preemtively check the rate limit before submitting EthereumTransaction', async function () {
+          process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK = 'true';
+          try {
+            for (let i = 0; i < 50; i++) {
+              const largeContract = await Utils.deployContract(
+                largeContractJson.abi,
+                largeContractJson.bytecode,
+                accounts[0].wallet,
+              );
+              await largeContract.waitForDeployment();
+            }
+            expect.fail('The rate limiter will throw HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED error');
+          } catch (e) {
+            console.log(`asdaksjdhuqwiyeiqwuyhdkajshdkajhsiduuqywe`);
+            console.log(e);
+
+            expect(e.message).to.contain(predefined.HBAR_RATE_LIMIT_PREEMTIVE_EXCEEDED.message);
+          }
+
+          delete process.env.HBAR_RATE_LIMIT_PREEMTIVE_CHECK;
         });
 
         it('multiple deployments of large contracts should eventually exhaust the remaining hbar limit', async function () {

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -264,14 +264,14 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
           );
 
           const fileChunkSize = Number(process.env.FILE_APPEND_CHUNK_SIZE) || 5120;
-          const estimatedTxFeeForFileTransactions = estimateFileTransactionsFee(
+          const estimatedTxFee = estimateFileTransactionsFee(
             contract.deploymentTransaction()!.data.length,
             fileChunkSize,
             exchangeRateInCents,
           );
 
           const actualFileTransactionTotalFee = fileCreateTxFee + fileAppendTxFee;
-          const estimatedFileTransactionTotalFee = estimatedTxFeeForFileTransactions;
+          const estimatedFileTransactionTotalFee = estimatedTxFee;
 
           const tolerance = 0.003 * actualFileTransactionTotalFee; // 0.3% tolerance
           expect(estimatedFileTransactionTotalFee).to.be.approximately(actualFileTransactionTotalFee, tolerance);

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -998,7 +998,6 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             const expectedNonceTooLowError = predefined.NONCE_TOO_LOW(0, signerNonce);
             const errObj = JSON.parse(error.info.responseBody).error;
             expect(errObj.code).to.eq(expectedNonceTooLowError.code);
-            expect(errObj.name).to.eq(expectedNonceTooLowError.name);
             expect(errObj.message).to.contain(expectedNonceTooLowError.message);
           }
         }

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -82,7 +82,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
   const signSendAndConfirmTransaction = async (transaction, accounts, requestId) => {
     const signedTx = await accounts.wallet.signTransaction(transaction);
-    const txHash = await relay.sendRawTransaction(signedTx);
+    const txHash = await relay.sendRawTransaction(signedTx, requestId);
     await mirrorNode.get(`/contracts/results/${txHash}`, requestId);
     await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_TRANSACTION_BY_HASH, [txHash]);
     await new Promise((r) => setTimeout(r, 2000));


### PR DESCRIPTION
**Description**:
A preemptive rate limit was introduced as a hotfix in version 0.52.1, using a logic that preemptively rate-limited file transactions by comparing a hard-coded amount of tinybars that was assumed to be the cost for `FileCreate` and `FileAppend` transactions. However, this logic was incorrect and the tinybar amount was a random figure agreed among the team for the purposes of the hotfix.

This PR improves the rate-limiting logic by leveraging the [Hedera Fee Calculator](https://hedera.com/fee) to estimate fees for `FileCreate` and `FileAppend` transactions based on a file size of `FILE_APPEND_CHUNK_SIZE` bytes. This approach ensures the estimated fees more closely align with the actual transaction fees charged for these transactions.

Fixes #2921

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
