### PR TITLE
fix: bug where finalized and safe tags are cached

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1230,7 +1230,7 @@ export class EthImpl implements Eth {
         );
       });
 
-      if (blockNumOrTag != EthImpl.blockLatest && blockNumOrTag != EthImpl.blockPending) {
+      if (!this.common.blockTagIsLatestOrPending(blockNumOrTag)) {
         await this.cacheService.set(cacheKey, block, EthImpl.ethGetBlockByNumber, undefined, requestIdPrefix);
       }
     }

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -544,6 +544,70 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         Assertions.block(blockResult, mirrorBlock, mirrorTransactions, expectedGasPrice, false);
       });
 
+      it('should not cache "latest" block in "eth_getBlockByNumber" ', async function () {
+        const blockResult = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
+          ['latest', false],
+          requestId,
+        );
+        await new Promise((r) => setTimeout(r, 1000));
+
+        const blockResult2 = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
+          ['latest', false],
+          requestId,
+        );
+        expect(blockResult).to.not.deep.equal(blockResult2);
+      });
+
+      it('should not cache "finalized" block in "eth_getBlockByNumber" ', async function () {
+        const blockResult = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
+          ['finalized', false],
+          requestId,
+        );
+        await new Promise((r) => setTimeout(r, 1000));
+
+        const blockResult2 = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
+          ['finalized', false],
+          requestId,
+        );
+        expect(blockResult).to.not.deep.equal(blockResult2);
+      });
+
+      it('should not cache "safe" block in "eth_getBlockByNumber" ', async function () {
+        const blockResult = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
+          ['safe', false],
+          requestId,
+        );
+        await new Promise((r) => setTimeout(r, 1000));
+
+        const blockResult2 = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
+          ['safe', false],
+          requestId,
+        );
+        expect(blockResult).to.not.deep.equal(blockResult2);
+      });
+
+      it('should not cache "pending" block in "eth_getBlockByNumber" ', async function () {
+        const blockResult = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
+          ['pending', false],
+          requestId,
+        );
+        await new Promise((r) => setTimeout(r, 1000));
+
+        const blockResult2 = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
+          ['pending', false],
+          requestId,
+        );
+        expect(blockResult).to.not.deep.equal(blockResult2);
+      });
+
       it('@release should execute "eth_getBlockByNumber", hydrated transactions = true', async function () {
         const blockResult = await relay.call(
           RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -550,7 +550,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           ['latest', false],
           requestId,
         );
-        await new Promise((r) => setTimeout(r, 1000));
+        await Utils.wait(1000);
 
         const blockResult2 = await relay.call(
           RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
@@ -566,7 +566,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           ['finalized', false],
           requestId,
         );
-        await new Promise((r) => setTimeout(r, 1000));
+        await Utils.wait(1000);
 
         const blockResult2 = await relay.call(
           RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
@@ -582,7 +582,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           ['safe', false],
           requestId,
         );
-        await new Promise((r) => setTimeout(r, 1000));
+        await Utils.wait(1000);
 
         const blockResult2 = await relay.call(
           RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,
@@ -598,7 +598,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           ['pending', false],
           requestId,
         );
-        await new Promise((r) => setTimeout(r, 1000));
+        await Utils.wait(1000);
 
         const blockResult2 = await relay.call(
           RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER,


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Currently "latest" and "pending" blocks are not cached, as it should be, since Hedera doesn't have such thing as a pending block. However, the network doesn't support finalized and safe as well, but they are cached and this leads to the issue mentioned below.
**Related issue(s)**:

Fixes #2916 


- [x] Tested (unit, integration, etc.)
