### PR TITLE
fix: do not link IP addresses of general users

### DIFF
--- a/packages/relay/src/lib/db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository.ts
@@ -103,21 +103,6 @@ export class EthAddressHbarSpendingPlanRepository {
   }
 
   /**
-   * Deletes all spending plans associted with EVM addresses from cache.
-   *
-   * @param {RequestDetails} requestDetails - The request details for logging and tracking.
-   * @returns {Promise<void>} - A promise that resolves when all IP address spending plans are deleted.
-   */
-  async deleteAll(requestDetails: RequestDetails): Promise<void> {
-    const key = this.getKey('*');
-    const keys = await this.cache.keys(key, this.deleteAll.name, requestDetails);
-    for (const key of keys) {
-      await this.cache.delete(key, this.deleteAll.name, requestDetails);
-    }
-    this.logger.trace(`${requestDetails.formattedRequestId} Deleted all EVM address spending plans`);
-  }
-
-  /**
    * Finds an {@link EthAddressHbarSpendingPlan} for an ETH address.
    *
    * @param {string} ethAddress - The ETH address to search for.

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
@@ -103,21 +103,6 @@ export class IPAddressHbarSpendingPlanRepository {
   }
 
   /**
-   * Deletes all spending plans associated with IP address from cache.
-   *
-   * @param {RequestDetails} requestDetails - The request details for logging and tracking.
-   * @returns {Promise<void>} - A promise that resolves when all IP address spending plans are deleted.
-   */
-  async deleteAll(requestDetails: RequestDetails): Promise<void> {
-    const key = this.getKey('*');
-    const keys = await this.cache.keys(key, this.deleteAll.name, requestDetails);
-    for (const key of keys) {
-      await this.cache.delete(key, this.deleteAll.name, requestDetails);
-    }
-    this.logger.trace(`${requestDetails.formattedRequestId} Deleted all IP address spending plans`);
-  }
-
-  /**
    * Finds an {@link IPAddressHbarSpendingPlan} for an IP address.
    *
    * @param {string} ipAddress - The IP address to search for.

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -229,13 +229,21 @@ export class HbarLimitService implements IHbarLimitService {
 
     const ipAddress = requestDetails.ipAddress;
     if (!ethAddress && !ipAddress) {
-      throw new Error('Cannot add expense without an eth address or ip address');
+      this.logger.trace('Cannot add expense to a spending plan without an eth address or ip address');
+      return;
     }
 
     let spendingPlan = await this.getSpendingPlan(ethAddress, requestDetails);
     if (!spendingPlan) {
-      // Create a basic spending plan if none exists for the eth address or ip address
-      spendingPlan = await this.createBasicSpendingPlan(ethAddress, requestDetails);
+      if (ethAddress) {
+        // Create a basic spending plan if none exists for the eth address
+        spendingPlan = await this.createBasicSpendingPlan(ethAddress, requestDetails);
+      } else {
+        this.logger.warn(
+          `${requestDetails.formattedRequestId} Cannot add expense to a spending plan without an eth address or ip address`,
+        );
+        return;
+      }
     }
 
     this.logger.trace(
@@ -455,7 +463,7 @@ export class HbarLimitService implements IHbarLimitService {
     requestDetails: RequestDetails,
   ): Promise<IDetailedHbarSpendingPlan> {
     if (!ethAddress) {
-      throw new Error('Cannot create a spending plan without an associated eth address or ip address');
+      throw new Error('Cannot create a spending plan without an associated eth address');
     }
 
     const spendingPlan = await this.hbarSpendingPlanRepository.create(

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -454,8 +454,7 @@ export class HbarLimitService implements IHbarLimitService {
     ethAddress: string,
     requestDetails: RequestDetails,
   ): Promise<IDetailedHbarSpendingPlan> {
-    const ipAddress = requestDetails.ipAddress;
-    if (!ethAddress && !ipAddress) {
+    if (!ethAddress) {
       throw new Error('Cannot create a spending plan without an associated eth address or ip address');
     }
 
@@ -464,26 +463,16 @@ export class HbarLimitService implements IHbarLimitService {
       requestDetails,
       this.limitDuration,
     );
-    if (ethAddress) {
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} Linking spending plan with ID ${spendingPlan.id} to eth address ${ethAddress}`,
-      );
-      await this.ethAddressHbarSpendingPlanRepository.save(
-        { ethAddress, planId: spendingPlan.id },
-        requestDetails,
-        this.limitDuration,
-      );
-    }
-    if (ipAddress) {
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} Linking spending plan with ID ${spendingPlan.id} to ip address`,
-      );
-      await this.ipAddressHbarSpendingPlanRepository.save(
-        { ipAddress, planId: spendingPlan.id },
-        requestDetails,
-        this.limitDuration,
-      );
-    }
+
+    this.logger.trace(
+      `${requestDetails.formattedRequestId} Linking spending plan with ID ${spendingPlan.id} to eth address ${ethAddress}`,
+    );
+    await this.ethAddressHbarSpendingPlanRepository.save(
+      { ethAddress, planId: spendingPlan.id },
+      requestDetails,
+      this.limitDuration,
+    );
+
     return spendingPlan;
   }
 }

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -371,8 +371,6 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
               `${requestDetails.formattedRequestId} Deploy parent contract on address ${parentContractAddress}`,
             );
 
-            //Unlinking the ipAdress, since the deployContract will link the ip address to a spending plan and the following transaction will use the same plan
-            await ipSpendingPlanRepository.deleteAll(requestDetails);
             expect(ethAddressSpendingPlanRepository.findByAddress(accounts[2].address, requestDetails)).to.be.rejected;
             const gasPrice = await relay.gasPrice(requestId);
             const transaction = {
@@ -423,7 +421,6 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
             );
             expect(amountSpendAfterFirst).to.be.lt(spendingPlanAssociatedAfterSecond.amountSpent);
 
-            await ipSpendingPlanRepository.deleteAll(requestDetails);
             // it should use a different BASIC plan for another user
             const thirdTransaction = {
               ...defaultLondonTransactionData,


### PR DESCRIPTION
Related issue: #2850 
**Description**:

This PR addresses the following concern:
> Yeah I believe the logic should securely handle checks on both EVM addresses and IP addresses independently, without either depending on the other.
> I thought of a scenario where a random application, like an NFT marketplace or a DEX, submits user requests from the same centralized server (i.e., the same IP address). Users connect to the platform using different wallet accounts (i.e., different EVM addresses), but all requests are submitted to the network under a single IP address. If we only validate based on the IP address, traffic becomes unfair since requests from different users would be dependent on one another. A user might reach the HBAR limit even if they have not made prior calls, simply because the spending plan associated with that IP address has exceeded its limit.

For EXTENDED and PRIVILEGED:
- this is not possible to happen due to us clearing any previous links of the ETH and IP addresses specified in the configuration file
