### PR TITLE
feat: eth_call revert error message is too long, and should not be a REVERT but a BAD Request Response

### DIFF
--- a/packages/server/src/validator/constants.ts
+++ b/packages/server/src/validator/constants.ts
@@ -21,6 +21,7 @@
 export const BASE_HEX_REGEX = '^0[xX][a-fA-F0-9]';
 export const ERROR_CODE = -32602;
 export const DEFAULT_HEX_ERROR = 'Expected 0x prefixed hexadecimal value';
+export const EVEN_HEX_ERROR = `${DEFAULT_HEX_ERROR} with even length`;
 export const HASH_ERROR = 'Expected 0x prefixed string representing the hash (32 bytes)';
 export const ADDRESS_ERROR = 'Expected 0x prefixed string representing the address (20 bytes)';
 export const BLOCK_NUMBER_ERROR =

--- a/packages/server/src/validator/objectTypes.ts
+++ b/packages/server/src/validator/objectTypes.ts
@@ -162,7 +162,7 @@ export const OBJECTS_VALIDATIONS: { [key: string]: IObjectSchema } = {
         nullable: false,
       },
       data: {
-        type: 'hex',
+        type: 'hexEvenLength',
         nullable: true,
       },
       type: {

--- a/packages/server/src/validator/types.ts
+++ b/packages/server/src/validator/types.ts
@@ -90,6 +90,10 @@ export const TYPES: { [key: string]: ITypeValidation } = {
     test: (param: string) => new RegExp(Constants.BASE_HEX_REGEX + '*$').test(param),
     error: Constants.DEFAULT_HEX_ERROR,
   },
+  hexEvenLength: {
+    test: (param: string) => new RegExp(Constants.BASE_HEX_REGEX + '*$').test(param) && !(param.length % 2),
+    error: Constants.EVEN_HEX_ERROR,
+  },
   hex64: {
     test: (param: string) => new RegExp(Constants.BASE_HEX_REGEX + '{1,64}$').test(param),
     error: Constants.HASH_ERROR,

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -859,7 +859,7 @@ describe('RPC Server', function () {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 'data' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`,
+            `Invalid parameter 'data' for TransactionObject: ${Validator.EVEN_HEX_ERROR}, value: 123`,
           );
         }
       });
@@ -1503,7 +1503,7 @@ describe('RPC Server', function () {
           BaseTest.invalidParamError(
             error.response,
             Validator.ERROR_CODE,
-            `Invalid parameter 'data' for TransactionObject: ${Validator.DEFAULT_HEX_ERROR}, value: 123`,
+            `Invalid parameter 'data' for TransactionObject: ${Validator.EVEN_HEX_ERROR}, value: 123`,
           );
         }
       });

--- a/packages/server/tests/integration/validator.spec.ts
+++ b/packages/server/tests/integration/validator.spec.ts
@@ -564,7 +564,7 @@ describe('Validator', async () => {
         expectInvalidObject('value', Validator.DEFAULT_HEX_ERROR, object, '123456'),
       );
       expect(() => Validator.validateParams([{ data: '123456' }], validation)).to.throw(
-        expectInvalidObject('data', Validator.DEFAULT_HEX_ERROR, object, '123456'),
+        expectInvalidObject('data', Validator.EVEN_HEX_ERROR, object, '123456'),
       );
     });
   });

--- a/packages/server/tests/integration/validator.spec.ts
+++ b/packages/server/tests/integration/validator.spec.ts
@@ -566,6 +566,9 @@ describe('Validator', async () => {
       expect(() => Validator.validateParams([{ data: '123456' }], validation)).to.throw(
         expectInvalidObject('data', Validator.EVEN_HEX_ERROR, object, '123456'),
       );
+      expect(() => Validator.validateParams([{ data: '0x1234567' }], validation)).to.throw(
+        expectInvalidObject('data', Validator.EVEN_HEX_ERROR, object, '0x1234567'),
+      );
     });
   });
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Sometimes when the relay attempts to do a `contract/call` to the mirror node and gets a '400` status assumes a "revert" happenend. see the attached  curl.
[Curl request mirror node contract call.txt](https://github.com/hashgraph/hedera-json-rpc-relay/files/15421908/Curl.request.mirror.node.contract.call.txt)

The actual mirror-node error code is a `BAD REQUEST` due to `contains invalid odd length characters`

but the relay assumes is a REVERT and not only that but returns the whole payload on the error message.

**Related issue(s)**:

Fixes #2532

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
