### PR TITLE
feat: enabled retrieval of network `gasPrice` in `sendRawTransaction` using MAPI instead of HAPI.

### DIFF
--- a/packages/relay/src/formatters.ts
+++ b/packages/relay/src/formatters.ts
@@ -132,24 +132,23 @@ const parseNumericEnvVar = (envVarName: string, fallbackConstantKey: string): nu
 };
 
 /**
- * Parse weibar hex string to tinybar number, by applying tinybar to weibar coef.
- * Return null, if value is not a valid hex. Null is the only other valid response that mirror-node accepts.
- * @param value
- * @returns tinybarValue
+ * Converts a value in weibars (as a hex string, bigint, boolean, number, or string) to tinybars.
+ *
+ * @param {bigint | boolean | number | string} value - The value to convert, can be in various formats such as hex string, bigint, boolean, number, or string.
+ * @returns {number} - The equivalent value in tinybars, rounded to the nearest whole number.
  */
-const weibarHexToTinyBarInt = (value: bigint | boolean | number | string | null | undefined): number | null => {
-  if (value && value !== '0x') {
-    const weiBigInt = BigInt(value);
-    const coefBigInt = BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
-    // Calculate the tinybar value
-    const tinybarValue = weiBigInt / coefBigInt;
-    // Check if there was a fractional part that got discarded
-    if (tinybarValue === BigInt(0) && weiBigInt > BigInt(0)) {
-      return 1; // Round up to the smallest unit of tinybar
-    }
-    return Number(tinybarValue);
+const weibarHexToTinyBarInt = (value: bigint | boolean | number | string): number => {
+  if (value === '0x') return 0;
+
+  const weiBigInt = BigInt(value);
+  const coefBigInt = BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
+  // Calculate the tinybar value
+  const tinybarValue = weiBigInt / coefBigInt;
+  // Check if there was a fractional part that got discarded
+  if (tinybarValue === BigInt(0) && weiBigInt > BigInt(0)) {
+    return 1; // Round up to the smallest unit of tinybar
   }
-  return null;
+  return Number(tinybarValue);
 };
 
 const formatContractResult = (cr: any) => {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -375,7 +375,7 @@ export class SDKClient {
    * @param {Uint8Array} transactionBuffer - The transaction data in bytes.
    * @param {string} callerName - The name of the caller initiating the transaction.
    * @param {string} originalCallerAddress - The address of the original caller making the request.
-   * @param {string} networkGasPriceInWeiBars - The predefined gas price of the network in hexadecimal weibar.
+   * @param {number} networkGasPriceInWeiBars - The predefined gas price of the network in weibar.
    * @param {string} requestId - The unique identifier for the request.
    * @returns {Promise<{ txResponse: TransactionResponse; fileId: FileId | null }>}
    * @throws {SDKClientError} Throws an error if no file ID is created or if the preemptive fee check fails.
@@ -384,7 +384,7 @@ export class SDKClient {
     transactionBuffer: Uint8Array,
     callerName: string,
     originalCallerAddress: string,
-    networkGasPriceInWeiBars: string,
+    networkGasPriceInWeiBars: number,
     requestId: string,
   ): Promise<{ txResponse: TransactionResponse; fileId: FileId | null }> {
     const ethereumTransactionData: EthereumTransactionData = EthereumTransactionData.fromBytes(transactionBuffer);

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -437,7 +437,7 @@ export class SDKClient {
       ethereumTransactionData.callData = new Uint8Array();
       ethereumTransaction.setEthereumData(ethereumTransactionData.toBytes()).setCallDataFileId(fileId);
     }
-    const networkGasPriceInTinyBars = weibarHexToTinyBarInt(networkGasPriceInWeiBars)!;
+    const networkGasPriceInTinyBars = weibarHexToTinyBarInt(networkGasPriceInWeiBars);
 
     ethereumTransaction.setMaxTransactionFee(
       Hbar.fromTinybars(Math.floor(networkGasPriceInTinyBars * constants.MAX_GAS_PER_SEC)),

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -32,6 +32,7 @@ enum CACHE_KEY {
   FEE_HISTORY = 'fee_history',
   FILTER = 'filter',
   GAS_PRICE = 'gas_price',
+  NETWORK_FEES = 'network_fees',
   GET_BLOCK = 'getBlock',
   GET_CONTRACT = 'getContract',
   GET_CONTRACT_RESULT = 'getContractResult',

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -68,12 +68,12 @@ export class Precheck {
   /**
    * Sends a raw transaction after performing various prechecks.
    * @param {ethers.Transaction} parsedTx - The parsed transaction.
-   * @param {string} networkGasPriceInWeiBars - The predefined gas price of the network in hexadecimal weibar.
+   * @param {number} networkGasPriceInWeiBars - The predefined gas price of the network in weibar.
    * @param {string} [requestId] - The request ID.
    */
   async sendRawTransactionCheck(
     parsedTx: ethers.Transaction,
-    networkGasPriceInWeiBars: string,
+    networkGasPriceInWeiBars: number,
     requestId?: string,
   ): Promise<void> {
     this.transactionType(parsedTx, requestId);
@@ -160,10 +160,10 @@ export class Precheck {
   /**
    * Checks the gas price of the transaction.
    * @param {Transaction} tx - The transaction.
-   * @param {string} networkGasPriceInWeiBars - The predefined gas price of the network in hexadecimal weibar.
+   * @param {number} networkGasPriceInWeiBars - The predefined gas price of the network in weibar.
    * @param {string} [requestId] - The request ID.
    */
-  gasPrice(tx: Transaction, networkGasPriceInWeiBars: string, requestId?: string): void {
+  gasPrice(tx: Transaction, networkGasPriceInWeiBars: number, requestId?: string): void {
     const requestIdPrefix = formatRequestIdMessage(requestId);
     const networkGasPrice = BigInt(networkGasPriceInWeiBars);
     const txGasPrice = tx.gasPrice || tx.maxFeePerGas! + tx.maxPriorityFeePerGas!;

--- a/packages/relay/tests/lib/formatters.spec.ts
+++ b/packages/relay/tests/lib/formatters.spec.ts
@@ -20,14 +20,11 @@
 
 import { expect } from 'chai';
 import {
-  ASCIIToHex,
   decodeErrorMessage,
   formatContractResult,
-  formatRequestIdMessage,
   formatTransactionId,
   formatTransactionIdWithoutQueryParams,
   hexToASCII,
-  isHex,
   isValidEthereumAddress,
   mapKeysAndValues,
   nanOrNumberTo0x,
@@ -35,9 +32,7 @@ import {
   numberTo0x,
   parseNumericEnvVar,
   prepend0x,
-  strip0x,
   toHash32,
-  toHexString,
   toNullableBigNumber,
   toNullIfEmptyHex,
   trimPrecedingZeros,
@@ -447,24 +442,9 @@ describe('Formatters', () => {
       expect(weibarHexToTinyBarInt(value)).to.eq(111);
     });
 
-    it('should convert weibar hex value to tinybar number', () => {
-      const value = undefined;
-      expect(weibarHexToTinyBarInt(value)).to.be.null;
-    });
-
-    it('should convert weibar hex value to tinybar number', () => {
-      const value = null;
-      expect(weibarHexToTinyBarInt(value)).to.be.null;
-    });
-
     it('should handle 0x value', () => {
       const value = '0x';
-      expect(weibarHexToTinyBarInt(value)).to.eq(null);
-    });
-
-    it('should handle 0x value', () => {
-      const value = '0x';
-      expect(weibarHexToTinyBarInt(value)).to.eq(null);
+      expect(weibarHexToTinyBarInt(value)).to.eq(0);
     });
 
     it('should 0x0', () => {
@@ -706,8 +686,8 @@ describe('Formatters', () => {
       const result = getFunctionSelector('0x1234567890abcdef');
       expect(result).to.eq('12345678');
     });
-   });
-  
+  });
+
   describe('mapKeysAndValues', () => {
     it('should map keys and values correctly', () => {
       const target = { a: '1', b: '2', c: '3' };

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -2139,6 +2139,7 @@ describe('SdkClient', async function () {
     const fileId = FileId.fromString('0.0.1234');
     const transactionReceipt = { fileId, status: Status.Success };
     const gasUsed = Long.fromNumber(10000);
+    const mockedNetworkGasPrice = '0xa54f4c3c00';
 
     const randomAccountAddress = random20BytesAddress();
 
@@ -2271,7 +2272,13 @@ describe('SdkClient', async function () {
         .returns(true);
 
       try {
-        await sdkClient.submitEthereumTransaction(transactionBuffer, mockedCallerName, requestId, randomAccountAddress);
+        await sdkClient.submitEthereumTransaction(
+          transactionBuffer,
+          mockedCallerName,
+          randomAccountAddress,
+          mockedNetworkGasPrice,
+          requestId,
+        );
         expect.fail(`Expected an error but nothing was thrown`);
       } catch (error: any) {
         expect(error.message).to.equal('HBAR Rate limit exceeded');
@@ -2309,7 +2316,6 @@ describe('SdkClient', async function () {
       // last transactionRecordStub call for EthereumTransaction
       transactionRecordStub.onCall(i).resolves(getMockedTransactionRecord(EthereumTransaction.name));
 
-      sdkClientMock.expects('getTinyBarGasFee').once().returns(1000);
       hbarLimitMock.expects('shouldLimit').thrice().returns(false);
       hbarLimitMock.expects('addExpense').withArgs(fileCreateFee).once();
       hbarLimitMock.expects('addExpense').withArgs(defaultTransactionFee).once();
@@ -2324,7 +2330,13 @@ describe('SdkClient', async function () {
         .withArgs(mockedTransactionRecordFee)
         .exactly(fileAppendChunks + 2);
 
-      await sdkClient.submitEthereumTransaction(transactionBuffer, mockedCallerName, requestId, randomAccountAddress);
+      await sdkClient.submitEthereumTransaction(
+        transactionBuffer,
+        mockedCallerName,
+        randomAccountAddress,
+        mockedNetworkGasPrice,
+        requestId,
+      );
 
       expect(queryStub.called).to.be.true;
       expect(transactionStub.called).to.be.true;


### PR DESCRIPTION
**Description**:

This PR enables `sendRawTransaction` to retrieve the current `gasPrice` of the network via the mirror node, instead of querying the consensus node for the fee schedule file. By switching to MAPI, the relay operator account can avoid incurring costs associated with MAPI queries.

**Related issue(s)**:

Fixes #2979 

**Notes for reviewer**:
This PR utilizes the `gasPrice()` method in the `eth.ts` module for `sendRawTransaction` to take advantage of querying the `gasPrice` through the mirror node. If that query fails, it falls back to querying the consensus node for the fee schedule using the `getTinybarGasFee` method in the `sdkClient`.

<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
