### PR TITLE
ci: Revert breaking change to publish-unit-test-result-action

### DIFF
--- a/.github/workflows/acceptance-public.yml
+++ b/.github/workflows/acceptance-public.yml
@@ -162,7 +162,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish Test Report
-        uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.17.0
+        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
         with:
           check_name: Test Results
           json_thousands_separator: ','

--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -116,7 +116,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Publish Test Report
-        uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.17.0
+        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
         if: ${{ !cancelled() }}
         with:
           check_run_disabled: true

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -139,7 +139,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish Test Report
-        uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.17.0
+        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
         with:
           check_name: Acceptance Tests
           check_run_disabled: true

--- a/.github/workflows/manual-testing.yml
+++ b/.github/workflows/manual-testing.yml
@@ -146,7 +146,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish Test Report
-        uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.17.0
+        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
         with:
           check_name: Acceptance Tests
           check_run_disabled: true

--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -86,7 +86,7 @@ jobs:
           path: test-*.xml
 
       - name: Publish Test Report
-        uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.17.0
+        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
         if: ${{ !cancelled() }}
         with:
           check_run_disabled: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Publish Test Report
         if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name && github.actor != 'dependabot[bot]' && github.actor != 'swirlds-automation' && !cancelled() && !failure() }}
-        uses: step-security/publish-unit-test-result-action@4519d7c9f71dd765f8bbb98626268780f23bab28 # v2.17.0
+        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
         with:
           check_name: Tests
           check_run_disabled: true


### PR DESCRIPTION
**Description**:

Previously the publish-unit-test-result action was updated to use the step-security maintained version of publish-unit-test-result-action. However, the step-security action is a fork of the enricoCI action. This change broke the actionite publish steps.

**Related Issue(s)**:

Fixes: #2941
