### PR TITLE
fix: Update `getBlockByHash` and `getBlockByNumber` to pass `timestamp` to MAPI calls

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2282,18 +2282,10 @@ export class EthImpl implements Eth {
     // prepare transactionArray
     let transactionArray: any[] = [];
     for (const contractResult of contractResults) {
-      contractResult.from = await this.resolveEvmAddress(
-        contractResult.from,
-        requestIdPrefix,
-        [constants.TYPE_ACCOUNT],
-        { timestamp: timestampRangeParams },
-      );
-      contractResult.to = await this.resolveEvmAddress(
-        contractResult.to,
-        requestIdPrefix,
-        [constants.TYPE_CONTRACT, constants.TYPE_TOKEN, constants.TYPE_ACCOUNT],
-        { timestamp: timestampRangeParams },
-      );
+      contractResult.from = await this.resolveEvmAddress(contractResult.from, requestIdPrefix, [
+        constants.TYPE_ACCOUNT,
+      ]);
+      contractResult.to = await this.resolveEvmAddress(contractResult.to, requestIdPrefix);
       contractResult.chain_id = contractResult.chain_id || this.chain;
 
       transactionArray.push(showDetails ? formatContractResult(contractResult) : contractResult.hash);

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -29,6 +29,7 @@ import { MirrorNodeClientError } from '../../../errors/MirrorNodeClientError';
 import { Log } from '../../../model';
 import * as _ from 'lodash';
 import { CacheService } from '../../cacheService/cacheService';
+import { IContractLogsResultsParams } from '../../../types';
 
 /**
  * Create a new Common Service implementation.
@@ -99,7 +100,7 @@ export class CommonService implements ICommonService {
   };
 
   public async validateBlockRangeAndAddTimestampToParams(
-    params: any,
+    params: IContractLogsResultsParams,
     fromBlock: string,
     toBlock: string,
     requestIdPrefix?: string,
@@ -253,7 +254,11 @@ export class CommonService implements ICommonService {
     throw predefined.INTERNAL_ERROR(error.message.toString());
   }
 
-  public async validateBlockHashAndAddTimestampToParams(params: any, blockHash: string, requestIdPrefix?: string) {
+  public async validateBlockHashAndAddTimestampToParams(
+    params: IContractLogsResultsParams,
+    blockHash: string,
+    requestIdPrefix?: string,
+  ) {
     try {
       const block = await this.mirrorNodeClient.getBlock(blockHash, requestIdPrefix);
       if (block) {
@@ -272,7 +277,7 @@ export class CommonService implements ICommonService {
     return true;
   }
 
-  public addTopicsToParams(params: any, topics: any[] | null) {
+  public addTopicsToParams(params: IContractLogsResultsParams, topics: any[] | null) {
     if (topics) {
       for (let i = 0; i < topics.length; i++) {
         if (!_.isNil(topics[i])) {
@@ -282,7 +287,7 @@ export class CommonService implements ICommonService {
     }
   }
 
-  public async getLogsByAddress(address: string | string[], params: any, requestIdPrefix) {
+  public async getLogsByAddress(address: string | string[], params: IContractLogsResultsParams, requestIdPrefix) {
     const addresses = Array.isArray(address) ? address : [address];
     const logPromises = addresses.map((addr) =>
       this.mirrorNodeClient.getContractResultsLogsByAddress(addr, params, undefined, requestIdPrefix),
@@ -297,10 +302,14 @@ export class CommonService implements ICommonService {
     return logs;
   }
 
-  public async getLogsWithParams(address: string | string[] | null, params, requestIdPrefix?: string): Promise<Log[]> {
+  public async getLogsWithParams(
+    address: string | string[] | null,
+    params: IContractLogsResultsParams,
+    requestIdPrefix?: string,
+  ): Promise<Log[]> {
     const EMPTY_RESPONSE = [];
 
-    let logResults;
+    let logResults: any[];
     if (address) {
       logResults = await this.getLogsByAddress(address, params, requestIdPrefix);
     } else {
@@ -340,7 +349,7 @@ export class CommonService implements ICommonService {
     requestIdPrefix?: string,
   ): Promise<Log[]> {
     const EMPTY_RESPONSE = [];
-    const params: any = {};
+    const params: IContractLogsResultsParams = {};
 
     if (blockHash) {
       if (!(await this.validateBlockHashAndAddTimestampToParams(params, blockHash, requestIdPrefix))) {

--- a/packages/relay/src/lib/types/mirrorNode.ts
+++ b/packages/relay/src/lib/types/mirrorNode.ts
@@ -45,6 +45,10 @@ export interface ILimitOrderParams {
   order?: string;
 }
 
+export interface ITimestampParams {
+  timestamp?: string | string[];
+}
+
 export interface IContractResultsParams {
   blockHash?: string;
   blockNumber?: number;
@@ -55,7 +59,7 @@ export interface IContractResultsParams {
 }
 
 export interface IContractLogsResultsParams {
-  'transaction.hash': string;
+  'transaction.hash'?: string;
   index?: number;
   timestamp?: string | string[];
   topic0?: string | string[];

--- a/packages/relay/tests/lib/eth/eth-config.ts
+++ b/packages/relay/tests/lib/eth/eth-config.ts
@@ -691,7 +691,6 @@ export const CONTRACTS_LOGS_WITH_FILTER = `contracts/${CONTRACT_ADDRESS_1}/resul
 export const CONTRACT_RESULTS_LOGS_WITH_FILTER_URL = `contracts/results/logs?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&limit=100&order=asc`;
 export const BLOCKS_LIMIT_ORDER_URL = 'blocks?limit=1&order=desc';
 export const CONTRACTS_RESULTS_NEXT_URL = `contracts/results?timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&limit=100&order=asc`; // just flip the timestamp parameters for simplicity
-export const ACCOUNT_WITHOUT_TRANSACTIONS = `accounts/${LONG_ZERO_ADDRESS}?transactions=false`;
 export const contractByEvmAddress = (evmAddress: string) => `contracts/${evmAddress}`;
 
 export const MOCK_ACCOUNT_WITHOUT_TRANSACTIONS = {

--- a/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
@@ -84,11 +84,7 @@ describe('@ethGetBlockByHash using MirrorNode', async function () {
     sdkClientStub = sinon.createStubInstance(SDKClient);
     getSdkClientStub = sinon.stub(hapiServiceInstance, 'getSDKClient').returns(sdkClientStub);
     restMock.onGet('network/fees').reply(200, DEFAULT_NETWORK_FEES);
-    restMock
-      .onGet(
-        `accounts/${LONG_ZERO_ADDRESS}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
-      )
-      .reply(200, MOCK_ACCOUNT_WITHOUT_TRANSACTIONS);
+    restMock.onGet(`accounts/${LONG_ZERO_ADDRESS}?transactions=false`).reply(200, MOCK_ACCOUNT_WITHOUT_TRANSACTIONS);
     restMock
       .onGet(contractByEvmAddress(CONTRACT_ADDRESS_1))
       .reply(200, { ...DEFAULT_CONTRACT, evmAddress: CONTRACT_ADDRESS_1 });

--- a/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
@@ -25,12 +25,16 @@ import chaiAsPromised from 'chai-as-promised';
 
 import { predefined } from '../../../src/lib/errors/JsonRpcError';
 import { EthImpl } from '../../../src/lib/eth';
-import { blockLogsBloom, defaultContractResults, defaultDetailedContractResults } from '../../helpers';
+import {
+  blockLogsBloom,
+  defaultContractResults,
+  defaultDetailedContractResults,
+  LONG_ZERO_ADDRESS,
+} from '../../helpers';
 import { SDKClient } from '../../../src/lib/clients';
 import RelayAssertions from '../../assertions';
 import { numberTo0x } from '../../../dist/formatters';
 import {
-  ACCOUNT_WITHOUT_TRANSACTIONS,
   BLOCK_HASH,
   BLOCK_HASH_PREV_TRIMMED,
   BLOCK_HASH_TRIMMED,
@@ -80,7 +84,11 @@ describe('@ethGetBlockByHash using MirrorNode', async function () {
     sdkClientStub = sinon.createStubInstance(SDKClient);
     getSdkClientStub = sinon.stub(hapiServiceInstance, 'getSDKClient').returns(sdkClientStub);
     restMock.onGet('network/fees').reply(200, DEFAULT_NETWORK_FEES);
-    restMock.onGet(ACCOUNT_WITHOUT_TRANSACTIONS).reply(200, MOCK_ACCOUNT_WITHOUT_TRANSACTIONS);
+    restMock
+      .onGet(
+        `accounts/${LONG_ZERO_ADDRESS}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
+      )
+      .reply(200, MOCK_ACCOUNT_WITHOUT_TRANSACTIONS);
     restMock
       .onGet(contractByEvmAddress(CONTRACT_ADDRESS_1))
       .reply(200, { ...DEFAULT_CONTRACT, evmAddress: CONTRACT_ADDRESS_1 });

--- a/packages/relay/tests/lib/eth/eth_getBlockByNumber.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByNumber.spec.ts
@@ -126,10 +126,26 @@ describe('@ethGetBlockByNumber using MirrorNode', async function () {
       cacheService,
     );
     restMock.onGet('network/fees').reply(200, DEFAULT_NETWORK_FEES);
-    restMock.onGet(`accounts/${defaultContractResults.results[0].from}?transactions=false`).reply(200);
-    restMock.onGet(`accounts/${defaultContractResults.results[1].from}?transactions=false`).reply(200);
-    restMock.onGet(`accounts/${defaultContractResults.results[0].to}?transactions=false`).reply(200);
-    restMock.onGet(`accounts/${defaultContractResults.results[1].to}?transactions=false`).reply(200);
+    restMock
+      .onGet(
+        `accounts/${defaultContractResults.results[0].from}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
+      )
+      .reply(200);
+    restMock
+      .onGet(
+        `accounts/${defaultContractResults.results[1].from}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
+      )
+      .reply(200);
+    restMock
+      .onGet(
+        `accounts/${defaultContractResults.results[0].to}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
+      )
+      .reply(200);
+    restMock
+      .onGet(
+        `accounts/${defaultContractResults.results[1].to}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
+      )
+      .reply(200);
     restMock.onGet(`contracts/${defaultContractResults.results[0].from}`).reply(404, NOT_FOUND_RES);
     restMock.onGet(`contracts/${defaultContractResults.results[1].from}`).reply(404, NOT_FOUND_RES);
     restMock.onGet(`contracts/${defaultContractResults.results[0].to}`).reply(200);

--- a/packages/relay/tests/lib/eth/eth_getBlockByNumber.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByNumber.spec.ts
@@ -126,26 +126,10 @@ describe('@ethGetBlockByNumber using MirrorNode', async function () {
       cacheService,
     );
     restMock.onGet('network/fees').reply(200, DEFAULT_NETWORK_FEES);
-    restMock
-      .onGet(
-        `accounts/${defaultContractResults.results[0].from}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
-      )
-      .reply(200);
-    restMock
-      .onGet(
-        `accounts/${defaultContractResults.results[1].from}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
-      )
-      .reply(200);
-    restMock
-      .onGet(
-        `accounts/${defaultContractResults.results[0].to}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
-      )
-      .reply(200);
-    restMock
-      .onGet(
-        `accounts/${defaultContractResults.results[1].to}?timestamp=gte:${DEFAULT_BLOCK.timestamp.from}&timestamp=lte:${DEFAULT_BLOCK.timestamp.to}&transactions=false`,
-      )
-      .reply(200);
+    restMock.onGet(`accounts/${defaultContractResults.results[0].from}?transactions=false`).reply(200);
+    restMock.onGet(`accounts/${defaultContractResults.results[1].from}?transactions=false`).reply(200);
+    restMock.onGet(`accounts/${defaultContractResults.results[0].to}?transactions=false`).reply(200);
+    restMock.onGet(`accounts/${defaultContractResults.results[1].to}?transactions=false`).reply(200);
     restMock.onGet(`contracts/${defaultContractResults.results[0].from}`).reply(404, NOT_FOUND_RES);
     restMock.onGet(`contracts/${defaultContractResults.results[1].from}`).reply(404, NOT_FOUND_RES);
     restMock.onGet(`contracts/${defaultContractResults.results[0].to}`).reply(200);


### PR DESCRIPTION
**Description**:

- adds improvements to `MirrorNodeClient`:
- enhanced `getAccount` method to optionally accept a `ITimestampParams` parameter
- enhanced `prepareLogsParams`, `getContractResultsLogs` and `getContractResultsLogsByAddress` with strong typing on the `params` object that they accept - it now uses the `IContractLogsResultsParams` interface and this helps us track exactly where those methods are called and with which params passed to them
- updates the `eth_getBlockByHash` and `eth_getBlockByNumber` to pass a timestamp range from the fetched block to subsequent calls to `getLogsWithParams`

**Related issue(s)**:

Fixes #3040

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
