### PR TITLE
feat: added redis in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
     tty: true
     volumes:
       - ./.env:/home/node/app/.env
+    environment:
+      REDIS_ENABLED: "true"
+      REDIS_URL: "redis://redis:6379"
+
   relay-ws:
     container_name: hedera-json-rpc-relay-ws
     image: "ghcr.io/hashgraph/hedera-json-rpc-relay:main"
@@ -17,6 +21,8 @@ services:
     environment:
       HEALTHCHECK_PORT: 8547
       SUBSCRIPTIONS_ENABLED: true
+      REDIS_ENABLED: "true"
+      REDIS_URL: "redis://redis:6379"
     restart: "unless-stopped"
     ports:
       - 8546:8546
@@ -25,3 +31,16 @@ services:
     tty: true
     volumes:
       - ./.env:/home/node/app/.env
+
+  redis:
+    image: redis:latest
+    container_name: redis_cache
+    ports:
+      - '6379:6379'
+    volumes:
+      - redis-data:/data
+    restart: always
+
+volumes:
+  redis-data:
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,3 +43,4 @@ services:
 
 volumes:
   redis-data:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./.env:/home/node/app/.env
     environment:
-      REDIS_ENABLED: "true"
+      REDIS_ENABLED: true
       REDIS_URL: "redis://redis:6379"
 
   relay-ws:
@@ -21,7 +21,7 @@ services:
     environment:
       HEALTHCHECK_PORT: 8547
       SUBSCRIPTIONS_ENABLED: true
-      REDIS_ENABLED: "true"
+      REDIS_ENABLED: true
       REDIS_URL: "redis://redis:6379"
     restart: "unless-stopped"
     ports:
@@ -43,4 +43,3 @@ services:
 
 volumes:
   redis-data:
-    


### PR DESCRIPTION
**Description**:
This PR adds redis to the docker-compose so that both servers can share the cache among themselves.

<img width="1308" alt="Screenshot 2024-10-19 at 4 20 29 PM" src="https://github.com/user-attachments/assets/b9f2ca01-957e-46c0-847e-fa2aae57dc54">


**Related issue(s)**:

Fixes #1869 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Docker Containers up & running :
<img width="1401" alt="Screenshot 2024-10-23 at 11 43 12 PM" src="https://github.com/user-attachments/assets/f8d24032-b6a4-4b05-9c9c-a13e6eabccfe">

Environmental variables : 
<img width="777" alt="Screenshot 2024-10-23 at 11 44 17 PM" src="https://github.com/user-attachments/assets/bc172341-36b2-44c9-a088-cb18cd3aff21">
<img width="699" alt="Screenshot 2024-10-23 at 11 44 29 PM" src="https://github.com/user-attachments/assets/9e6a7a60-5c7a-4dc4-893c-bd955df481d6">
<img width="620" alt="Screenshot 2024-10-23 at 11 44 44 PM" src="https://github.com/user-attachments/assets/245c8ee7-87b9-4ad8-9c58-d1eb50338fcd">


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
