### PR TITLE
chore: Implement custom LRU cache with protected keys

### DIFF
--- a/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
@@ -104,13 +104,33 @@ export class CustomLRUCache<K, V> extends LRUCache<K, V> {
    * @private
    */
   private isKeyProtected(key: string): boolean {
-    return this.spendingPlansConfig.some((plan) => {
-      return (
-        this.isPreconfiguredPlanKey(key, plan) ||
-        this.isPreconfiguredEthAddressKey(key, plan) ||
-        this.isPreconfiguredIpAddressKey(key, plan)
-      );
-    });
+    if (this.isHbarSpendingPlanRepositoryKey(key)) {
+      return this.spendingPlansConfig.some((plan) => {
+        return (
+          this.isPreconfiguredPlanKey(key, plan) ||
+          this.isPreconfiguredEthAddressKey(key, plan) ||
+          this.isPreconfiguredIpAddressKey(key, plan)
+        );
+      });
+    }
+    return false;
+  }
+
+  /**
+   * Determines if a key is associated with any of the spending plan repositories.
+   * @param {string} key - The key to check.
+   * @returns {boolean} - True if the key is associated with a spending plan repository, false otherwise.
+   * @private
+   */
+  private isHbarSpendingPlanRepositoryKey(key: string): boolean {
+    if (!key) {
+      return false;
+    }
+    return (
+      key.startsWith(HbarSpendingPlanRepository.collectionKey) ||
+      key.startsWith(EthAddressHbarSpendingPlanRepository.collectionKey) ||
+      key.startsWith(IPAddressHbarSpendingPlanRepository.collectionKey)
+    );
   }
 
   /**

--- a/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
@@ -23,32 +23,11 @@ import findConfig from 'find-config';
 import fs from 'fs';
 import { Logger } from 'pino';
 import { SpendingPlanConfig } from '../../../types/spendingPlanConfig';
+import { EthAddressHbarSpendingPlanRepository } from '../../../db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository';
+import { IPAddressHbarSpendingPlanRepository } from '../../../db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository';
+import { HbarSpendingPlanRepository } from '../../../db/repositories/hbarLimiter/hbarSpendingPlanRepository';
 
 export class CustomLRUCache<K, V> extends LRUCache<K, V> {
-  /**
-   * Prefix for HbarSpendingPlan keys.
-   *
-   * @type {string}
-   * @private
-   */
-  private readonly hbarSpendingPlanKeyPrefix = 'hbarSpendingPlan';
-
-  /**
-   * Prefix for EthAddressHbarSpendingPlan keys.
-   *
-   * @type {string}
-   * @private
-   */
-  private readonly ethAddressHbarSpendingPlanKeyPrefix = 'ethAddressHbarSpendingPlan';
-
-  /**
-   * Prefix for IpAddressHbarSpendingPlan keys.
-   *
-   * @type {string}
-   * @private
-   */
-  private readonly ipAddressHbarSpendingPlanKeyPrefix = 'ipAddressHbarSpendingPlan';
-
   /**
    * The name of the spending plans configuration file. Defaults to `spendingPlansConfig.json`.
    *
@@ -142,7 +121,7 @@ export class CustomLRUCache<K, V> extends LRUCache<K, V> {
    * @private
    */
   private isPreconfiguredPlanKey(key: string, plan: SpendingPlanConfig): boolean {
-    return key.includes(`${this.hbarSpendingPlanKeyPrefix}:${plan.id}`);
+    return key.includes(`${HbarSpendingPlanRepository.collectionKey}:${plan.id}`);
   }
 
   /**
@@ -154,7 +133,7 @@ export class CustomLRUCache<K, V> extends LRUCache<K, V> {
    */
   private isPreconfiguredEthAddressKey(key: string, plan: SpendingPlanConfig): boolean {
     return (plan.ethAddresses || []).some((ethAddress) => {
-      return key.includes(`${this.ethAddressHbarSpendingPlanKeyPrefix}:${ethAddress.trim().toLowerCase()}`);
+      return key.includes(`${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress.trim().toLowerCase()}`);
     });
   }
 
@@ -167,7 +146,7 @@ export class CustomLRUCache<K, V> extends LRUCache<K, V> {
    */
   private isPreconfiguredIpAddressKey(key: string, plan: SpendingPlanConfig): boolean {
     return (plan.ipAddresses || []).some((ipAddress) => {
-      return key.includes(`${this.ipAddressHbarSpendingPlanKeyPrefix}:${ipAddress}`);
+      return key.includes(`${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`);
     });
   }
 }

--- a/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
@@ -89,6 +89,16 @@ export class CustomLRUCache<K, V> extends LRUCache<K, V> {
   }
 
   /**
+   * Deletes a key from the cache without checking if it is protected.
+   * @param {K} key - The key to delete.
+   * @returns {boolean} - True if the key was deleted, false otherwise.
+   * @template K - The key type.
+   */
+  deleteUnsafe(key: K): boolean {
+    return super.delete(key);
+  }
+
+  /**
    * Loads the pre-configured spending plans from the spending plans configuration file.
    * @returns {SpendingPlanConfig[]} - The pre-configured spending plans.
    * @private

--- a/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/impl/customLRUCache.ts
@@ -1,0 +1,163 @@
+/*
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import LRUCache from 'lru-cache';
+import findConfig from 'find-config';
+import fs from 'fs';
+import { Logger } from 'pino';
+import { SpendingPlanConfig } from '../../../types/spendingPlanConfig';
+
+export class CustomLRUCache<K, V> extends LRUCache<K, V> {
+  /**
+   * Prefix for HbarSpendingPlan keys.
+   *
+   * @type {string}
+   * @private
+   */
+  private readonly hbarSpendingPlanKeyPrefix = 'hbarSpendingPlan';
+
+  /**
+   * Prefix for EthAddressHbarSpendingPlan keys.
+   *
+   * @type {string}
+   * @private
+   */
+  private readonly ethAddressHbarSpendingPlanKeyPrefix = 'ethAddressHbarSpendingPlan';
+
+  /**
+   * Prefix for IpAddressHbarSpendingPlan keys.
+   *
+   * @type {string}
+   * @private
+   */
+  private readonly ipAddressHbarSpendingPlanKeyPrefix = 'ipAddressHbarSpendingPlan';
+
+  /**
+   * The name of the spending plans configuration file. Defaults to `spendingPlansConfig.json`.
+   *
+   * @type {string}
+   * @private
+   */
+  private readonly SPENDING_PLANS_CONFIG_FILE: string =
+    process.env.HBAR_SPENDING_PLANS_CONFIG_FILE || 'spendingPlansConfig.json';
+
+  /**
+   * The spending plans configuration. This is loaded from the spending plans configuration file.
+   *
+   * @type {SpendingPlanConfig[]}
+   * @private
+   */
+  private readonly spendingPlansConfig: SpendingPlanConfig[];
+
+  constructor(
+    private readonly logger: Logger,
+    options: LRUCache.Options<K, V>,
+  ) {
+    super(options);
+    this.spendingPlansConfig = this.loadSpendingPlansConfig();
+  }
+
+  /**
+   * Deletes a key from the cache. If the key is protected, the deletion is ignored.
+   * @param {K} key - The key to delete.
+   * @returns {boolean} - True if the key was deleted, false otherwise.
+   * @template K - The key type.
+   */
+  delete(key: K): boolean {
+    if (typeof key === 'string' && this.isKeyProtected(key)) {
+      this.logger.trace(`Deletion of key ${key} is ignored as it is protected.`);
+      return false;
+    }
+    return super.delete(key);
+  }
+
+  /**
+   * Loads the pre-configured spending plans from the spending plans configuration file.
+   * @returns {SpendingPlanConfig[]} - The pre-configured spending plans.
+   * @private
+   */
+  private loadSpendingPlansConfig(): SpendingPlanConfig[] {
+    const configPath = findConfig(this.SPENDING_PLANS_CONFIG_FILE);
+    if (!configPath || !fs.existsSync(configPath)) {
+      this.logger.trace(`Configuration file not found at path "${configPath ?? this.SPENDING_PLANS_CONFIG_FILE}"`);
+      return [];
+    }
+    try {
+      const rawData = fs.readFileSync(configPath, 'utf-8');
+      return JSON.parse(rawData) as SpendingPlanConfig[];
+    } catch (error: any) {
+      this.logger.error(`Failed to parse JSON from ${configPath}: ${error.message}`);
+      return [];
+    }
+  }
+
+  /**
+   * Determines if a key is protected. A key is protected if it is associated with a pre-configured spending plan.
+   * @param {string} key - The key to check.
+   * @returns {boolean} - True if the key is protected, false otherwise.
+   * @private
+   */
+  private isKeyProtected(key: string): boolean {
+    return this.spendingPlansConfig.some((plan) => {
+      return (
+        this.isPreconfiguredPlanKey(key, plan) ||
+        this.isPreconfiguredEthAddressKey(key, plan) ||
+        this.isPreconfiguredIpAddressKey(key, plan)
+      );
+    });
+  }
+
+  /**
+   * Determines if a key is associated with a pre-configured spending plan.
+   * @param {string} key - The key to check.
+   * @param {SpendingPlanConfig} plan - The spending plan to check against.
+   * @returns {boolean} - True if the key is associated with the spending plan, false otherwise.
+   * @private
+   */
+  private isPreconfiguredPlanKey(key: string, plan: SpendingPlanConfig): boolean {
+    return key.includes(`${this.hbarSpendingPlanKeyPrefix}:${plan.id}`);
+  }
+
+  /**
+   * Determines if a key is associated with a pre-configured ETH address.
+   * @param {string} key - The key to check.
+   * @param {SpendingPlanConfig} plan - The spending plan to check against.
+   * @returns {boolean} - True if the key is associated with the ETH address, false otherwise.
+   * @private
+   */
+  private isPreconfiguredEthAddressKey(key: string, plan: SpendingPlanConfig): boolean {
+    return (plan.ethAddresses || []).some((ethAddress) => {
+      return key.includes(`${this.ethAddressHbarSpendingPlanKeyPrefix}:${ethAddress.trim().toLowerCase()}`);
+    });
+  }
+
+  /**
+   * Determines if a key is associated with a pre-configured IP address.
+   * @param {string} key - The key to check.
+   * @param {SpendingPlanConfig} plan - The spending plan to check against.
+   * @returns {boolean} - True if the key is associated with the IP address, false otherwise.
+   * @private
+   */
+  private isPreconfiguredIpAddressKey(key: string, plan: SpendingPlanConfig): boolean {
+    return (plan.ipAddresses || []).some((ipAddress) => {
+      return key.includes(`${this.ipAddressHbarSpendingPlanKeyPrefix}:${ipAddress}`);
+    });
+  }
+}

