### PR TITLE
feat: Moved sdkClient reset metrics into the metricService

### DIFF
--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -218,6 +218,9 @@ export default {
   EVENTS: {
     EXECUTE_TRANSACTION: 'execute_transaction',
     EXECUTE_QUERY: 'execute_query',
+    RESET_CLIENT_DURATION: 'reset_client_duration',
+    RESET_CLIENT_ERRORS: 'reset_client_errors',
+    RESET_CLIENT_TRANSACTIONS: 'reset_client_transactions',
   },
 
   EXECUTION_MODE: {

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -142,7 +142,7 @@ export class RelayImpl implements Relay {
 
     this.eventEmitter = new EventEmitter();
     this.cacheService = new CacheService(logger.child({ name: 'cache-service' }), register);
-    const hapiService = new HAPIService(logger, register, hbarLimiter, this.cacheService, this.eventEmitter);
+    const hapiService = new HAPIService(logger, hbarLimiter, this.cacheService, this.eventEmitter);
     this.clientMain = hapiService.getMainClientInstance();
 
     this.web3Impl = new Web3Impl(this.clientMain);
@@ -159,7 +159,7 @@ export class RelayImpl implements Relay {
 
     this.metricService = new MetricService(
       logger,
-      hapiService.getSDKClient(),
+      hapiService,
       this.mirrorNodeClient,
       hbarLimiter,
       register,

--- a/packages/relay/src/lib/types/events.ts
+++ b/packages/relay/src/lib/types/events.ts
@@ -40,3 +40,14 @@ export interface IExecuteQueryEventPayload {
   status: string;
   requestDetails: RequestDetails;
 }
+
+export interface IExecuteConsenusClientResetDurationPayload {
+  duration: number;
+}
+export interface IExecuteConsenusClientResetErrorPayload {
+  errorCodes: number[];
+}
+
+export interface IExecuteConsenusClientResetTransactionPayload {
+  transactionCount: number;
+}

--- a/packages/relay/src/lib/types/index.ts
+++ b/packages/relay/src/lib/types/index.ts
@@ -22,7 +22,13 @@ import { IFeeHistory } from './IFeeHistory';
 import { ITransactionRecordMetric } from './metrics';
 import { ITransactionReceipt } from './ITransactionReceipt';
 import { ITracerConfigWrapper } from './ITracerConfigWrapper';
-import { IExecuteQueryEventPayload, IExecuteTransactionEventPayload } from './events';
+import {
+  IExecuteQueryEventPayload,
+  IExecuteTransactionEventPayload,
+  IExecuteConsenusClientResetDurationPayload,
+  IExecuteConsenusClientResetErrorPayload,
+  IExecuteConsenusClientResetTransactionPayload,
+} from './events';
 import { ICallTracerConfig, IOpcodeLoggerConfig, ITracerConfig } from './ITracerConfig';
 import {
   IAssessedCustomFee,
@@ -62,6 +68,9 @@ export {
   MirrorNodeTransactionRecord,
   IMirrorNodeTransactionRecord,
   IExecuteTransactionEventPayload,
+  IExecuteConsenusClientResetDurationPayload,
+  IExecuteConsenusClientResetErrorPayload,
+  IExecuteConsenusClientResetTransactionPayload,
   IRequestDetails,
   RequestDetails,
 };

--- a/packages/relay/tests/lib/hapiService.spec.ts
+++ b/packages/relay/tests/lib/hapiService.spec.ts
@@ -72,7 +72,7 @@ describe('HAPI Service', async function () {
 
   withOverriddenEnvsInMochaTest({ HAPI_CLIENT_TRANSACTION_RESET: '2' }, () => {
     it('should be able to reinitialise SDK instance upon reaching transaction limit', async function () {
-      hapiService = new HAPIService(logger, registry, hbarLimiter, cacheService, eventEmitter);
+      hapiService = new HAPIService(logger, hbarLimiter, cacheService, eventEmitter);
       expect(hapiService.getTransactionCount()).to.eq(parseInt(process.env.HAPI_CLIENT_TRANSACTION_RESET!));
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -90,7 +90,7 @@ describe('HAPI Service', async function () {
 
   withOverriddenEnvsInMochaTest({ HAPI_CLIENT_DURATION_RESET: '100' }, () => {
     it('should be able to reinitialise SDK instance upon reaching time limit', async function () {
-      hapiService = new HAPIService(logger, registry, hbarLimiter, cacheService, eventEmitter);
+      hapiService = new HAPIService(logger, hbarLimiter, cacheService, eventEmitter);
       expect(hapiService.getTimeUntilReset()).to.eq(parseInt(process.env.HAPI_CLIENT_DURATION_RESET!));
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -107,7 +107,7 @@ describe('HAPI Service', async function () {
 
   withOverriddenEnvsInMochaTest({ HAPI_CLIENT_ERROR_RESET: '[50]' }, () => {
     it('should be able to reinitialise SDK instance upon error status code encounter', async function () {
-      hapiService = new HAPIService(logger, registry, hbarLimiter, cacheService, eventEmitter);
+      hapiService = new HAPIService(logger, hbarLimiter, cacheService, eventEmitter);
       expect(hapiService.getErrorCodes()[0]).to.eq(JSON.parse(process.env.HAPI_CLIENT_ERROR_RESET!)[0]);
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -130,7 +130,7 @@ describe('HAPI Service', async function () {
     },
     () => {
       it('should be able to reset all counter upon reinitialization of the SDK Client', async function () {
-        hapiService = new HAPIService(logger, registry, hbarLimiter, cacheService, eventEmitter);
+        hapiService = new HAPIService(logger, hbarLimiter, cacheService, eventEmitter);
 
         expect(hapiService.getErrorCodes()[0]).to.eq(JSON.parse(process.env.HAPI_CLIENT_ERROR_RESET!)[0]);
         const oldClientInstance = hapiService.getMainClientInstance();
@@ -157,7 +157,7 @@ describe('HAPI Service', async function () {
     () => {
       it('should keep the same instance of hbar limiter and not reset the budget', async function () {
         const costAmount = 10000;
-        hapiService = new HAPIService(logger, registry, hbarLimiter, cacheService, eventEmitter);
+        hapiService = new HAPIService(logger, hbarLimiter, cacheService, eventEmitter);
 
         const hbarLimiterBudgetBefore = hbarLimiter.getRemainingBudget();
         const oldClientInstance = hapiService.getMainClientInstance();
@@ -185,7 +185,7 @@ describe('HAPI Service', async function () {
     },
     () => {
       it('should not be able to reinitialise and decrement counters, if it is disabled', async function () {
-        hapiService = new HAPIService(logger, registry, hbarLimiter, cacheService, eventEmitter);
+        hapiService = new HAPIService(logger, hbarLimiter, cacheService, eventEmitter);
         expect(hapiService.getTransactionCount()).to.eq(parseInt(process.env.HAPI_CLIENT_TRANSACTION_RESET!));
 
         const oldClientInstance = hapiService.getMainClientInstance();

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -141,8 +141,9 @@ describe('SdkClient', async function () {
       new CacheService(logger.child({ name: `cache` }), registry),
       instance,
     );
+    const hapiService = new HAPIService(logger, hbarLimiter, new CacheService(logger, registry), eventEmitter);
 
-    metricService = new MetricService(logger, sdkClient, mirrorNodeClient, hbarLimiter, registry, eventEmitter);
+    metricService = new MetricService(logger, hapiService, mirrorNodeClient, hbarLimiter, registry, eventEmitter);
   });
 
   beforeEach(() => {

--- a/packages/relay/tests/lib/services/metricService/metricService.spec.ts
+++ b/packages/relay/tests/lib/services/metricService/metricService.spec.ts
@@ -40,6 +40,7 @@ import MetricService from '../../../../src/lib/services/metricService/metricServ
 import { CacheService } from '../../../../src/lib/services/cacheService/cacheService';
 import { IExecuteQueryEventPayload, IExecuteTransactionEventPayload, RequestDetails } from '../../../../src/lib/types';
 import { AccountId, Client, Hbar, Long, Status, TransactionRecord, TransactionRecordQuery } from '@hashgraph/sdk';
+import HAPIService from '../../../../src/lib/services/hapiService/hapiService';
 
 config({ path: resolve(__dirname, '../../../test.env') });
 const registry = new Registry();
@@ -142,15 +143,15 @@ describe('Metric Service', function () {
     hbarLimiter = new HbarLimit(logger.child({ name: 'hbar-rate-limit' }), Date.now(), total, duration, registry);
     eventEmitter = new EventEmitter();
 
-    const sdkClient = new SDKClient(
-      client,
-      logger.child({ name: `consensus-node` }),
+    const hapiService = new HAPIService(
+      logger,
       hbarLimiter,
       new CacheService(logger.child({ name: `cache` }), registry),
       eventEmitter,
     );
+
     // Init new MetricService instance
-    metricService = new MetricService(logger, sdkClient, mirrorNodeClient, hbarLimiter, registry, eventEmitter);
+    metricService = new MetricService(logger, hapiService, mirrorNodeClient, hbarLimiter, registry, eventEmitter);
   });
 
   afterEach(() => {


### PR DESCRIPTION

**Description**:
Moved sdkClient reset metrics into the metricService and replaced labels with prometheus counters.

**Related issue(s)**:

Fixes #3075 

**Notes for reviewer**:
The old client reset counter was not used and was problematic.

Labels Are Not Meant for Numerical Data: In Prometheus, labels are designed for categorical data used to identify or group metrics (e.g., by host, region, or service). They are not intended for storing numerical data that you want to plot or perform calculations on.

Inability to Perform Calculations: Since label values are strings, you cannot perform arithmetic operations on them in Prometheus queries.

Visualization Challenges: Grafana relies on numerical data points over time to generate graphs. With the current setup, it's difficult to extract and plot the numerical values from labels.

This change replaces the labels with counters.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
