### PR TITLE
chore: Disable spending history of HbarSpendingPlans

### DIFF
--- a/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
@@ -77,7 +77,7 @@ export class HbarSpendingPlanRepository {
     const plan = await this.findById(id);
     return new HbarSpendingPlan({
       ...plan,
-      spendingHistory: await this.getSpendingHistory(id),
+      spendingHistory: [],
       spentToday: await this.getSpentToday(id),
     });
   }
@@ -192,8 +192,8 @@ export class HbarSpendingPlanRepository {
             new HbarSpendingPlan({
               ...plan,
               createdAt: new Date(plan.createdAt),
+              spendingHistory: [],
               spentToday: await this.getSpentToday(plan.id),
-              spendingHistory: await this.getSpendingHistory(plan.id),
             }),
         ),
     );

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -224,7 +224,6 @@ export class HbarLimitService implements IHbarLimitService {
     }
 
     await this.hbarSpendingPlanRepository.addAmountToSpentToday(spendingPlan.id, cost);
-    await this.hbarSpendingPlanRepository.addAmountToSpendingHistory(spendingPlan.id, cost);
     this.remainingBudget -= cost;
     this.hbarLimitRemainingGauge.set(this.remainingBudget);
 

--- a/packages/relay/tests/lib/repositories/hbarLimiter/hbarSpendingPlanRepository.spec.ts
+++ b/packages/relay/tests/lib/repositories/hbarLimiter/hbarSpendingPlanRepository.spec.ts
@@ -148,12 +148,6 @@ describe('HbarSpendingPlanRepository', function () {
         expect(spendingHistory).to.have.lengthOf(1);
         expect(spendingHistory[0].amount).to.equal(amount);
         expect(spendingHistory[0].timestamp).to.be.a('Date');
-
-        // const plan = await repository.findByIdWithDetails(createdPlan.id);
-        // expect(plan).to.not.be.null;
-        // expect(plan.spendingHistory).to.have.lengthOf(1);
-        // expect(plan.spendingHistory[0].amount).to.equal(amount);
-        // expect(plan.spendingHistory[0].timestamp).to.be.a('Date');
       });
 
       it('adds multiple amounts to spending history', async () => {
@@ -169,11 +163,6 @@ describe('HbarSpendingPlanRepository', function () {
         const spendingHistory = await repository.getSpendingHistory(createdPlan.id);
         expect(spendingHistory).to.have.lengthOf(3);
         expect(spendingHistory.map((entry) => entry.amount)).to.deep.equal(amounts);
-
-        // const plan = await repository.findByIdWithDetails(createdPlan.id);
-        // expect(plan).to.not.be.null;
-        // expect(plan.spendingHistory).to.have.lengthOf(3);
-        // expect(plan.spendingHistory.map((entry) => entry.amount)).to.deep.equal(amounts);
       });
 
       it('throws error if plan not found when adding to spending history', async () => {

--- a/packages/relay/tests/lib/repositories/hbarLimiter/hbarSpendingPlanRepository.spec.ts
+++ b/packages/relay/tests/lib/repositories/hbarLimiter/hbarSpendingPlanRepository.spec.ts
@@ -149,11 +149,11 @@ describe('HbarSpendingPlanRepository', function () {
         expect(spendingHistory[0].amount).to.equal(amount);
         expect(spendingHistory[0].timestamp).to.be.a('Date');
 
-        const plan = await repository.findByIdWithDetails(createdPlan.id);
-        expect(plan).to.not.be.null;
-        expect(plan!.spendingHistory).to.have.lengthOf(1);
-        expect(plan!.spendingHistory[0].amount).to.equal(amount);
-        expect(plan!.spendingHistory[0].timestamp).to.be.a('Date');
+        // const plan = await repository.findByIdWithDetails(createdPlan.id);
+        // expect(plan).to.not.be.null;
+        // expect(plan.spendingHistory).to.have.lengthOf(1);
+        // expect(plan.spendingHistory[0].amount).to.equal(amount);
+        // expect(plan.spendingHistory[0].timestamp).to.be.a('Date');
       });
 
       it('adds multiple amounts to spending history', async () => {
@@ -170,10 +170,10 @@ describe('HbarSpendingPlanRepository', function () {
         expect(spendingHistory).to.have.lengthOf(3);
         expect(spendingHistory.map((entry) => entry.amount)).to.deep.equal(amounts);
 
-        const plan = await repository.findByIdWithDetails(createdPlan.id);
-        expect(plan).to.not.be.null;
-        expect(plan!.spendingHistory).to.have.lengthOf(3);
-        expect(plan!.spendingHistory.map((entry) => entry.amount)).to.deep.equal(amounts);
+        // const plan = await repository.findByIdWithDetails(createdPlan.id);
+        // expect(plan).to.not.be.null;
+        // expect(plan.spendingHistory).to.have.lengthOf(3);
+        // expect(plan.spendingHistory.map((entry) => entry.amount)).to.deep.equal(amounts);
       });
 
       it('throws error if plan not found when adding to spending history', async () => {

--- a/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
+++ b/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
@@ -391,7 +391,6 @@ describe('HbarLimitService', function () {
       }
       hbarSpendingPlanRepositoryStub.findByIdWithDetails.resolves(existingSpendingPlan);
       hbarSpendingPlanRepositoryStub.addAmountToSpentToday.resolves();
-      hbarSpendingPlanRepositoryStub.addAmountToSpendingHistory.resolves();
       hbarSpendingPlanRepositoryStub.findAllActiveBySubscriptionType.resolves([
         otherPlanUsedToday,
         {
@@ -416,7 +415,6 @@ describe('HbarLimitService', function () {
       await hbarLimitService.addExpense(expense, ethAddress, ipAddress);
 
       expect(hbarSpendingPlanRepositoryStub.addAmountToSpentToday.calledOnceWith(mockPlanId, expense)).to.be.true;
-      expect(hbarSpendingPlanRepositoryStub.addAmountToSpendingHistory.calledOnceWith(mockPlanId, expense)).to.be.true;
       // @ts-ignore
       expect(hbarLimitService.remainingBudget).to.equal(hbarLimitService.totalBudget - expense);
       // @ts-ignore


### PR DESCRIPTION
**Description**:

It's not clear yet if the spending history of the plans is going to be used for anything and it will consume a lot of the cache's memory so it's better to keep it empty for now.

Changes:
- Removed all usages of `HbarSpendingPlanRepository#getSpendingHistory`
- Removed all usages of `HbarSpendingPlanRepository#addAmountToSpendingHistory`

**Related issue(s)**:

Fixes #2994

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