--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -22,9 +22,10 @@ import { Logger } from 'pino';
 import { Gauge, Registry } from 'prom-client';
 import { ICacheClient } from './ICacheClient';
 import constants from '../../constants';
-import LRUCache, { LimitedByCount, LimitedByTTL } from 'lru-cache';
+import { LimitedByCount, LimitedByTTL } from 'lru-cache';
 import { RequestDetails } from '../../types';
 import { Utils } from '../../../utils';
+import { CustomLRUCache } from './impl/customLRUCache';
 
 /**
  * Represents a LocalLRUCache instance that uses an LRU (Least Recently Used) caching strategy
@@ -49,7 +50,7 @@ export class LocalLRUCache implements ICacheClient {
    *
    * @private
    */
-  private readonly cache: LRUCache<string, any>;
+  private readonly cache: CustomLRUCache<string, any>;
 
   /**
    * The logger used for logging all output from this class.
@@ -74,7 +75,7 @@ export class LocalLRUCache implements ICacheClient {
    * @param {Registry} register - The registry instance used for metrics tracking.
    */
   public constructor(logger: Logger, register: Registry) {
-    this.cache = new LRUCache(this.options);
+    this.cache = new CustomLRUCache(logger.child({ name: 'custom-lru-cache' }), this.options);
     this.logger = logger;
     this.register = register;
 

--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -213,7 +213,7 @@ export class LocalLRUCache implements ICacheClient {
    */
   public async delete(key: string, callingMethod: string, requestDetails: RequestDetails): Promise<void> {
     this.logger.trace(`${requestDetails.formattedRequestId} delete cache for ${key}`);
-    this.cache.delete(key);
+    this.cache.deleteUnsafe(key);
   }
 
   /**

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository.ts
@@ -26,7 +26,7 @@ import { EthAddressHbarSpendingPlan } from '../../entities/hbarLimiter/ethAddres
 import { RequestDetails } from '../../../types';
 
 export class EthAddressHbarSpendingPlanRepository {
-  private readonly collectionKey = 'ethAddressHbarSpendingPlan';
+  public static readonly collectionKey = 'ethAddressHbarSpendingPlan';
 
   /**
    * The cache service used for storing data.
@@ -161,6 +161,6 @@ export class EthAddressHbarSpendingPlanRepository {
    * @private
    */
   private getKey(ethAddress: string): string {
-    return `${this.collectionKey}:${ethAddress?.trim().toLowerCase()}`;
+    return `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress?.trim().toLowerCase()}`;
   }
 }

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
@@ -30,7 +30,7 @@ import { HbarSpendingPlan } from '../../entities/hbarLimiter/hbarSpendingPlan';
 import { RequestDetails } from '../../../types';
 
 export class HbarSpendingPlanRepository {
-  private readonly collectionKey = 'hbarSpendingPlan';
+  public static readonly collectionKey = 'hbarSpendingPlan';
 
   /**
    * The cache service used for storing data.
@@ -266,7 +266,7 @@ export class HbarSpendingPlanRepository {
    * @private
    */
   private getKey(id: string): string {
-    return `${this.collectionKey}:${id}`;
+    return `${HbarSpendingPlanRepository.collectionKey}:${id}`;
   }
 
   /**
@@ -275,7 +275,7 @@ export class HbarSpendingPlanRepository {
    * @private
    */
   private getAmountSpentKey(id: string): string {
-    return `${this.collectionKey}:${id}:amountSpent`;
+    return `${HbarSpendingPlanRepository.collectionKey}:${id}:amountSpent`;
   }
 
   /**
@@ -284,6 +284,6 @@ export class HbarSpendingPlanRepository {
    * @private
    */
   private getSpendingHistoryKey(id: string): string {
-    return `${this.collectionKey}:${id}:spendingHistory`;
+    return `${HbarSpendingPlanRepository.collectionKey}:${id}:spendingHistory`;
   }
 }

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
@@ -26,7 +26,7 @@ import { IPAddressHbarSpendingPlan } from '../../entities/hbarLimiter/ipAddressH
 import { RequestDetails } from '../../../types';
 
 export class IPAddressHbarSpendingPlanRepository {
-  private readonly collectionKey = 'ipAddressHbarSpendingPlan';
+  public static readonly collectionKey = 'ipAddressHbarSpendingPlan';
 
   /**
    * The cache service used for storing data.
@@ -161,6 +161,6 @@ export class IPAddressHbarSpendingPlanRepository {
    * @private
    */
   private getKey(ipAddress: string): string {
-    return `${this.collectionKey}:${ipAddress}`;
+    return `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`;
   }
 }

--- a/packages/relay/src/lib/services/cacheService/cacheService.ts
+++ b/packages/relay/src/lib/services/cacheService/cacheService.ts
@@ -34,7 +34,7 @@ export class CacheService {
    *
    * @private
    */
-  private readonly internalCache: ICacheClient;
+  private readonly internalCache: LocalLRUCache;
 
   /**
    * The Redis cache used for caching items from requests.

--- a/packages/relay/src/lib/services/cacheService/cacheService.ts
+++ b/packages/relay/src/lib/services/cacheService/cacheService.ts
@@ -34,7 +34,7 @@ export class CacheService {
    *
    * @private
    */
-  private readonly internalCache: LocalLRUCache;
+  private readonly internalCache: ICacheClient;
 
   /**
    * The Redis cache used for caching items from requests.

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -65,6 +65,10 @@ const random20BytesAddress = (addHexPrefix = true) => {
   return (addHexPrefix ? '0x' : '') + crypto.randomBytes(20).toString('hex');
 };
 
+const randomIpAddress = () => {
+  return Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.');
+};
+
 export const toHex = (num) => {
   return `0x${Number(num).toString(16)}`;
 };
@@ -358,6 +362,7 @@ export {
   signTransaction,
   mockData,
   random20BytesAddress,
+  randomIpAddress,
   getRequestId,
   getQueryParams,
 };

--- a/packages/relay/tests/lib/clients/impl/customLRUCache.spec.ts
+++ b/packages/relay/tests/lib/clients/impl/customLRUCache.spec.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/relay/tests/lib/clients/impl/customLRUCache.spec.ts
+++ b/packages/relay/tests/lib/clients/impl/customLRUCache.spec.ts
@@ -42,88 +42,129 @@ describe('CustomLRUCache', () => {
     cache = new CustomLRUCache<string, any>(logger, { max: 10 });
   });
 
-  it('deletes a non-protected key', () => {
-    cache.set('nonProtectedKey', 'value');
-    expect(cache.delete('nonProtectedKey')).to.be.true;
-    expect(cache.has('nonProtectedKey')).to.be.false;
-  });
-
-  it('does not delete a protected HbarSpendingPlan key', () => {
-    const protectedKey = `hbarSpendingPlan:${spendingPlansConfig[0].id}`;
-    cache.set(protectedKey, spendingPlansConfig[0]);
-    expect(cache.delete(protectedKey)).to.be.false;
-    expect(cache.has(protectedKey)).to.be.true;
-  });
-
-  it('does not delete a protected EthAddressHbarSpendingPlan key', () => {
-    const ethAddressPlan = spendingPlansConfig.find((plan) => !!plan.ethAddresses);
-    if (!ethAddressPlan || !ethAddressPlan.ethAddresses) {
-      expect.fail('No spending plan with ethAddresses found');
-    }
-
-    const protectedKey = `ethAddressHbarSpendingPlan:${ethAddressPlan.ethAddresses[0]}`;
-    cache.set(protectedKey, 'value');
-    expect(cache.delete(protectedKey)).to.be.false;
-    expect(cache.has(protectedKey)).to.be.true;
-  });
-
-  it('does not delete a protected IpAddressHbarSpendingPlan key', () => {
-    const ipAddressPlan = spendingPlansConfig.find((plan) => !!plan.ipAddresses);
-    if (!ipAddressPlan || !ipAddressPlan.ipAddresses) {
-      expect.fail('No spending plan with ipAddresses found');
-    }
-
-    const protectedKey = `ipAddressHbarSpendingPlan:${ipAddressPlan.ipAddresses[0]}`;
-    cache.set(protectedKey, 'value');
-    expect(cache.delete(protectedKey)).to.be.false;
-    expect(cache.has(protectedKey)).to.be.true;
-  });
-
-  it('deletes a HbarSpendingPlan key that is not in the spending plans config', () => {
-    const nonProtectedKey = `hbarSpendingPlan:${randomUUID()}`;
-    cache.set(nonProtectedKey, 'value');
-    expect(cache.delete(nonProtectedKey)).to.be.true;
-    expect(cache.has(nonProtectedKey)).to.be.false;
-  });
-
-  it('deletes a EthAddressHbarSpendingPlan key that is not in the spending plans config', () => {
-    const nonProtectedKey = `ethAddressHbarSpendingPlan:${random20BytesAddress()}`;
-    cache.set(nonProtectedKey, 'value');
-    expect(cache.delete(nonProtectedKey)).to.be.true;
-    expect(cache.has(nonProtectedKey)).to.be.false;
-  });
-
-  it('deletes a IpAddressHbarSpendingPlan key that is not in the spending plans config', () => {
-    const nonProtectedKey = `ipAddressHbarSpendingPlan:${randomIpAddress()}`;
-    cache.set(nonProtectedKey, 'value');
-    expect(cache.delete(nonProtectedKey)).to.be.true;
-    expect(cache.has(nonProtectedKey)).to.be.false;
-  });
-
-  describe('given empty spending plans config', () => {
-    overrideEnvsInMochaDescribe({ HBAR_SPENDING_PLANS_CONFIG_FILE: 'nonExistentFile.json' });
-
-    it('deletes a non-protected HbarSpendingPlan key', () => {
-      cache = new CustomLRUCache<string, any>(logger, { max: 10 });
-
-      const spendingPlanKey = `hbarSpendingPlan:${randomUUID()}`;
-      cache.set(spendingPlanKey, { id: randomUUID(), name: 'test', subscriptionTier: SubscriptionTier.BASIC });
-      expect(cache.delete(spendingPlanKey)).to.be.true;
-      expect(cache.has(spendingPlanKey)).to.be.false;
+  describe('delete', () => {
+    it('deletes a non-protected key', () => {
+      cache.set('nonProtectedKey', 'value');
+      expect(cache.delete('nonProtectedKey')).to.be.true;
+      expect(cache.has('nonProtectedKey')).to.be.false;
     });
 
-    it('deletes a non-protected EthAddressHbarSpendingPlan key', () => {
-      const ethAddressPlanKey = `ethAddressHbarSpendingPlan:${random20BytesAddress()}`;
-      cache.set(ethAddressPlanKey, 'value');
-      expect(cache.delete(ethAddressPlanKey)).to.be.true;
-      expect(cache.has(ethAddressPlanKey)).to.be.false;
+    it('does not delete a protected HbarSpendingPlan key', () => {
+      const protectedKey = `hbarSpendingPlan:${spendingPlansConfig[0].id}`;
+      cache.set(protectedKey, spendingPlansConfig[0]);
+      expect(cache.delete(protectedKey)).to.be.false;
+      expect(cache.has(protectedKey)).to.be.true;
     });
 
-    it('deletes a non-protected IpAddressHbarSpendingPlan key', () => {
-      const ipAddressPlanKey = `ipAddressHbarSpendingPlan:${randomIpAddress()}`;
-      cache.set(ipAddressPlanKey, 'value');
-      expect(cache.delete(ipAddressPlanKey)).to.be.true;
-      expect(cache.has(ipAddressPlanKey)).to.be.false;
+    it('does not delete a protected EthAddressHbarSpendingPlan key', () => {
+      const ethAddressPlan = spendingPlansConfig.find((plan) => !!plan.ethAddresses);
+      if (!ethAddressPlan || !ethAddressPlan.ethAddresses) {
+        expect.fail('No spending plan with ethAddresses found');
+      }
+
+      const protectedKey = `ethAddressHbarSpendingPlan:${ethAddressPlan.ethAddresses[0]}`;
+      cache.set(protectedKey, 'value');
+      expect(cache.delete(protectedKey)).to.be.false;
+      expect(cache.has(protectedKey)).to.be.true;
+    });
+
+    it('does not delete a protected IpAddressHbarSpendingPlan key', () => {
+      const ipAddressPlan = spendingPlansConfig.find((plan) => !!plan.ipAddresses);
+      if (!ipAddressPlan || !ipAddressPlan.ipAddresses) {
+        expect.fail('No spending plan with ipAddresses found');
+      }
+
+      const protectedKey = `ipAddressHbarSpendingPlan:${ipAddressPlan.ipAddresses[0]}`;
+      cache.set(protectedKey, 'value');
+      expect(cache.delete(protectedKey)).to.be.false;
+      expect(cache.has(protectedKey)).to.be.true;
+    });
+
+    it('deletes a HbarSpendingPlan key that is not in the spending plans config', () => {
+      const nonProtectedKey = `hbarSpendingPlan:${randomUUID()}`;
+      cache.set(nonProtectedKey, 'value');
+      expect(cache.delete(nonProtectedKey)).to.be.true;
+      expect(cache.has(nonProtectedKey)).to.be.false;
+    });
+
+    it('deletes a EthAddressHbarSpendingPlan key that is not in the spending plans config', () => {
+      const nonProtectedKey = `ethAddressHbarSpendingPlan:${random20BytesAddress()}`;
+      cache.set(nonProtectedKey, 'value');
+      expect(cache.delete(nonProtectedKey)).to.be.true;
+      expect(cache.has(nonProtectedKey)).to.be.false;
+    });
+
+    it('deletes a IpAddressHbarSpendingPlan key that is not in the spending plans config', () => {
+      const nonProtectedKey = `ipAddressHbarSpendingPlan:${randomIpAddress()}`;
+      cache.set(nonProtectedKey, 'value');
+      expect(cache.delete(nonProtectedKey)).to.be.true;
+      expect(cache.has(nonProtectedKey)).to.be.false;
+    });
+
+    describe('given empty spending plans config', () => {
+      overrideEnvsInMochaDescribe({ HBAR_SPENDING_PLANS_CONFIG_FILE: 'nonExistentFile.json' });
+
+      it('deletes a non-protected HbarSpendingPlan key', () => {
+        cache = new CustomLRUCache<string, any>(logger, { max: 10 });
+
+        const spendingPlanKey = `hbarSpendingPlan:${randomUUID()}`;
+        cache.set(spendingPlanKey, { id: randomUUID(), name: 'test', subscriptionTier: SubscriptionTier.BASIC });
+        expect(cache.delete(spendingPlanKey)).to.be.true;
+        expect(cache.has(spendingPlanKey)).to.be.false;
+      });
+
+      it('deletes a non-protected EthAddressHbarSpendingPlan key', () => {
+        const ethAddressPlanKey = `ethAddressHbarSpendingPlan:${random20BytesAddress()}`;
+        cache.set(ethAddressPlanKey, 'value');
+        expect(cache.delete(ethAddressPlanKey)).to.be.true;
+        expect(cache.has(ethAddressPlanKey)).to.be.false;
+      });
+
+      it('deletes a non-protected IpAddressHbarSpendingPlan key', () => {
+        const ipAddressPlanKey = `ipAddressHbarSpendingPlan:${randomIpAddress()}`;
+        cache.set(ipAddressPlanKey, 'value');
+        expect(cache.delete(ipAddressPlanKey)).to.be.true;
+        expect(cache.has(ipAddressPlanKey)).to.be.false;
+      });
+    });
+  });
+
+  describe('deleteUnsafe', () => {
+    it('deletes a non-protected key', () => {
+      cache.set('nonProtectedKey', 'value');
+      expect(cache.delete('nonProtectedKey')).to.be.true;
+      expect(cache.has('nonProtectedKey')).to.be.false;
+    });
+
+    it('deletes a protected HbarSpendingPlan key', () => {
+      const protectedKey = `hbarSpendingPlan:${spendingPlansConfig[0].id}`;
+      cache.set(protectedKey, spendingPlansConfig[0]);
+      expect(cache.delete(protectedKey)).to.be.true;
+      expect(cache.has(protectedKey)).to.be.false;
+    });
+
+    it('deletes a protected EthAddressHbarSpendingPlan key', () => {
+      const ethAddressPlan = spendingPlansConfig.find((plan) => !!plan.ethAddresses);
+      if (!ethAddressPlan || !ethAddressPlan.ethAddresses) {
+        expect.fail('No spending plan with ethAddresses found');
+      }
+
+      const protectedKey = `ethAddressHbarSpendingPlan:${ethAddressPlan.ethAddresses[0]}`;
+      cache.set(protectedKey, 'value');
+      expect(cache.delete(protectedKey)).to.be.true;
+      expect(cache.has(protectedKey)).to.be.false;
+    });
+
+    it('deletes a protected IpAddressHbarSpendingPlan key', () => {
+      const ipAddressPlan = spendingPlansConfig.find((plan) => !!plan.ipAddresses);
+      if (!ipAddressPlan || !ipAddressPlan.ipAddresses) {
+        expect.fail('No spending plan with ipAddresses found');
+      }
+
+      const protectedKey = `ipAddressHbarSpendingPlan:${ipAddressPlan.ipAddresses[0]}`;
+      cache.set(protectedKey, 'value');
+      expect(cache.delete(protectedKey)).to.be.true;
+      expect(cache.has(protectedKey)).to.be.false;
     });
   });
 });

--- a/packages/relay/tests/lib/clients/impl/customLRUCache.spec.ts
+++ b/packages/relay/tests/lib/clients/impl/customLRUCache.spec.ts
@@ -1,0 +1,129 @@
+/*
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import findConfig from 'find-config';
+import fs from 'fs';
+import pino from 'pino';
+import { expect } from 'chai';
+import { CustomLRUCache } from '../../../../src/lib/clients/cache/impl/customLRUCache';
+import { SpendingPlanConfig } from '../../../../src/lib/types/spendingPlanConfig';
+import { overrideEnvsInMochaDescribe, random20BytesAddress, randomIpAddress } from '../../../helpers';
+import { randomUUID } from 'node:crypto';
+import { SubscriptionTier } from '../../../../src/lib/db/types/hbarLimiter/subscriptionTier';
+
+describe('CustomLRUCache', () => {
+  let cache: CustomLRUCache<string, any>;
+
+  const logger = pino();
+  const spendingPlansConfigFile = 'spendingPlansConfig.example.json';
+  const path = findConfig(spendingPlansConfigFile);
+  const spendingPlansConfig = JSON.parse(fs.readFileSync(path!, 'utf-8')) as SpendingPlanConfig[];
+
+  overrideEnvsInMochaDescribe({ HBAR_SPENDING_PLANS_CONFIG_FILE: spendingPlansConfigFile });
+
+  before(() => {
+    cache = new CustomLRUCache<string, any>(logger, { max: 10 });
+  });
+
+  it('deletes a non-protected key', () => {
+    cache.set('nonProtectedKey', 'value');
+    expect(cache.delete('nonProtectedKey')).to.be.true;
+    expect(cache.has('nonProtectedKey')).to.be.false;
+  });
+
+  it('does not delete a protected HbarSpendingPlan key', () => {
+    const protectedKey = `hbarSpendingPlan:${spendingPlansConfig[0].id}`;
+    cache.set(protectedKey, spendingPlansConfig[0]);
+    expect(cache.delete(protectedKey)).to.be.false;
+    expect(cache.has(protectedKey)).to.be.true;
+  });
+
+  it('does not delete a protected EthAddressHbarSpendingPlan key', () => {
+    const ethAddressPlan = spendingPlansConfig.find((plan) => !!plan.ethAddresses);
+    if (!ethAddressPlan || !ethAddressPlan.ethAddresses) {
+      expect.fail('No spending plan with ethAddresses found');
+    }
+
+    const protectedKey = `ethAddressHbarSpendingPlan:${ethAddressPlan.ethAddresses[0]}`;
+    cache.set(protectedKey, 'value');
+    expect(cache.delete(protectedKey)).to.be.false;
+    expect(cache.has(protectedKey)).to.be.true;
+  });
+
+  it('does not delete a protected IpAddressHbarSpendingPlan key', () => {
+    const ipAddressPlan = spendingPlansConfig.find((plan) => !!plan.ipAddresses);
+    if (!ipAddressPlan || !ipAddressPlan.ipAddresses) {
+      expect.fail('No spending plan with ipAddresses found');
+    }
+
+    const protectedKey = `ipAddressHbarSpendingPlan:${ipAddressPlan.ipAddresses[0]}`;
+    cache.set(protectedKey, 'value');
+    expect(cache.delete(protectedKey)).to.be.false;
+    expect(cache.has(protectedKey)).to.be.true;
+  });
+
+  it('deletes a HbarSpendingPlan key that is not in the spending plans config', () => {
+    const nonProtectedKey = `hbarSpendingPlan:${randomUUID()}`;
+    cache.set(nonProtectedKey, 'value');
+    expect(cache.delete(nonProtectedKey)).to.be.true;
+    expect(cache.has(nonProtectedKey)).to.be.false;
+  });
+
+  it('deletes a EthAddressHbarSpendingPlan key that is not in the spending plans config', () => {
+    const nonProtectedKey = `ethAddressHbarSpendingPlan:${random20BytesAddress()}`;
+    cache.set(nonProtectedKey, 'value');
+    expect(cache.delete(nonProtectedKey)).to.be.true;
+    expect(cache.has(nonProtectedKey)).to.be.false;
+  });
+
+  it('deletes a IpAddressHbarSpendingPlan key that is not in the spending plans config', () => {
+    const nonProtectedKey = `ipAddressHbarSpendingPlan:${randomIpAddress()}`;
+    cache.set(nonProtectedKey, 'value');
+    expect(cache.delete(nonProtectedKey)).to.be.true;
+    expect(cache.has(nonProtectedKey)).to.be.false;
+  });
+
+  describe('given empty spending plans config', () => {
+    overrideEnvsInMochaDescribe({ HBAR_SPENDING_PLANS_CONFIG_FILE: 'nonExistentFile.json' });
+
+    it('deletes a non-protected HbarSpendingPlan key', () => {
+      cache = new CustomLRUCache<string, any>(logger, { max: 10 });
+
+      const spendingPlanKey = `hbarSpendingPlan:${randomUUID()}`;
+      cache.set(spendingPlanKey, { id: randomUUID(), name: 'test', subscriptionTier: SubscriptionTier.BASIC });
+      expect(cache.delete(spendingPlanKey)).to.be.true;
+      expect(cache.has(spendingPlanKey)).to.be.false;
+    });
+
+    it('deletes a non-protected EthAddressHbarSpendingPlan key', () => {
+      const ethAddressPlanKey = `ethAddressHbarSpendingPlan:${random20BytesAddress()}`;
+      cache.set(ethAddressPlanKey, 'value');
+      expect(cache.delete(ethAddressPlanKey)).to.be.true;
+      expect(cache.has(ethAddressPlanKey)).to.be.false;
+    });
+
+    it('deletes a non-protected IpAddressHbarSpendingPlan key', () => {
+      const ipAddressPlanKey = `ipAddressHbarSpendingPlan:${randomIpAddress()}`;
+      cache.set(ipAddressPlanKey, 'value');
+      expect(cache.delete(ipAddressPlanKey)).to.be.true;
+      expect(cache.has(ipAddressPlanKey)).to.be.false;
+    });
+  });
+});

--- a/packages/relay/tests/lib/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository.spec.ts
+++ b/packages/relay/tests/lib/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository.spec.ts
@@ -75,7 +75,12 @@ describe('EthAddressHbarSpendingPlanRepository', function () {
       it('returns true if address plan exists', async () => {
         const ethAddress = '0x123';
         const addressPlan = new EthAddressHbarSpendingPlan({ ethAddress, planId: uuidV4(randomBytes(16)) });
-        await cacheService.set(`${repository['collectionKey']}:${ethAddress}`, addressPlan, 'test', requestDetails);
+        await cacheService.set(
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
+          addressPlan,
+          'test',
+          requestDetails,
+        );
 
         await expect(repository.existsByAddress(ethAddress, requestDetails)).to.eventually.be.true;
       });
@@ -94,7 +99,12 @@ describe('EthAddressHbarSpendingPlanRepository', function () {
           new EthAddressHbarSpendingPlan({ ethAddress: '0x456', planId }),
         ];
         for (const plan of ethAddressPlans) {
-          await cacheService.set(`${repository['collectionKey']}:${plan.ethAddress}`, plan, 'test', requestDetails);
+          await cacheService.set(
+            `${EthAddressHbarSpendingPlanRepository.collectionKey}:${plan.ethAddress}`,
+            plan,
+            'test',
+            requestDetails,
+          );
         }
 
         const result = await repository.findAllByPlanId(planId, 'findAllByPlanId', requestDetails);
@@ -114,14 +124,24 @@ describe('EthAddressHbarSpendingPlanRepository', function () {
         const ethAddresses = ['0x123', '0x456', '0x789'];
         for (const ethAddress of ethAddresses) {
           const addressPlan = new EthAddressHbarSpendingPlan({ ethAddress, planId });
-          await cacheService.set(`${repository['collectionKey']}:${ethAddress}`, addressPlan, 'test', requestDetails);
+          await cacheService.set(
+            `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
+            addressPlan,
+            'test',
+            requestDetails,
+          );
         }
 
         await repository.deleteAllByPlanId(planId, 'deleteAllByPlanId', requestDetails);
 
         for (const ethAddress of ethAddresses) {
-          await expect(cacheService.getAsync(`${repository['collectionKey']}:${ethAddress}`, 'test', requestDetails)).to
-            .eventually.be.null;
+          await expect(
+            cacheService.getAsync(
+              `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
+              'test',
+              requestDetails,
+            ),
+          ).to.eventually.be.null;
         }
       });
 
@@ -135,7 +155,12 @@ describe('EthAddressHbarSpendingPlanRepository', function () {
       it('retrieves an address plan by address', async () => {
         const ethAddress = '0x123';
         const addressPlan: IEthAddressHbarSpendingPlan = { ethAddress, planId: uuidV4(randomBytes(16)) };
-        await cacheService.set(`${repository['collectionKey']}:${ethAddress}`, addressPlan, 'test', requestDetails);
+        await cacheService.set(
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
+          addressPlan,
+          'test',
+          requestDetails,
+        );
 
         const result = await repository.findByAddress(ethAddress, requestDetails);
         expect(result).to.deep.equal(addressPlan);
@@ -157,14 +182,14 @@ describe('EthAddressHbarSpendingPlanRepository', function () {
 
         await repository.save(addressPlan, requestDetails, ttl);
         const result = await cacheService.getAsync<IEthAddressHbarSpendingPlan>(
-          `${repository['collectionKey']}:${ethAddress}`,
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
           'test',
           requestDetails,
         );
         expect(result).to.deep.equal(addressPlan);
         sinon.assert.calledWith(
           cacheServiceSpy.set,
-          `${repository['collectionKey']}:${ethAddress}`,
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
           addressPlan,
           'save',
           requestDetails,
@@ -175,20 +200,25 @@ describe('EthAddressHbarSpendingPlanRepository', function () {
       it('overwrites an existing address plan', async () => {
         const ethAddress = '0x123';
         const addressPlan: IEthAddressHbarSpendingPlan = { ethAddress, planId: uuidV4(randomBytes(16)) };
-        await cacheService.set(`${repository['collectionKey']}:${ethAddress}`, addressPlan, 'test', requestDetails);
+        await cacheService.set(
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
+          addressPlan,
+          'test',
+          requestDetails,
+        );
 
         const newPlanId = uuidV4(randomBytes(16));
         const newAddressPlan: IEthAddressHbarSpendingPlan = { ethAddress, planId: newPlanId };
         await repository.save(newAddressPlan, requestDetails, ttl);
         const result = await cacheService.getAsync<IEthAddressHbarSpendingPlan>(
-          `${repository['collectionKey']}:${ethAddress}`,
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
           'test',
           requestDetails,
         );
         expect(result).to.deep.equal(newAddressPlan);
         sinon.assert.calledWith(
           cacheServiceSpy.set,
-          `${repository['collectionKey']}:${ethAddress}`,
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
           newAddressPlan,
           'save',
           requestDetails,
@@ -201,11 +231,16 @@ describe('EthAddressHbarSpendingPlanRepository', function () {
       it('deletes an address plan successfully', async () => {
         const ethAddress = '0x123';
         const addressPlan: IEthAddressHbarSpendingPlan = { ethAddress, planId: uuidV4(randomBytes(16)) };
-        await cacheService.set(`${repository['collectionKey']}:${ethAddress}`, addressPlan, 'test', requestDetails);
+        await cacheService.set(
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
+          addressPlan,
+          'test',
+          requestDetails,
+        );
 
         await repository.delete(ethAddress, requestDetails);
         const result = await cacheService.getAsync<IEthAddressHbarSpendingPlan>(
-          `${repository['collectionKey']}:${ethAddress}`,
+          `${EthAddressHbarSpendingPlanRepository.collectionKey}:${ethAddress}`,
           'test',
           requestDetails,
         );

--- a/packages/relay/tests/lib/repositories/hbarLimiter/hbarSpendingPlanRepository.spec.ts
+++ b/packages/relay/tests/lib/repositories/hbarLimiter/hbarSpendingPlanRepository.spec.ts
@@ -77,7 +77,7 @@ describe('HbarSpendingPlanRepository', function () {
         );
         sinon.assert.calledWithMatch(
           cacheServiceSpy.set,
-          `${repository['collectionKey']}:${createdPlan.id}`,
+          `${HbarSpendingPlanRepository.collectionKey}:${createdPlan.id}`,
           createdPlan,
           'create',
           requestDetails,
@@ -137,7 +137,7 @@ describe('HbarSpendingPlanRepository', function () {
         const subscriptionTier = SubscriptionTier.BASIC;
         const createdPlan = await repository.create(subscriptionTier, requestDetails, ttl);
 
-        const key = `${repository['collectionKey']}:${createdPlan.id}:spendingHistory`;
+        const key = `${HbarSpendingPlanRepository.collectionKey}:${createdPlan.id}:spendingHistory`;
         const hbarSpending = { amount: 100, timestamp: new Date() } as IHbarSpendingRecord;
         await cacheService.rPush(key, hbarSpending, 'test', requestDetails);
 
@@ -164,7 +164,7 @@ describe('HbarSpendingPlanRepository', function () {
 
         sinon.assert.calledWithMatch(
           cacheServiceSpy.rPush,
-          `${repository['collectionKey']}:${createdPlan.id}:spendingHistory`,
+          `${HbarSpendingPlanRepository.collectionKey}:${createdPlan.id}:spendingHistory`,
           { amount, timestamp: spendingHistory[0].timestamp },
           'addAmountToSpendingHistory',
           requestDetails,
@@ -262,7 +262,7 @@ describe('HbarSpendingPlanRepository', function () {
         expect(plan!.amountSpent).to.equal(amount);
         sinon.assert.calledWithMatch(
           cacheServiceSpy.set,
-          `${repository['collectionKey']}:${createdPlan.id}:amountSpent`,
+          `${HbarSpendingPlanRepository.collectionKey}:${createdPlan.id}:amountSpent`,
           amount,
           'addToAmountSpent',
           requestDetails,
@@ -274,7 +274,7 @@ describe('HbarSpendingPlanRepository', function () {
         await repository.addToAmountSpent(createdPlan.id, newAmount, requestDetails, ttl);
         sinon.assert.calledWithMatch(
           cacheServiceSpy.incrBy,
-          `${repository['collectionKey']}:${createdPlan.id}:amountSpent`,
+          `${HbarSpendingPlanRepository.collectionKey}:${createdPlan.id}:amountSpent`,
           newAmount,
           'addToAmountSpent',
           requestDetails,
@@ -300,7 +300,7 @@ describe('HbarSpendingPlanRepository', function () {
         const createdPlan = await repository.create(subscriptionTier, requestDetails, ttl);
 
         // Manually set the plan to inactive
-        const key = `${repository['collectionKey']}:${createdPlan.id}`;
+        const key = `${HbarSpendingPlanRepository.collectionKey}:${createdPlan.id}`;
         await cacheService.set(key, { ...createdPlan, active: false }, 'test', requestDetails);
 
         const amount = 50;
@@ -327,7 +327,7 @@ describe('HbarSpendingPlanRepository', function () {
         const createdPlan = await repository.create(subscriptionTier, requestDetails, ttl);
 
         // Manually set the plan to inactive
-        const key = `${repository['collectionKey']}:${createdPlan.id}`;
+        const key = `${HbarSpendingPlanRepository.collectionKey}:${createdPlan.id}`;
         await cacheService.set(key, { ...createdPlan, active: false }, 'test', requestDetails);
 
         await expect(repository.checkExistsAndActive(createdPlan.id, requestDetails)).to.be.eventually.rejectedWith(
@@ -360,7 +360,7 @@ describe('HbarSpendingPlanRepository', function () {
         const inactivePlan = await repository.create(subscriptionTier, requestDetails, ttl);
 
         // Manually set the plan to inactive
-        const key = `${repository['collectionKey']}:${inactivePlan.id}`;
+        const key = `${HbarSpendingPlanRepository.collectionKey}:${inactivePlan.id}`;
         await cacheService.set(key, { ...inactivePlan, active: false }, 'test', requestDetails);
 
         const activePlans = await repository.findAllActiveBySubscriptionTier([subscriptionTier], requestDetails);

--- a/packages/relay/tests/lib/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.spec.ts
+++ b/packages/relay/tests/lib/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.spec.ts
@@ -76,7 +76,12 @@ describe('IPAddressHbarSpendingPlanRepository', function () {
     describe('existsByAddress', () => {
       it('returns true if address plan exists', async () => {
         const addressPlan = new IPAddressHbarSpendingPlan({ ipAddress, planId: uuidV4(randomBytes(16)) });
-        await cacheService.set(`${repository['collectionKey']}:${ipAddress}`, addressPlan, 'test', requestDetails);
+        await cacheService.set(
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
+          addressPlan,
+          'test',
+          requestDetails,
+        );
 
         await expect(repository.existsByAddress(ipAddress, requestDetails)).to.eventually.be.true;
       });
@@ -94,7 +99,12 @@ describe('IPAddressHbarSpendingPlanRepository', function () {
           new IPAddressHbarSpendingPlan({ ipAddress: '666.666.666.666', planId }),
         ];
         for (const plan of ipAddressPlans) {
-          await cacheService.set(`${repository['collectionKey']}:${plan.ipAddress}`, plan, 'test', requestDetails);
+          await cacheService.set(
+            `${IPAddressHbarSpendingPlanRepository.collectionKey}:${plan.ipAddress}`,
+            plan,
+            'test',
+            requestDetails,
+          );
         }
 
         const result = await repository.findAllByPlanId(planId, 'findAllByPlanId', requestDetails);
@@ -114,14 +124,24 @@ describe('IPAddressHbarSpendingPlanRepository', function () {
         const ipAddresses = ['555.555.555.555', '666.666.666.666'];
         for (const ipAddress of ipAddresses) {
           const addressPlan = new IPAddressHbarSpendingPlan({ ipAddress, planId });
-          await cacheService.set(`${repository['collectionKey']}:${ipAddress}`, addressPlan, 'test', requestDetails);
+          await cacheService.set(
+            `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
+            addressPlan,
+            'test',
+            requestDetails,
+          );
         }
 
         await repository.deleteAllByPlanId(planId, 'deleteAllByPlanId', requestDetails);
 
         for (const ipAddress of ipAddresses) {
-          await expect(cacheService.getAsync(`${repository['collectionKey']}:${ipAddress}`, 'test', requestDetails)).to
-            .eventually.be.null;
+          await expect(
+            cacheService.getAsync(
+              `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
+              'test',
+              requestDetails,
+            ),
+          ).to.eventually.be.null;
         }
       });
 
@@ -134,7 +154,12 @@ describe('IPAddressHbarSpendingPlanRepository', function () {
     describe('findByAddress', () => {
       it('retrieves an address plan by ip', async () => {
         const addressPlan: IIPAddressHbarSpendingPlan = { ipAddress, planId: uuidV4(randomBytes(16)) };
-        await cacheService.set(`${repository['collectionKey']}:${ipAddress}`, addressPlan, 'test', requestDetails);
+        await cacheService.set(
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
+          addressPlan,
+          'test',
+          requestDetails,
+        );
 
         const result = await repository.findByAddress(ipAddress, requestDetails);
         expect(result).to.deep.equal(addressPlan);
@@ -154,14 +179,14 @@ describe('IPAddressHbarSpendingPlanRepository', function () {
 
         await repository.save(addressPlan, requestDetails, ttl);
         const result = await cacheService.getAsync<IIPAddressHbarSpendingPlan>(
-          `${repository['collectionKey']}:${ipAddress}`,
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
           'test',
           requestDetails,
         );
         expect(result).to.deep.equal(addressPlan);
         sinon.assert.calledWith(
           cacheServiceSpy.set,
-          `${repository['collectionKey']}:${ipAddress}`,
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
           addressPlan,
           'save',
           requestDetails,
@@ -171,20 +196,25 @@ describe('IPAddressHbarSpendingPlanRepository', function () {
 
       it('overwrites an existing address plan', async () => {
         const addressPlan: IIPAddressHbarSpendingPlan = { ipAddress, planId: uuidV4(randomBytes(16)) };
-        await cacheService.set(`${repository['collectionKey']}:${ipAddress}`, addressPlan, 'test', requestDetails);
+        await cacheService.set(
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
+          addressPlan,
+          'test',
+          requestDetails,
+        );
 
         const newPlanId = uuidV4(randomBytes(16));
         const newAddressPlan: IIPAddressHbarSpendingPlan = { ipAddress, planId: newPlanId };
         await repository.save(newAddressPlan, requestDetails, ttl);
         const result = await cacheService.getAsync<IIPAddressHbarSpendingPlan>(
-          `${repository['collectionKey']}:${ipAddress}`,
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
           'test',
           requestDetails,
         );
         expect(result).to.deep.equal(newAddressPlan);
         sinon.assert.calledWith(
           cacheServiceSpy.set,
-          `${repository['collectionKey']}:${ipAddress}`,
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
           newAddressPlan,
           'save',
           requestDetails,
@@ -196,11 +226,16 @@ describe('IPAddressHbarSpendingPlanRepository', function () {
     describe('delete', () => {
       it('deletes an address plan successfully', async () => {
         const addressPlan: IIPAddressHbarSpendingPlan = { ipAddress, planId: uuidV4(randomBytes(16)) };
-        await cacheService.set(`${repository['collectionKey']}:${ipAddress}`, addressPlan, 'test', requestDetails);
+        await cacheService.set(
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
+          addressPlan,
+          'test',
+          requestDetails,
+        );
 
         await repository.delete(ipAddress, requestDetails);
         const result = await cacheService.getAsync<IIPAddressHbarSpendingPlan>(
-          `${repository['collectionKey']}:${ipAddress}`,
+          `${IPAddressHbarSpendingPlanRepository.collectionKey}:${ipAddress}`,
           'test',
           requestDetails,
         );


### PR DESCRIPTION
**Description**:

This PR implements a custom `LRUCache` implementation with the ability to protect certain keys from being deleted. The cache is designed to handle specific key prefixes that are associated with pre-configured spending plans, ensuring that these keys are not removed from the cache.

**Changes**
- CustomLRUCache Class:  
  - Added a new class CustomLRUCache that extends the LRUCache class.
  - Implemented methods to load and parse spending plans configuration from a JSON file.
  - Added logic to protect keys with specific prefixes (`hbarSpendingPlan:{{id}}`, `ethAddressHbarSpendingPlan:{{ethAddress}}`, `ipAddressHbarSpendingPlan:{{ipAddress}}`).
  - Overridden the delete method to prevent deletion of protected keys.

**Unit Tests:**  
- Added unit tests in `customLRUCache.spec.ts` to verify the behavior of the `CustomLRUCache`.
- Tests include scenarios for deleting non-protected keys, and ensuring protected keys are not deleted.

**Related issue(s)**:

Fixes #3096

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
