### PR TITLE
feat: Added consensus node information to the logging.

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1489,11 +1489,7 @@ export class EthImpl implements Eth {
   ): Promise<string | JsonRpcError> {
     this.logger.error(
       e,
-      `${
-        requestDetails.formattedRequestId
-      } Failed to successfully submit sendRawTransaction for transaction ${transaction} to node ${JSON.stringify(
-        this.hapiService.getMainClientInstance().network,
-      )}`,
+      `${requestDetails.formattedRequestId} Failed to successfully submit sendRawTransaction for transaction ${transaction} to node ${this.hapiService.hederaNetwork}`,
     );
     if (e instanceof JsonRpcError) {
       return e;
@@ -1935,7 +1931,7 @@ export class EthImpl implements Eth {
       this.logger.error(
         e,
         `${requestIdPrefix} Failed to successfully submit contractCallQuery to consensus-node: ${JSON.stringify(
-          this.hapiService.getMainClientInstance().network,
+          this.hapiService.hederaNetwork,
         )}`,
       );
       if (e instanceof JsonRpcError) {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1489,7 +1489,11 @@ export class EthImpl implements Eth {
   ): Promise<string | JsonRpcError> {
     this.logger.error(
       e,
-      `${requestDetails.formattedRequestId} Failed to successfully submit sendRawTransaction for transaction ${transaction}`,
+      `${
+        requestDetails.formattedRequestId
+      } Failed to successfully submit sendRawTransaction for transaction ${transaction} to node ${JSON.stringify(
+        this.hapiService.getMainClientInstance().network,
+      )}`,
     );
     if (e instanceof JsonRpcError) {
       return e;
@@ -1928,7 +1932,12 @@ export class EthImpl implements Eth {
         `Invalid contractCallResponse from consensus-node: ${JSON.stringify(contractCallResponse)}`,
       );
     } catch (e: any) {
-      this.logger.error(e, `${requestIdPrefix} Failed to successfully submit contractCallQuery`);
+      this.logger.error(
+        e,
+        `${requestIdPrefix} Failed to successfully submit contractCallQuery to consensus-node: ${JSON.stringify(
+          this.hapiService.getMainClientInstance().network,
+        )}`,
+      );
       if (e instanceof JsonRpcError) {
         return e;
       }

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -44,7 +44,7 @@ export default class HAPIService {
   private initialErrorCodes: number[];
   private initialResetDuration: number;
 
-  private hederaNetwork: string;
+  public hederaNetwork: string;
   private clientMain: Client;
 
   /**


### PR DESCRIPTION
Adds the consensus node to logging information on failed calls.
e.g.
```
{"level":50,"time":1728573006569,"pid":29184,"hostname":"Admins-Laptop-2.hsd1.co.comcast.net","code":-32603,"message":"Error invoking RPC: Invalid transactionID: ","msg":"[Request ID: testId] Failed to successfully submit sendRawTransaction for transaction 0x01f87582012a8088ad78ebc5ac6200008303d0909413212a14deaf2775a5b3becc857806d5c719d3f2890511617de831b9e17380c001a0d3ae419f17fa82fa7e89acb782d87b5df611c545a81a0250b0bc5cc9c8f9e5f8a0102ed103f88d2a6e7d8597449e3806e5ce1ef5c2ace3f8958a21838a9bdb7099 to node {\"127.0.0.1:50211\":\"0.0.3\"}
```
This PR adds the following that was not in the logged messages:
```
to node {\"127.0.0.1:50211\":\"0.0.3\"}
```

**Related issue(s)**:

Fixes #3083 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
