### PR TITLE
feat: Added NodeId to the logging just before the transaction is exec…

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -712,7 +712,11 @@ export class SDKClient {
     }
 
     try {
-      this.logger.info(`${requestDetails.formattedRequestId} Execute ${txConstructorName} transaction`);
+      this.logger.info(
+        `${requestDetails.formattedRequestId} Execute ${txConstructorName} transaction to NodeId: ${
+          this.clientMain._network.getNode().address
+        }`,
+      );
       transactionResponse = await transaction.execute(this.clientMain);
 
       transactionId = transactionResponse.transactionId.toString();


### PR DESCRIPTION
Added NodeId to the logging just before the `transaction.execute()` method in order to trace which node a transaction is submitted to.

**Related issue(s)**:

Fixes #3083 

**Notes for reviewer**:
This is a logging update.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
