### PR TITLE
feat: add maxAttempts parameter to the acceptance test workflow

### DIFF
--- a/.github/workflows/acceptance-public.yml
+++ b/.github/workflows/acceptance-public.yml
@@ -28,6 +28,7 @@ jobs:
       testfilter: release_light
       envfile: ${{ inputs.network }}Acceptance.env
       operator_id: ${{ inputs.operator_id }}
+      maxAttempts: 1
     secrets:
       operator_key: ${{ inputs.operator_key }}
 

--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -26,6 +26,10 @@ on:
       relayTag:
         required: false
         type: string
+      maxAttempts:
+        required: false
+        type: number
+        default: 3
     secrets:
       operator_key:
         description: 'The ED25519, ECDSA, or DER encoded private key of the operator'
@@ -82,7 +86,7 @@ jobs:
       - name: Run acceptance tests
         uses: step-security/retry@2ab886c0de89f68f146c9b43f53e61abc59c46dc # v3.0.1
         with:
-          max_attempts: 3
+          max_attempts: ${{ inputs.maxAttempts }}
           timeout_minutes: 30
           command: npm run acceptancetest:${{ inputs.testfilter }}
         env:


### PR DESCRIPTION
Fixes #3091

This PR makes the following changes:

- Adds a `maxAttempts` parameter to the acceptance test workflow, so that we can control the number of test retry attempts.
- Updates the public acceptance workflow to set the maxAtempts parameter to 1, ensuring we only do a single acceptance test run against public networks.