### PR TITLE
feat: add env masking for values starting with known secrets prefixes

### DIFF
--- a/packages/config-service/src/services/loggerService.ts
+++ b/packages/config-service/src/services/loggerService.ts
@@ -45,8 +45,9 @@ export class LoggerService {
   static maskUpEnv(envName: string, envValue: string | undefined): string {
     const isSensitiveField: boolean = this.SENSITIVE_FIELDS.indexOf(envName) > -1;
     const isKnownSecret: boolean =
-      GlobalConfig.ENTRIES[envName].type === 'string' &&
-      this.KNOWN_SECRET_PREFIXES.indexOf(envValue ? envValue.slice(0, 3) : '') > -1;
+      GlobalConfig.ENTRIES[envName].type === 'string' && envValue
+        ? !!envValue.match(/^(gh[pousr]_[a-zA-Z0-9]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$/)
+        : false;
 
     if (isSensitiveField || isKnownSecret) {
       return `${envName} = **********`;

--- a/packages/config-service/src/services/loggerService.ts
+++ b/packages/config-service/src/services/loggerService.ts
@@ -28,6 +28,14 @@ export class LoggerService {
     GlobalConfig.ENTRIES.GH_ACCESS_TOKEN.envName,
   ];
 
+  public static readonly KNOWN_SECRET_PREFIXES = [
+    'ghp', // GitHub personal access tokens
+    'gho', // OAuth access tokens
+    'ghu', // GitHub user-to-server tokens
+    'ghs', // GitHub server-to-server tokens
+    'ghr', // refresh tokens
+  ];
+
   /**
    * Hide sensitive information
    *
@@ -35,7 +43,12 @@ export class LoggerService {
    * @param envValue
    */
   static maskUpEnv(envName: string, envValue: string | undefined): string {
-    if (this.SENSITIVE_FIELDS.indexOf(envName) > -1) {
+    const isSensitiveField: boolean = this.SENSITIVE_FIELDS.indexOf(envName) > -1;
+    const isKnownSecret: boolean =
+      GlobalConfig.ENTRIES[envName].type === 'string' &&
+      this.KNOWN_SECRET_PREFIXES.indexOf(envValue ? envValue.slice(0, 3) : '') > -1;
+
+    if (isSensitiveField || isKnownSecret) {
       return `${envName} = **********`;
     }
 

--- a/packages/config-service/src/services/loggerService.ts
+++ b/packages/config-service/src/services/loggerService.ts
@@ -36,6 +36,9 @@ export class LoggerService {
     'ghr', // refresh tokens
   ];
 
+  public static readonly GITHUB_SECRET_PATTERN: RegExp =
+    /^(gh[pousr]_[a-zA-Z0-9]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$/;
+
   /**
    * Hide sensitive information
    *
@@ -46,7 +49,7 @@ export class LoggerService {
     const isSensitiveField: boolean = this.SENSITIVE_FIELDS.indexOf(envName) > -1;
     const isKnownSecret: boolean =
       GlobalConfig.ENTRIES[envName].type === 'string' && envValue
-        ? !!envValue.match(/^(gh[pousr]_[a-zA-Z0-9]{36,251}|github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})$/)
+        ? !!envValue.match(this.GITHUB_SECRET_PATTERN)
         : false;
 
     if (isSensitiveField || isKnownSecret) {

--- a/packages/config-service/src/services/loggerService.ts
+++ b/packages/config-service/src/services/loggerService.ts
@@ -48,7 +48,7 @@ export class LoggerService {
   static maskUpEnv(envName: string, envValue: string | undefined): string {
     const isSensitiveField: boolean = this.SENSITIVE_FIELDS.indexOf(envName) > -1;
     const isKnownSecret: boolean =
-      GlobalConfig.ENTRIES[envName].type === 'string' && envValue ? !!this.GITHUB_SECRET_PATTERN.exec(envValue) : false;
+      GlobalConfig.ENTRIES[envName].type === 'string' && !!this.GITHUB_SECRET_PATTERN.exec(envValue ?? '');
 
     if (isSensitiveField || isKnownSecret) {
       return `${envName} = **********`;

--- a/packages/config-service/src/services/loggerService.ts
+++ b/packages/config-service/src/services/loggerService.ts
@@ -48,9 +48,7 @@ export class LoggerService {
   static maskUpEnv(envName: string, envValue: string | undefined): string {
     const isSensitiveField: boolean = this.SENSITIVE_FIELDS.indexOf(envName) > -1;
     const isKnownSecret: boolean =
-      GlobalConfig.ENTRIES[envName].type === 'string' && envValue
-        ? !!envValue.match(this.GITHUB_SECRET_PATTERN)
-        : false;
+      GlobalConfig.ENTRIES[envName].type === 'string' && envValue ? !!this.GITHUB_SECRET_PATTERN.exec(envValue) : false;
 
     if (isSensitiveField || isKnownSecret) {
       return `${envName} = **********`;

--- a/packages/config-service/tests/src/services/loggerService.spec.ts
+++ b/packages/config-service/tests/src/services/loggerService.spec.ts
@@ -40,7 +40,7 @@ describe('LoggerService tests', async function () {
     const { envName } = GlobalConfig.ENTRIES.HBAR_SPENDING_PLANS_CONFIG_FILE;
 
     for (const prefix of LoggerService.KNOWN_SECRET_PREFIXES) {
-      const value = prefix + crypto.randomBytes(16).toString('hex');
+      const value = prefix + '_VVurqVVh68wgxgcVjrvVVVcNcVVVVi3CRwl1';
       const res = LoggerService.maskUpEnv(envName, value);
       expect(res).to.equal(`${envName} = **********`);
     }

--- a/packages/config-service/tests/src/services/loggerService.spec.ts
+++ b/packages/config-service/tests/src/services/loggerService.spec.ts
@@ -36,6 +36,16 @@ describe('LoggerService tests', async function () {
     }
   });
 
+  it('should be able to mask every value if it starts with known secret prefix', async () => {
+    const { envName } = GlobalConfig.ENTRIES.HBAR_SPENDING_PLANS_CONFIG_FILE;
+
+    for (const prefix of LoggerService.KNOWN_SECRET_PREFIXES) {
+      const value = prefix + crypto.randomBytes(16).toString('hex');
+      const res = LoggerService.maskUpEnv(envName, value);
+      expect(res).to.equal(`${envName} = **********`);
+    }
+  });
+
   it('should be able to return plain information', async () => {
     const envName = GlobalConfig.ENTRIES.CHAIN_ID.envName;
     const res = ConfigService.get(envName);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

Examine the env variable value and mask anything starting with one of the prefixes described in https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/

**Solution**:

Modify the `maskUp` method in ConfigService to hide secrets that start with known prefixes.

**Related issue(s)**:

Fixes #3143

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
