### PR TITLE
fix: Update `getTransactionByBlockHashOrBlockNumAndIndex` to pass `timestamp` to MAPI calls

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1707,10 +1707,16 @@ export class EthImpl implements Eth {
     transactionIndex: string,
     requestIdPrefix?: string,
   ): Promise<Transaction | null> {
+    const block = await this.mirrorNodeClient.getBlock(blockParam.value, requestIdPrefix);
+    if (!block) {
+      return null;
+    }
+
     const contractResults = await this.mirrorNodeClient.getContractResults(
       {
         [blockParam.title]: blockParam.value,
         transactionIndex: Number(transactionIndex),
+        timestamp: [`gte:${block.timestamp.from}`, `lte:${block.timestamp.to}`],
       },
       undefined,
       requestIdPrefix,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1708,15 +1708,13 @@ export class EthImpl implements Eth {
     requestIdPrefix?: string,
   ): Promise<Transaction | null> {
     const block = await this.mirrorNodeClient.getBlock(blockParam.value, requestIdPrefix);
-    if (!block) {
-      return null;
-    }
+    const timestampRangeParams = block ? [`gte:${block.timestamp.from}`, `lte:${block.timestamp.to}`] : undefined;
 
     const contractResults = await this.mirrorNodeClient.getContractResults(
       {
         [blockParam.title]: blockParam.value,
         transactionIndex: Number(transactionIndex),
-        timestamp: [`gte:${block.timestamp.from}`, `lte:${block.timestamp.to}`],
+        timestamp: timestampRangeParams,
       },
       undefined,
       requestIdPrefix,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1721,7 +1721,7 @@ export class EthImpl implements Eth {
     transactionIndex: string,
     requestDetails: RequestDetails,
   ): Promise<Transaction | null> {
-    const block = await this.mirrorNodeClient.getBlock(blockParam.value, requestIdPrefix);
+    const block = await this.mirrorNodeClient.getBlock(blockParam.value, requestDetails);
     const timestampRangeParams = block ? [`gte:${block.timestamp.from}`, `lte:${block.timestamp.to}`] : undefined;
 
     const contractResults = await this.mirrorNodeClient.getContractResults(

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -38,7 +38,12 @@ const getQueryParams = (params: object) => {
 
   return '?'.concat(
     Object.entries(params)
-      .map(([key, value]) => `${key}=${value}`)
+      .map(([key, value]) => {
+        if (Array.isArray(value)) {
+          return value.map((v) => `${key}=${v}`).join('&');
+        }
+        return `${key}=${value}`;
+      })
       .join('&'),
   );
 };

--- a/packages/relay/tests/lib/eth/eth-helpers.ts
+++ b/packages/relay/tests/lib/eth/eth-helpers.ts
@@ -28,20 +28,7 @@ import MockAdapter from 'axios-mock-adapter';
 import { MirrorNodeClient } from '../../../src/lib/clients';
 import { EthImpl } from '../../../src/lib/eth';
 import EventEmitter from 'events';
-
-export function getQueryParams(params: object) {
-  let paramString = '';
-  for (const [key, value] of Object.entries(params)) {
-    let additionalString = '';
-    if (Array.isArray(value)) {
-      additionalString = value.map((v) => `${key}=${v}`).join('&');
-    } else if (value !== undefined) {
-      additionalString = `${key}=${value}`;
-    }
-    paramString += paramString === '' ? `?${additionalString}` : `&${additionalString}`;
-  }
-  return paramString;
-}
+import { getQueryParams } from '../../helpers';
 
 export function contractResultsByNumberByIndexURL(
   number: number,

--- a/packages/relay/tests/lib/eth/eth_getTransactionByBlockHashAndIndex.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionByBlockHashAndIndex.spec.ts
@@ -134,6 +134,15 @@ describe('@ethGetTransactionByBlockHashAndIndex using MirrorNode', async functio
     );
   });
 
+  it('eth_getTransactionByBlockHashAndIndex with no block found for given hash', async function () {
+    restMock.onGet(`blocks/${DEFAULT_BLOCK.hash}`).reply(404, NOT_FOUND_RES);
+    const result = await ethImpl.getTransactionByBlockHashAndIndex(
+      DEFAULT_BLOCK.hash.toString(),
+      numberTo0x(DEFAULT_BLOCK.count),
+    );
+    expect(result).to.be.null;
+  });
+
   it('eth_getTransactionByBlockHashAndIndex with no contract result match', async function () {
     // mirror node request mocks
     restMock

--- a/packages/relay/tests/lib/eth/eth_getTransactionByBlockHashAndIndex.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionByBlockHashAndIndex.spec.ts
@@ -134,15 +134,6 @@ describe('@ethGetTransactionByBlockHashAndIndex using MirrorNode', async functio
     );
   });
 
-  it('eth_getTransactionByBlockHashAndIndex with no block found for given hash', async function () {
-    restMock.onGet(`blocks/${DEFAULT_BLOCK.hash}`).reply(404, NOT_FOUND_RES);
-    const result = await ethImpl.getTransactionByBlockHashAndIndex(
-      DEFAULT_BLOCK.hash.toString(),
-      numberTo0x(DEFAULT_BLOCK.count),
-    );
-    expect(result).to.be.null;
-  });
-
   it('eth_getTransactionByBlockHashAndIndex with no contract result match', async function () {
     // mirror node request mocks
     restMock

--- a/packages/relay/tests/lib/eth/eth_getTransactionByBlockNumberAndIndex.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionByBlockNumberAndIndex.spec.ts
@@ -173,15 +173,6 @@ describe('@ethGetTransactionByBlockNumberAndIndex using MirrorNode', async funct
     );
   });
 
-  it('eth_getTransactionByBlockHashAndIndex with no block found for given number', async function () {
-    restMock.onGet(`blocks/${DEFAULT_BLOCK.number}`).reply(404, NOT_FOUND_RES);
-    const result = await ethImpl.getTransactionByBlockNumberAndIndex(
-      numberTo0x(DEFAULT_BLOCK.number),
-      numberTo0x(DEFAULT_BLOCK.count),
-    );
-    expect(result).to.be.null;
-  });
-
   it('eth_getTransactionByBlockNumberAndIndex with no contract results', async function () {
     restMock
       .onGet(contractResultsByNumberByIndexURL(DEFAULT_BLOCK.number, DEFAULT_BLOCK.count, DEFAULT_BLOCK.timestamp))

--- a/packages/relay/tests/lib/eth/eth_getTransactionByBlockNumberAndIndex.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionByBlockNumberAndIndex.spec.ts
@@ -173,6 +173,15 @@ describe('@ethGetTransactionByBlockNumberAndIndex using MirrorNode', async funct
     );
   });
 
+  it('eth_getTransactionByBlockHashAndIndex with no block found for given number', async function () {
+    restMock.onGet(`blocks/${DEFAULT_BLOCK.number}`).reply(404, NOT_FOUND_RES);
+    const result = await ethImpl.getTransactionByBlockNumberAndIndex(
+      numberTo0x(DEFAULT_BLOCK.number),
+      numberTo0x(DEFAULT_BLOCK.count),
+    );
+    expect(result).to.be.null;
+  });
+
   it('eth_getTransactionByBlockNumberAndIndex with no contract results', async function () {
     restMock
       .onGet(contractResultsByNumberByIndexURL(DEFAULT_BLOCK.number, DEFAULT_BLOCK.count, DEFAULT_BLOCK.timestamp))

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -19,7 +19,7 @@
  */
 
 import { expect } from 'chai';
-import { validateOpenRPCDocument, parseOpenRPCDocument } from '@open-rpc/schema-utils-js';
+import { parseOpenRPCDocument, validateOpenRPCDocument } from '@open-rpc/schema-utils-js';
 
 import Ajv from 'ajv';
 
@@ -70,12 +70,11 @@ import { NOT_FOUND_RES } from './eth/eth-config';
 import ClientService from '../../src/lib/services/hapiService/hapiService';
 import HbarLimit from '../../src/lib/hbarlimiter';
 import { numberTo0x } from '../../../../packages/relay/src/formatters';
-
-dotenv.config({ path: path.resolve(__dirname, '../test.env') });
-
 import constants from '../../src/lib/constants';
 import { CacheService } from '../../src/lib/services/cacheService/cacheService';
 import EventEmitter from 'events';
+
+dotenv.config({ path: path.resolve(__dirname, '../test.env') });
 
 process.env.npm_package_version = 'relay/0.0.1-SNAPSHOT';
 
@@ -157,12 +156,12 @@ describe('Open RPC Specification', function () {
     mock.onGet(`contracts/results/${defaultTxHash}`).reply(200, defaultDetailedContractResultByHash);
     mock
       .onGet(
-        `contracts/results?block.hash=${defaultBlock.hash}&transaction.index=${defaultBlock.count}&limit=100&order=asc`,
+        `contracts/results?block.hash=${defaultBlock.hash}&timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&transaction.index=${defaultBlock.count}&limit=100&order=asc`,
       )
       .reply(200, defaultContractResults);
     mock
       .onGet(
-        `contracts/results?block.number=${defaultBlock.number}&transaction.index=${defaultBlock.count}&limit=100&order=asc`,
+        `contracts/results?block.number=${defaultBlock.number}&timestamp=gte:${defaultBlock.timestamp.from}&timestamp=lte:${defaultBlock.timestamp.to}&transaction.index=${defaultBlock.count}&limit=100&order=asc`,
       )
       .reply(200, defaultContractResults);
     mock


### PR DESCRIPTION
**Description**:

- Updates the `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex` to pass a timestamp range of the block to subsequent calls to `getContractResults`

**Related issue(s)**:

Fixes #3042

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
