### PR TITLE
fix: added newFilter to paramRearrangementMap for WS server

### DIFF
--- a/packages/ws-server/src/controllers/index.ts
+++ b/packages/ws-server/src/controllers/index.ts
@@ -81,6 +81,7 @@ const handleSendingRequestsToRelay = async ({
       chainId: (_, requestDetails) => [requestDetails],
       estimateGas: (params, requestDetails) => [...params, null, requestDetails],
       getStorageAt: (params, requestDetails) => [params[0], params[1], requestDetails, params[2]],
+      newFilter: (params, requestDetails) => [params[0], params[1], requestDetails, params[2], params[3]],
       default: (params, requestDetails) => [...params, requestDetails],
     };
 

--- a/packages/ws-server/src/controllers/index.ts
+++ b/packages/ws-server/src/controllers/index.ts
@@ -26,7 +26,7 @@ import { handleEthSubscribe, handleEthUnsubscribe } from './eth_subscribe';
 import { JsonRpcError, predefined, Relay } from '@hashgraph/json-rpc-relay';
 import { MirrorNodeClient } from '@hashgraph/json-rpc-relay/dist/lib/clients';
 import jsonResp from '@hashgraph/json-rpc-server/dist/koaJsonRpc/lib/RpcResponse';
-import { resolveParams, validateJsonRpcRequest, verifySupportedMethod } from '../utils/utils';
+import { paramRearrangementMap, resolveParams, validateJsonRpcRequest, verifySupportedMethod } from '../utils/utils';
 import {
   InvalidRequest,
   IPRateLimitExceeded,
@@ -76,17 +76,8 @@ const handleSendingRequestsToRelay = async ({
     const resolvedParams = resolveParams(method, params);
     const [service, methodName] = method.split('_');
 
-    // Rearrange the parameters for certain methods, since not everywhere requestDetails is last aparameter
-    const paramRearrangementMap: { [key: string]: (params: any[], requestDetails: RequestDetails) => any[] } = {
-      chainId: (_, requestDetails) => [requestDetails],
-      estimateGas: (params, requestDetails) => [...params, null, requestDetails],
-      getStorageAt: (params, requestDetails) => [params[0], params[1], requestDetails, params[2]],
-      newFilter: (params, requestDetails) => [params[0], params[1], requestDetails, params[2], params[3]],
-      default: (params, requestDetails) => [...params, requestDetails],
-    };
-
-    const rearrangeParams = paramRearrangementMap[methodName] || paramRearrangementMap['default'];
-    const rearrangedParams = rearrangeParams(resolvedParams, requestDetails);
+    const rearrangeParamsFn = paramRearrangementMap[methodName] || paramRearrangementMap['default'];
+    const rearrangedParamsArray = rearrangeParamsFn(resolvedParams, requestDetails);
 
     // Call the relay method with the resolved parameters.
     // Method will be validated by "verifySupportedMethod" before reaching this point.
@@ -95,9 +86,9 @@ const handleSendingRequestsToRelay = async ({
       txRes = await relay
         .eth()
         .filterService()
-        [methodName](...rearrangedParams);
+        [methodName](...rearrangedParamsArray);
     } else {
-      txRes = await relay[service]()[methodName](...rearrangedParams);
+      txRes = await relay[service]()[methodName](...rearrangedParamsArray);
     }
 
     if (!txRes) {

--- a/packages/ws-server/src/utils/utils.ts
+++ b/packages/ws-server/src/utils/utils.ts
@@ -202,3 +202,18 @@ export const constructValidLogSubscriptionFilter = (filters: any): object => {
     Object.entries(filters).filter(([key, value]) => value !== undefined && ['address', 'topics'].includes(key)),
   );
 };
+
+/**
+ * A mapping of parameter rearrangement functions for various methods.
+ * Each function adjusts the order of parameters to ensure that the
+ * `requestDetails` object is placed correctly based on the method's requirements.
+ */
+export const paramRearrangementMap: {
+  [key: string]: (params: any[], requestDetails: RequestDetails) => any[];
+} = {
+  chainId: (_: any[], requestDetails: RequestDetails) => [requestDetails],
+  estimateGas: (params, requestDetails) => [params[0], params[1], requestDetails],
+  getStorageAt: (params, requestDetails) => [params[0], params[1], requestDetails, params[2]],
+  newFilter: (params, requestDetails) => [params[0], params[1], requestDetails, params[2], params[3]],
+  default: (params, requestDetails) => [...params, requestDetails],
+};

--- a/packages/ws-server/tests/unit/utils.spec.ts
+++ b/packages/ws-server/tests/unit/utils.spec.ts
@@ -26,6 +26,7 @@ import {
   getMultipleAddressesEnabled,
   getWsBatchRequestsEnabled,
   handleConnectionClose,
+  paramRearrangementMap,
   resolveParams,
   sendToClient,
 } from '../../src/utils/utils';
@@ -310,6 +311,58 @@ describe('Utilities unit tests', async function () {
     WsTestHelper.withOverriddenEnvsInMochaTest({ WS_BATCH_REQUESTS_MAX_SIZE: undefined }, () => {
       it('should return 20', () => {
         expect(getBatchRequestsMaxSize()).to.equal(20);
+      });
+    });
+  });
+
+  describe('paramRearrangementMap', () => {
+    const requestDetails = new RequestDetails({ ipAddress: '0.0.0.0', requestId: 'test-id' });
+    const specialMethodNames = [`chainId`, `estimateGas`, `getStorageAt`, `newFilter`, `default`];
+
+    const mockResolvedParams = {
+      chainId: [],
+      estimateGas: [
+        {
+          to: '0xD7d454ea421FA3E98c988c2A33b5292C70A43b1E',
+          data: '0x18160ddd',
+        },
+        'latest',
+      ],
+      getStorageAt: ['0xd7d454ea421fa3e98c988c2a33b5292c70a43b1e', '0x0', 'latest'],
+      newFilter: [
+        '0x0',
+        'latest',
+        ['0xf72ea4E404618E9DCcA79748236910887be9e2bd'],
+        ['0x25d719d88a4512dd76c7442b910a83360845505894eb444ef299409e180f8fb9'],
+      ],
+      default: ['0x7cb9357e', '0x7cb9357e', '0x00abv'],
+    };
+
+    const expectedRearrangedParams = {
+      chainId: [requestDetails],
+      estimateGas: [...mockResolvedParams.estimateGas, requestDetails],
+      getStorageAt: [
+        mockResolvedParams.getStorageAt[0],
+        mockResolvedParams.getStorageAt[1],
+        requestDetails,
+        mockResolvedParams.getStorageAt[2],
+      ],
+      newFilter: [
+        mockResolvedParams.newFilter[0],
+        mockResolvedParams.newFilter[1],
+        requestDetails,
+        mockResolvedParams.newFilter[2],
+        mockResolvedParams.newFilter[3],
+      ],
+      default: [...mockResolvedParams.default, requestDetails],
+    };
+
+    specialMethodNames.forEach((methodName) => {
+      it(`Should correctly rearrange parameters for ${methodName}`, () => {
+        const rearrangeParamsFn = paramRearrangementMap[methodName];
+        const rearrangedParamsArray = rearrangeParamsFn(mockResolvedParams[methodName], requestDetails);
+        const expectedResult = expectedRearrangedParams[methodName];
+        expect(rearrangedParamsArray).to.deep.eq(expectedResult);
       });
     });
   });


### PR DESCRIPTION
**Description**:
There's a regression in the WS server that breaks the `eth_newFilter` WS endpoint. Essentially, before the data is submitted to the Relay, there’s a step to rearrange the parameters for certain special endpoints that have a different parameter order than others. This step is handled by the `paramRearrangementMap`, but it missed the `newFilter` endpoint, so the parameters weren't ordered correctly, causing the `eth_newFilter` endpoint to fail.

This PR simply adds the `newFilter` method to the `paramRearrangementMap`, fixing the issue.

**Related issue(s)**:

Fixes #3114 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
