### PR TITLE
refactor: add log level guards to prevent unnecessary string generation

### DIFF
--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -128,7 +128,9 @@ export class LocalLRUCache implements ICacheClient {
       const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
       const censoredValue = JSON.stringify(value).replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
       const message = `Returning cached value ${censoredKey}:${censoredValue} on ${callingMethod} call`;
-      this.logger.trace(`${requestDetails.formattedRequestId} ${message}`);
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(`${requestDetails.formattedRequestId} ${message}`);
+      }
       return value;
     }
 
@@ -145,9 +147,11 @@ export class LocalLRUCache implements ICacheClient {
   public async getRemainingTtl(key: string, callingMethod: string, requestDetails: RequestDetails): Promise<number> {
     const cache = this.getCacheInstance(key);
     const remainingTtl = cache.getRemainingTTL(key); // in milliseconds
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} returning remaining TTL ${key}:${remainingTtl} on ${callingMethod} call`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} returning remaining TTL ${key}:${remainingTtl} on ${callingMethod} call`,
+      );
+    }
     return remainingTtl;
   }
 
@@ -179,9 +183,11 @@ export class LocalLRUCache implements ICacheClient {
     const message = `Caching ${censoredKey}:${censoredValue} on ${callingMethod} for ${
       resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'
     }`;
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} ${message} (cache size: ${this.cache.size}, max: ${this.options.max})`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} ${message} (cache size: ${this.cache.size}, max: ${this.options.max})`,
+      );
+    }
   }
 
   /**
@@ -232,7 +238,9 @@ export class LocalLRUCache implements ICacheClient {
    * @param {RequestDetails} requestDetails - The request details for logging and tracking.
    */
   public async delete(key: string, callingMethod: string, requestDetails: RequestDetails): Promise<void> {
-    this.logger.trace(`${requestDetails.formattedRequestId} delete cache for ${key} on ${callingMethod} call`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} delete cache for ${key} on ${callingMethod} call`);
+    }
     const cache = this.getCacheInstance(key);
     cache.delete(key);
   }
@@ -290,9 +298,11 @@ export class LocalLRUCache implements ICacheClient {
 
     const matchingKeys = keys.filter((key) => regex.test(key));
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} retrieving keys matching ${pattern} on ${callingMethod} call`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} retrieving keys matching ${pattern} on ${callingMethod} call`,
+      );
+    }
     return matchingKeys;
   }
 

--- a/packages/relay/src/lib/clients/cache/redisCache.ts
+++ b/packages/relay/src/lib/clients/cache/redisCache.ts
@@ -141,7 +141,9 @@ export class RedisCache implements IRedisCacheClient {
       const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
       const censoredValue = result.replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
       const message = `Returning cached value ${censoredKey}:${censoredValue} on ${callingMethod} call`;
-      this.logger.trace(`${requestDetails.formattedRequestId} ${message}`);
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(`${requestDetails.formattedRequestId} ${message}`);
+      }
       // TODO: add metrics
       return JSON.parse(result);
     }
@@ -179,7 +181,9 @@ export class RedisCache implements IRedisCacheClient {
     const message = `Caching ${censoredKey}:${censoredValue} on ${callingMethod} for ${
       resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'
     }`;
-    this.logger.trace(`${requestDetails.formattedRequestId} ${message}`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} ${message}`);
+    }
     // TODO: add metrics
   }
 
@@ -208,9 +212,11 @@ export class RedisCache implements IRedisCacheClient {
 
     // Log the operation
     const entriesLength = Object.keys(keyValuePairs).length;
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} caching multiple keys via ${callingMethod}, total keys: ${entriesLength}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} caching multiple keys via ${callingMethod}, total keys: ${entriesLength}`,
+      );
+    }
   }
 
   /**
@@ -243,9 +249,11 @@ export class RedisCache implements IRedisCacheClient {
 
     // Log the operation
     const entriesLength = Object.keys(keyValuePairs).length;
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} caching multiple keys via ${callingMethod}, total keys: ${entriesLength}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} caching multiple keys via ${callingMethod}, total keys: ${entriesLength}`,
+      );
+    }
   }
 
   /**
@@ -259,7 +267,9 @@ export class RedisCache implements IRedisCacheClient {
   async delete(key: string, callingMethod: string, requestDetails: RequestDetails): Promise<void> {
     const client = await this.getConnectedClient();
     await client.del(key);
-    this.logger.trace(`${requestDetails.formattedRequestId} delete cache for ${key} on ${callingMethod} call`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} delete cache for ${key} on ${callingMethod} call`);
+    }
     // TODO: add metrics
   }
 
@@ -327,7 +337,11 @@ export class RedisCache implements IRedisCacheClient {
   async incrBy(key: string, amount: number, callingMethod: string, requestDetails: RequestDetails): Promise<number> {
     const client = await this.getConnectedClient();
     const result = await client.incrBy(key, amount);
-    this.logger.trace(`${requestDetails.formattedRequestId} incrementing ${key} by ${amount} on ${callingMethod} call`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} incrementing ${key} by ${amount} on ${callingMethod} call`,
+      );
+    }
     return result;
   }
 
@@ -350,9 +364,11 @@ export class RedisCache implements IRedisCacheClient {
   ): Promise<any[]> {
     const client = await this.getConnectedClient();
     const result = await client.lRange(key, start, end);
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} retrieving range [${start}:${end}] from ${key} on ${callingMethod} call`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} retrieving range [${start}:${end}] from ${key} on ${callingMethod} call`,
+      );
+    }
     return result.map((item) => JSON.parse(item));
   }
 
@@ -369,9 +385,11 @@ export class RedisCache implements IRedisCacheClient {
     const client = await this.getConnectedClient();
     const serializedValue = JSON.stringify(value);
     const result = await client.rPush(key, serializedValue);
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} pushing ${serializedValue} to ${key} on ${callingMethod} call`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} pushing ${serializedValue} to ${key} on ${callingMethod} call`,
+      );
+    }
     return result;
   }
 
@@ -385,9 +403,11 @@ export class RedisCache implements IRedisCacheClient {
   async keys(pattern: string, callingMethod: string, requestDetails: RequestDetails): Promise<string[]> {
     const client = await this.getConnectedClient();
     const result = await client.keys(pattern);
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} retrieving keys matching ${pattern} on ${callingMethod} call`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} retrieving keys matching ${pattern} on ${callingMethod} call`,
+      );
+    }
     return result;
   }
 }

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -587,9 +587,11 @@ export class SDKClient {
         const sdkClientError = new SDKClientError(e, e.message);
         if (sdkClientError.isTimeoutExceeded()) {
           const delay = retries * 1000;
-          this.logger.trace(
-            `${requestDetails.formattedRequestId} Contract call query failed with status ${sdkClientError.message}. Retrying again after ${delay} ms ...`,
-          );
+          if (this.logger.isLevelEnabled('trace')) {
+            this.logger.trace(
+              `${requestDetails.formattedRequestId} Contract call query failed with status ${sdkClientError.message}. Retrying again after ${delay} ms ...`,
+            );
+          }
           retries++;
           await new Promise((r) => setTimeout(r, delay));
           continue;
@@ -702,9 +704,11 @@ export class SDKClient {
         throw predefined.REQUEST_TIMEOUT;
       }
 
-      this.logger.debug(
-        `${requestIdPrefix} Fail to execute ${queryConstructorName} query: paymentTransactionId=${query.paymentTransactionId}, callerName=${callerName}, status=${sdkClientError.status}(${sdkClientError.status._code}), cost=${queryCost} tinybars`,
-      );
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          `${requestIdPrefix} Fail to execute ${queryConstructorName} query: paymentTransactionId=${query.paymentTransactionId}, callerName=${callerName}, status=${sdkClientError.status}(${sdkClientError.status._code}), cost=${queryCost} tinybars`,
+        );
+      }
 
       throw sdkClientError;
     } finally {
@@ -982,9 +986,11 @@ export class SDKClient {
         this.logger.warn(`${requestDetails.formattedRequestId} File ${fileId} is empty.`);
         throw new SDKClientError({}, `${requestDetails.formattedRequestId} Created file is empty. `);
       }
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} Created file with fileId: ${fileId} and file size ${fileInfo.size}`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestDetails.formattedRequestId} Created file with fileId: ${fileId} and file size ${fileInfo.size}`,
+        );
+      }
     }
 
     return fileId;
@@ -1033,7 +1039,9 @@ export class SDKClient {
       );
 
       if (fileInfo.isDeleted) {
-        this.logger.trace(`${requestDetails.formattedRequestId} Deleted file with fileId: ${fileId}`);
+        if (this.logger.isLevelEnabled('trace')) {
+          this.logger.trace(`${requestDetails.formattedRequestId} Deleted file with fileId: ${fileId}`);
+        }
       } else {
         this.logger.warn(`${requestDetails.formattedRequestId} Fail to delete file with fileId: ${fileId} `);
       }
@@ -1088,9 +1096,11 @@ export class SDKClient {
     let transactionFee: number = 0;
     let txRecordChargeAmount: number = 0;
     try {
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} Get transaction record via consensus node: transactionId=${transactionId}, txConstructorName=${txConstructorName}, callerName=${callerName}`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestDetails.formattedRequestId} Get transaction record via consensus node: transactionId=${transactionId}, txConstructorName=${txConstructorName}, callerName=${callerName}`,
+        );
+      }
 
       const transactionRecord = await new TransactionRecordQuery()
         .setTransactionId(transactionId)

--- a/packages/relay/src/lib/config/hbarSpendingPlanConfigService.ts
+++ b/packages/relay/src/lib/config/hbarSpendingPlanConfigService.ts
@@ -131,7 +131,9 @@ export class HbarSpendingPlanConfigService {
     const spendingPlanConfig = ConfigService.get('HBAR_SPENDING_PLANS_CONFIG') as string;
 
     if (!spendingPlanConfig) {
-      logger.trace('HBAR_SPENDING_PLANS_CONFIG is undefined');
+      if (logger.isLevelEnabled('trace')) {
+        logger.trace('HBAR_SPENDING_PLANS_CONFIG is undefined');
+      }
       return [];
     }
 
@@ -140,16 +142,22 @@ export class HbarSpendingPlanConfigService {
       return JSON.parse(spendingPlanConfig) as SpendingPlanConfig[];
     } catch (jsonParseError: any) {
       // If parsing as JSON fails, treat it as a file path
-      logger.trace(
-        `Failed to parse HBAR_SPENDING_PLAN as JSON: ${jsonParseError.message}, now treating it as a file path...`,
-      );
+      if (logger.isLevelEnabled('trace')) {
+        logger.trace(
+          `Failed to parse HBAR_SPENDING_PLAN as JSON: ${jsonParseError.message}, now treating it as a file path...`,
+        );
+      }
       try {
         const configFilePath = findConfig(spendingPlanConfig);
         if (configFilePath && fs.existsSync(configFilePath)) {
           const fileContent = fs.readFileSync(configFilePath, 'utf-8');
           return JSON.parse(fileContent) as SpendingPlanConfig[];
         } else {
-          logger.trace(`HBAR Spending Configuration file not found at path "${configFilePath ?? spendingPlanConfig}"`);
+          if (logger.isLevelEnabled('trace')) {
+            logger.trace(
+              `HBAR Spending Configuration file not found at path "${configFilePath ?? spendingPlanConfig}"`,
+            );
+          }
           return [];
         }
       } catch (fileError: any) {
@@ -244,9 +252,11 @@ export class HbarSpendingPlanConfigService {
     requestDetails: RequestDetails,
   ): Promise<void> {
     for (const planConfig of spendingPlanConfigs) {
-      this.logger.trace(
-        `Updating associations for HBAR spending plan '${planConfig.name}' with ID ${planConfig.id}...`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `Updating associations for HBAR spending plan '${planConfig.name}' with ID ${planConfig.id}...`,
+        );
+      }
       await this.deleteObsoleteEthAddressAssociations(planConfig, requestDetails);
       await this.deleteObsoleteIpAddressAssociations(planConfig, requestDetails);
       await this.updateEthAddressAssociations(planConfig, requestDetails);

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository.ts
@@ -94,9 +94,11 @@ export class EthAddressHbarSpendingPlanRepository {
     for (const key of keys) {
       const addressPlan = await this.cache.getAsync<IEthAddressHbarSpendingPlan>(key, callingMethod, requestDetails);
       if (addressPlan?.planId === planId) {
-        this.logger.trace(
-          `${requestDetails.formattedRequestId} Removing ETH address ${addressPlan.ethAddress} from HbarSpendingPlan with ID ${planId}`,
-        );
+        if (this.logger.isLevelEnabled('trace')) {
+          this.logger.trace(
+            `${requestDetails.formattedRequestId} Removing ETH address ${addressPlan.ethAddress} from HbarSpendingPlan with ID ${planId}`,
+          );
+        }
         await this.cache.delete(key, callingMethod, requestDetails);
       }
     }
@@ -115,9 +117,11 @@ export class EthAddressHbarSpendingPlanRepository {
     if (!addressPlan) {
       throw new EthAddressHbarSpendingPlanNotFoundError(ethAddress);
     }
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Retrieved link between ETH address ${ethAddress} and HbarSpendingPlan with ID ${addressPlan.planId}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Retrieved link between ETH address ${ethAddress} and HbarSpendingPlan with ID ${addressPlan.planId}`,
+      );
+    }
     return new EthAddressHbarSpendingPlan(addressPlan);
   }
 
@@ -132,9 +136,11 @@ export class EthAddressHbarSpendingPlanRepository {
   async save(addressPlan: IEthAddressHbarSpendingPlan, requestDetails: RequestDetails, ttl: number): Promise<void> {
     const key = this.getKey(addressPlan.ethAddress);
     await this.cache.set(key, addressPlan, 'save', requestDetails, ttl);
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Linked ETH address ${addressPlan.ethAddress} to HbarSpendingPlan with ID ${addressPlan.planId}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Linked ETH address ${addressPlan.ethAddress} to HbarSpendingPlan with ID ${addressPlan.planId}`,
+      );
+    }
   }
 
   /**
@@ -151,7 +157,9 @@ export class EthAddressHbarSpendingPlanRepository {
     const errorMessage = ethAddressPlan
       ? `Removed ETH address ${ethAddress} from HbarSpendingPlan with ID ${ethAddressPlan.planId}`
       : `Trying to remove ETH address ${ethAddress}, which is not linked to a spending plan`;
-    this.logger.trace(`${requestDetails.formattedRequestId} ${errorMessage}`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} ${errorMessage}`);
+    }
   }
 
   /**

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
@@ -61,7 +61,9 @@ export class HbarSpendingPlanRepository {
     if (!plan) {
       throw new HbarSpendingPlanNotFoundError(id);
     }
-    this.logger.trace(`${requestDetails.formattedRequestId} Retrieved subscription with ID ${id}`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} Retrieved subscription with ID ${id}`);
+    }
     return {
       ...plan,
       createdAt: new Date(plan.createdAt),
@@ -105,14 +107,18 @@ export class HbarSpendingPlanRepository {
       spendingHistory: [],
       amountSpent: 0,
     };
-    this.logger.trace(`${requestDetails.formattedRequestId} Creating HbarSpendingPlan with ID ${plan.id}...`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} Creating HbarSpendingPlan with ID ${plan.id}...`);
+    }
     const key = this.getKey(plan.id);
     await this.cache.set(key, plan, 'create', requestDetails, ttl);
     return new HbarSpendingPlan(plan);
   }
 
   async delete(id: string, requestDetails: RequestDetails): Promise<void> {
-    this.logger.trace(`${requestDetails.formattedRequestId} Deleting HbarSpendingPlan with ID ${id}...`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} Deleting HbarSpendingPlan with ID ${id}...`);
+    }
     const key = this.getKey(id);
     await this.cache.delete(key, 'delete', requestDetails);
   }
@@ -139,9 +145,11 @@ export class HbarSpendingPlanRepository {
   async getSpendingHistory(id: string, requestDetails: RequestDetails): Promise<IHbarSpendingRecord[]> {
     await this.checkExistsAndActive(id, requestDetails);
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Retrieving spending history for HbarSpendingPlan with ID ${id}...`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Retrieving spending history for HbarSpendingPlan with ID ${id}...`,
+      );
+    }
     const key = this.getSpendingHistoryKey(id);
     const spendingHistory = await this.cache.lRange<IHbarSpendingRecord>(
       key,
@@ -163,9 +171,11 @@ export class HbarSpendingPlanRepository {
   async addAmountToSpendingHistory(id: string, amount: number, requestDetails: RequestDetails): Promise<number> {
     await this.checkExistsAndActive(id, requestDetails);
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Adding ${amount} to spending history for HbarSpendingPlan with ID ${id}...`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Adding ${amount} to spending history for HbarSpendingPlan with ID ${id}...`,
+      );
+    }
     const key = this.getSpendingHistoryKey(id);
     const entry: IHbarSpendingRecord = { amount, timestamp: new Date() };
     return this.cache.rPush(key, entry, 'addAmountToSpendingHistory', requestDetails);
@@ -180,9 +190,11 @@ export class HbarSpendingPlanRepository {
   async getAmountSpent(id: string, requestDetails: RequestDetails): Promise<number> {
     await this.checkExistsAndActive(id, requestDetails);
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Retrieving amountSpent for HbarSpendingPlan with ID ${id}...`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Retrieving amountSpent for HbarSpendingPlan with ID ${id}...`,
+      );
+    }
     const key = this.getAmountSpentKey(id);
     return this.cache
       .getAsync(key, 'getAmountSpent', requestDetails)
@@ -194,15 +206,19 @@ export class HbarSpendingPlanRepository {
    * @returns {Promise<void>} - A promise that resolves when the operation is complete.
    */
   async resetAmountSpentOfAllPlans(requestDetails: RequestDetails): Promise<void> {
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Resetting the \`amountSpent\` entries for all HbarSpendingPlans...`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Resetting the \`amountSpent\` entries for all HbarSpendingPlans...`,
+      );
+    }
     const callerMethod = this.resetAmountSpentOfAllPlans.name;
     const keys = await this.cache.keys(this.getAmountSpentKey('*'), callerMethod, requestDetails);
     await Promise.all(keys.map((key) => this.cache.delete(key, callerMethod, requestDetails)));
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Successfully reset ${keys.length} "amountSpent" entries for HbarSpendingPlans.`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Successfully reset ${keys.length} "amountSpent" entries for HbarSpendingPlans.`,
+      );
+    }
   }
 
   /**
@@ -218,14 +234,18 @@ export class HbarSpendingPlanRepository {
 
     const key = this.getAmountSpentKey(id);
     if (!(await this.cache.getAsync(key, 'addToAmountSpent', requestDetails))) {
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} No spending yet for HbarSpendingPlan with ID ${id}, setting amountSpent to ${amount}...`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestDetails.formattedRequestId} No spending yet for HbarSpendingPlan with ID ${id}, setting amountSpent to ${amount}...`,
+        );
+      }
       await this.cache.set(key, amount, 'addToAmountSpent', requestDetails, ttl);
     } else {
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} Adding ${amount} to amountSpent for HbarSpendingPlan with ID ${id}...`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestDetails.formattedRequestId} Adding ${amount} to amountSpent for HbarSpendingPlan with ID ${id}...`,
+        );
+      }
       await this.cache.incrBy(key, amount, 'addToAmountSpent', requestDetails);
     }
   }

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
@@ -94,9 +94,11 @@ export class IPAddressHbarSpendingPlanRepository {
     for (const key of keys) {
       const addressPlan = await this.cache.getAsync<IIPAddressHbarSpendingPlan>(key, callingMethod, requestDetails);
       if (addressPlan?.planId === planId) {
-        this.logger.trace(
-          `${requestDetails.formattedRequestId} Removing IP address from HbarSpendingPlan with ID ${planId}`,
-        );
+        if (this.logger.isLevelEnabled('trace')) {
+          this.logger.trace(
+            `${requestDetails.formattedRequestId} Removing IP address from HbarSpendingPlan with ID ${planId}`,
+          );
+        }
         await this.cache.delete(key, callingMethod, requestDetails);
       }
     }
@@ -115,9 +117,11 @@ export class IPAddressHbarSpendingPlanRepository {
     if (!addressPlan) {
       throw new IPAddressHbarSpendingPlanNotFoundError(ipAddress);
     }
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Retrieved link between IP address and HbarSpendingPlan with ID ${addressPlan.planId}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Retrieved link between IP address and HbarSpendingPlan with ID ${addressPlan.planId}`,
+      );
+    }
     return new IPAddressHbarSpendingPlan(addressPlan);
   }
 
@@ -151,7 +155,9 @@ export class IPAddressHbarSpendingPlanRepository {
     const errorMessage = ipAddressSpendingPlan
       ? `Removed IP address from HbarSpendingPlan with ID ${ipAddressSpendingPlan.planId}`
       : `Trying to remove an IP address, which is not linked to a spending plan`;
-    this.logger.trace(`${requestDetails.formattedRequestId} ${errorMessage}`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} ${errorMessage}`);
+    }
   }
 
   /**

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -307,7 +307,9 @@ export class EthImpl implements Eth {
    * with the behavior of Infura.
    */
   accounts(requestDetails: RequestDetails): never[] {
-    this.logger.trace(`${requestDetails.formattedRequestId} accounts()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} accounts()`);
+    }
     return EthImpl.accounts;
   }
 
@@ -330,9 +332,11 @@ export class EthImpl implements Eth {
       ? constants.DEFAULT_FEE_HISTORY_MAX_RESULTS
       : Number(ConfigService.get('FEE_HISTORY_MAX_RESULTS'));
 
-    this.logger.trace(
-      `${requestIdPrefix} feeHistory(blockCount=${blockCount}, newestBlock=${newestBlock}, rewardPercentiles=${rewardPercentiles})`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} feeHistory(blockCount=${blockCount}, newestBlock=${newestBlock}, rewardPercentiles=${rewardPercentiles})`,
+      );
+    }
 
     try {
       const latestBlockNumber = await this.translateBlockTag(EthImpl.blockLatest, requestDetails);
@@ -485,9 +489,11 @@ export class EthImpl implements Eth {
     }
 
     if (_.isNil(networkFees)) {
-      this.logger.debug(
-        `${requestDetails.formattedRequestId} Mirror Node returned no network fees. Fallback to consensus node.`,
-      );
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          `${requestDetails.formattedRequestId} Mirror Node returned no network fees. Fallback to consensus node.`,
+        );
+      }
       networkFees = {
         fees: [
           {
@@ -515,7 +521,9 @@ export class EthImpl implements Eth {
    * Gets the most recent block number.
    */
   async blockNumber(requestDetails: RequestDetails): Promise<string> {
-    this.logger.trace(`${requestDetails.formattedRequestId} blockNumber()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} blockNumber()`);
+    }
     return await this.common.getLatestBlockNumber(requestDetails);
   }
 
@@ -523,7 +531,9 @@ export class EthImpl implements Eth {
    * Gets the most recent block number and timestamp.to which represents the block finality.
    */
   async blockNumberTimestamp(caller: string, requestDetails: RequestDetails): Promise<LatestBlockNumberTimestamp> {
-    this.logger.trace(`${requestDetails.formattedRequestId} blockNumber()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} blockNumber()`);
+    }
 
     const cacheKey = `${constants.CACHE_KEY.ETH_BLOCK_NUMBER}`;
 
@@ -548,7 +558,9 @@ export class EthImpl implements Eth {
    * `CHAIN_ID`.
    */
   chainId(requestDetails: RequestDetails): string {
-    this.logger.trace(`${requestDetails.formattedRequestId} chainId()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} chainId()`);
+    }
     return this.chain;
   }
 
@@ -571,9 +583,11 @@ export class EthImpl implements Eth {
         .inc();
     }
 
-    this.logger.trace(
-      `${requestIdPrefix} estimateGas(transaction=${JSON.stringify(transaction)}, _blockParam=${_blockParam})`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} estimateGas(transaction=${JSON.stringify(transaction)}, _blockParam=${_blockParam})`,
+      );
+    }
 
     try {
       const response = await this.estimateGasFromMirrorNode(transaction, requestDetails);
@@ -740,7 +754,9 @@ export class EthImpl implements Eth {
    * @throws Will throw an error if unable to retrieve the gas price.
    */
   async gasPrice(requestDetails: RequestDetails): Promise<string> {
-    this.logger.trace(`${requestDetails.formattedRequestId} eth_gasPrice`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} eth_gasPrice`);
+    }
     try {
       let gasPrice: number | undefined = await this.cacheService.getAsync(
         constants.CACHE_KEY.GAS_PRICE,
@@ -770,7 +786,9 @@ export class EthImpl implements Eth {
    * Gets whether this "Ethereum client" is a miner. We don't mine, so this always returns false.
    */
   async mining(requestDetails: RequestDetails): Promise<boolean> {
-    this.logger.trace(`${requestDetails.formattedRequestId} mining()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} mining()`);
+    }
     return false;
   }
 
@@ -778,7 +796,9 @@ export class EthImpl implements Eth {
    * TODO Needs docs, or be removed?
    */
   async submitWork(requestDetails: RequestDetails): Promise<boolean> {
-    this.logger.trace(`${requestDetails.formattedRequestId} submitWork()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} submitWork()`);
+    }
     return false;
   }
 
@@ -786,7 +806,9 @@ export class EthImpl implements Eth {
    * TODO Needs docs, or be removed?
    */
   async syncing(requestDetails: RequestDetails): Promise<boolean> {
-    this.logger.trace(`${requestDetails.formattedRequestId} syncing()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} syncing()`);
+    }
     return false;
   }
 
@@ -794,7 +816,9 @@ export class EthImpl implements Eth {
    * Always returns null. There are no uncles in Hedera.
    */
   async getUncleByBlockHashAndIndex(requestDetails: RequestDetails): Promise<null> {
-    this.logger.trace(`${requestDetails.formattedRequestId} getUncleByBlockHashAndIndex()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} getUncleByBlockHashAndIndex()`);
+    }
     return null;
   }
 
@@ -802,7 +826,9 @@ export class EthImpl implements Eth {
    * Always returns null. There are no uncles in Hedera.
    */
   async getUncleByBlockNumberAndIndex(requestDetails: RequestDetails): Promise<null> {
-    this.logger.trace(`${requestDetails.formattedRequestId} getUncleByBlockNumberAndIndex()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} getUncleByBlockNumberAndIndex()`);
+    }
     return null;
   }
 
@@ -810,7 +836,9 @@ export class EthImpl implements Eth {
    * Always returns '0x0'. There are no uncles in Hedera.
    */
   async getUncleCountByBlockHash(requestDetails: RequestDetails): Promise<string> {
-    this.logger.trace(`${requestDetails.formattedRequestId} getUncleCountByBlockHash()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} getUncleCountByBlockHash()`);
+    }
     return EthImpl.zeroHex;
   }
 
@@ -818,7 +846,9 @@ export class EthImpl implements Eth {
    * Always returns '0x0'. There are no uncles in Hedera.
    */
   async getUncleCountByBlockNumber(requestDetails: RequestDetails): Promise<string> {
-    this.logger.trace(`${requestDetails.formattedRequestId} getUncleCountByBlockNumber()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} getUncleCountByBlockNumber()`);
+    }
     return EthImpl.zeroHex;
   }
 
@@ -826,7 +856,9 @@ export class EthImpl implements Eth {
    * TODO Needs docs, or be removed?
    */
   async hashrate(requestDetails: RequestDetails): Promise<string> {
-    this.logger.trace(`${requestDetails.formattedRequestId} hashrate()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} hashrate()`);
+    }
     return EthImpl.zeroHex;
   }
 
@@ -834,7 +866,9 @@ export class EthImpl implements Eth {
    * Always returns UNSUPPORTED_METHOD error.
    */
   getWork(requestDetails: RequestDetails): JsonRpcError {
-    this.logger.trace(`${requestDetails.formattedRequestId} getWork()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} getWork()`);
+    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -842,32 +876,44 @@ export class EthImpl implements Eth {
    * Unsupported methods always return UNSUPPORTED_METHOD error.
    */
   submitHashrate(requestDetails: RequestDetails): JsonRpcError {
-    this.logger.trace(`${requestDetails.formattedRequestId} submitHashrate()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} submitHashrate()`);
+    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
   signTransaction(requestDetails: RequestDetails): JsonRpcError {
-    this.logger.trace(`${requestDetails.formattedRequestId} signTransaction()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} signTransaction()`);
+    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
   sign(requestDetails: RequestDetails): JsonRpcError {
-    this.logger.trace(`${requestDetails.formattedRequestId} sign()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} sign()`);
+    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
   sendTransaction(requestDetails: RequestDetails): JsonRpcError {
-    this.logger.trace(`${requestDetails.formattedRequestId} sendTransaction()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} sendTransaction()`);
+    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
   protocolVersion(requestDetails: RequestDetails): JsonRpcError {
-    this.logger.trace(`${requestDetails.formattedRequestId} protocolVersion()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} protocolVersion()`);
+    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
   coinbase(requestDetails: RequestDetails): JsonRpcError {
-    this.logger.trace(`${requestDetails.formattedRequestId} coinbase()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} coinbase()`);
+    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -886,9 +932,11 @@ export class EthImpl implements Eth {
     blockNumberOrTagOrHash?: string | null,
   ): Promise<string> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(
-      `${requestIdPrefix} getStorageAt(address=${address}, slot=${slot}, blockNumberOrOrHashTag=${blockNumberOrTagOrHash})`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} getStorageAt(address=${address}, slot=${slot}, blockNumberOrOrHashTag=${blockNumberOrTagOrHash})`,
+      );
+    }
 
     let result = EthImpl.zeroHex32Byte; // if contract or slot not found then return 32 byte 0
 
@@ -942,7 +990,11 @@ export class EthImpl implements Eth {
   ): Promise<string> {
     const requestIdPrefix = requestDetails.formattedRequestId;
     const latestBlockTolerance = 1;
-    this.logger.trace(`${requestIdPrefix} getBalance(account=${account}, blockNumberOrTag=${blockNumberOrTagOrHash})`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} getBalance(account=${account}, blockNumberOrTag=${blockNumberOrTagOrHash})`,
+      );
+    }
 
     let latestBlock: LatestBlockNumberTimestamp | null | undefined;
     // this check is required, because some tools like Metamask pass for parameter latest block, with a number (ex 0x30ea)
@@ -953,7 +1005,11 @@ export class EthImpl implements Eth {
       const blockNumberCached = await this.cacheService.getAsync(cacheKey, EthImpl.ethGetBalance, requestDetails);
 
       if (blockNumberCached) {
-        this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(blockNumberCached)}`);
+        if (this.logger.isLevelEnabled('trace')) {
+          this.logger.trace(
+            `${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(blockNumberCached)}`,
+          );
+        }
         latestBlock = { blockNumber: blockNumberCached, timeStampTo: '0' };
       } else {
         latestBlock = await this.blockNumberTimestamp(EthImpl.ethGetBalance, requestDetails);
@@ -983,7 +1039,9 @@ export class EthImpl implements Eth {
     const cacheKey = `${constants.CACHE_KEY.ETH_GET_BALANCE}-${account}-${blockNumberOrTagOrHash}`;
     let cachedBalance = await this.cacheService.getAsync(cacheKey, EthImpl.ethGetBalance, requestDetails);
     if (cachedBalance && this.shouldUseCacheForBalance(blockNumberOrTagOrHash)) {
-      this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(cachedBalance)}`);
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(cachedBalance)}`);
+      }
       return cachedBalance;
     }
 
@@ -1067,17 +1125,21 @@ export class EthImpl implements Eth {
       }
 
       if (!balanceFound) {
-        this.logger.debug(
-          `${requestIdPrefix} Unable to find account ${account} in block ${JSON.stringify(
-            blockNumber,
-          )}(${blockNumberOrTagOrHash}), returning 0x0 balance`,
-        );
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(
+            `${requestIdPrefix} Unable to find account ${account} in block ${JSON.stringify(
+              blockNumber,
+            )}(${blockNumberOrTagOrHash}), returning 0x0 balance`,
+          );
+        }
         return EthImpl.zeroHex;
       }
 
       // save in cache the current balance for the account and blockNumberOrTag
       cachedBalance = numberTo0x(weibars);
-      this.logger.trace(`${requestIdPrefix} Value cached balance ${cachedBalance}`);
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(`${requestIdPrefix} Value cached balance ${cachedBalance}`);
+      }
       await this.cacheService.set(
         cacheKey,
         cachedBalance,
@@ -1109,14 +1171,18 @@ export class EthImpl implements Eth {
         `The value passed is not a valid blockHash/blockNumber/blockTag value: ${blockNumber}`,
       );
     }
-    this.logger.trace(`${requestIdPrefix} getCode(address=${address}, blockNumber=${blockNumber})`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} getCode(address=${address}, blockNumber=${blockNumber})`);
+    }
 
     // check for static precompile cases first before consulting nodes
     // this also account for environments where system entities were not yet exposed to the mirror node
     if (address === EthImpl.iHTSAddress) {
-      this.logger.trace(
-        `${requestIdPrefix} HTS precompile case, return ${EthImpl.invalidEVMInstruction} for byte code`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestIdPrefix} HTS precompile case, return ${EthImpl.invalidEVMInstruction} for byte code`,
+        );
+      }
       return EthImpl.invalidEVMInstruction;
     }
 
@@ -1137,7 +1203,9 @@ export class EthImpl implements Eth {
       ]);
       if (result) {
         if (result?.type === constants.TYPE_TOKEN) {
-          this.logger.trace(`${requestIdPrefix} Token redirect case, return redirectBytecode`);
+          if (this.logger.isLevelEnabled('trace')) {
+            this.logger.trace(`${requestIdPrefix} Token redirect case, return redirectBytecode`);
+          }
           return EthImpl.redirectBytecodeAddressReplace(address);
         } else if (result?.type === constants.TYPE_CONTRACT) {
           if (result?.entity.runtime_bytecode !== EthImpl.emptyHex) {
@@ -1166,9 +1234,11 @@ export class EthImpl implements Eth {
       if (e instanceof SDKClientError) {
         // handle INVALID_CONTRACT_ID or CONTRACT_DELETED
         if (e.isInvalidContractId() || e.isContractDeleted()) {
-          this.logger.debug(
-            `${requestIdPrefix} Unable to find code for contract ${address} in block "${blockNumber}", returning 0x0, err code: ${e.statusCode}`,
-          );
+          if (this.logger.isLevelEnabled('debug')) {
+            this.logger.debug(
+              `${requestIdPrefix} Unable to find code for contract ${address} in block "${blockNumber}", returning 0x0, err code: ${e.statusCode}`,
+            );
+          }
           return EthImpl.emptyHex;
         }
 
@@ -1182,9 +1252,11 @@ export class EthImpl implements Eth {
           e.status._code === constants.PRECHECK_STATUS_ERROR_STATUS_CODES.INVALID_CONTRACT_ID ||
           e.status._code === constants.PRECHECK_STATUS_ERROR_STATUS_CODES.CONTRACT_DELETED
         ) {
-          this.logger.debug(
-            `${requestIdPrefix} Unable to find code for contract ${address} in block "${blockNumber}", returning 0x0, err code: ${e.message}`,
-          );
+          if (this.logger.isLevelEnabled('debug')) {
+            this.logger.debug(
+              `${requestIdPrefix} Unable to find code for contract ${address} in block "${blockNumber}", returning 0x0, err code: ${e.message}`,
+            );
+          }
           return EthImpl.emptyHex;
         }
 
@@ -1273,9 +1345,11 @@ export class EthImpl implements Eth {
       requestDetails,
     );
     if (cachedResponse) {
-      this.logger.debug(
-        `${requestIdPrefix} getBlockTransactionCountByHash returned cached response: ${cachedResponse}`,
-      );
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          `${requestIdPrefix} getBlockTransactionCountByHash returned cached response: ${cachedResponse}`,
+        );
+      }
       return cachedResponse;
     }
 
@@ -1300,7 +1374,11 @@ export class EthImpl implements Eth {
     requestDetails: RequestDetails,
   ): Promise<string | null> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(`${requestIdPrefix} getBlockTransactionCountByNumber(blockNum=${blockNumOrTag}, showDetails=%o)`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} getBlockTransactionCountByNumber(blockNum=${blockNumOrTag}, showDetails=%o)`,
+      );
+    }
     const blockNum = await this.translateBlockTag(blockNumOrTag, requestDetails);
 
     const cacheKey = `${constants.CACHE_KEY.ETH_GET_TRANSACTION_COUNT_BY_NUMBER}_${blockNum}`;
@@ -1310,9 +1388,11 @@ export class EthImpl implements Eth {
       requestDetails,
     );
     if (cachedResponse) {
-      this.logger.debug(
-        `${requestIdPrefix} getBlockTransactionCountByNumber returned cached response: ${cachedResponse}`,
-      );
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          `${requestIdPrefix} getBlockTransactionCountByNumber returned cached response: ${cachedResponse}`,
+        );
+      }
       return cachedResponse;
     }
 
@@ -1343,9 +1423,11 @@ export class EthImpl implements Eth {
     requestDetails: RequestDetails,
   ): Promise<Transaction | null> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(
-      `${requestIdPrefix} getTransactionByBlockHashAndIndex(hash=${blockHash}, index=${transactionIndex})`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} getTransactionByBlockHashAndIndex(hash=${blockHash}, index=${transactionIndex})`,
+      );
+    }
 
     try {
       return await this.getTransactionByBlockHashOrBlockNumAndIndex(
@@ -1374,9 +1456,11 @@ export class EthImpl implements Eth {
     requestDetails: RequestDetails,
   ): Promise<Transaction | null> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(
-      `${requestIdPrefix} getTransactionByBlockNumberAndIndex(blockNum=${blockNumOrTag}, index=${transactionIndex})`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} getTransactionByBlockNumberAndIndex(blockNum=${blockNumOrTag}, index=${transactionIndex})`,
+      );
+    }
     const blockNum = await this.translateBlockTag(blockNumOrTag, requestDetails);
 
     try {
@@ -1409,13 +1493,17 @@ export class EthImpl implements Eth {
     requestDetails: RequestDetails,
   ): Promise<string | JsonRpcError> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(`${requestIdPrefix} getTransactionCount(address=${address}, blockNumOrTag=${blockNumOrTag})`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} getTransactionCount(address=${address}, blockNumOrTag=${blockNumOrTag})`);
+    }
 
     // cache considerations for high load
     const cacheKey = `eth_getTransactionCount_${address}_${blockNumOrTag}`;
     let nonceCount = await this.cacheService.getAsync(cacheKey, EthImpl.ethGetTransactionCount, requestDetails);
     if (nonceCount) {
-      this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(nonceCount)}`);
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(`${requestIdPrefix} returning cached value ${cacheKey}:${JSON.stringify(nonceCount)}`);
+      }
       return nonceCount;
     }
 
@@ -1463,9 +1551,11 @@ export class EthImpl implements Eth {
       const parsedTx = Precheck.parseTxIfNeeded(transaction);
       interactingEntity = parsedTx.to?.toString() || '';
       originatingAddress = parsedTx.from?.toString() || '';
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} sendRawTransaction(from=${originatingAddress}, to=${interactingEntity}, transaction=${transaction})`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestDetails.formattedRequestId} sendRawTransaction(from=${originatingAddress}, to=${interactingEntity}, transaction=${transaction})`,
+        );
+      }
 
       await this.precheck.sendRawTransactionCheck(parsedTx, networkGasPriceInWeiBars, requestDetails);
       return parsedTx;
@@ -1508,11 +1598,13 @@ export class EthImpl implements Eth {
             break;
           }
 
-          this.logger.trace(
-            `${
-              requestDetails.formattedRequestId
-            } Repeating retry to poll for updated account nonce. Count ${i} of ${mirrorNodeGetContractResultRetries}. Waiting ${this.mirrorNodeClient.getMirrorNodeRetryDelay()} ms before initiating a new request`,
-          );
+          if (this.logger.isLevelEnabled('trace')) {
+            this.logger.trace(
+              `${
+                requestDetails.formattedRequestId
+              } Repeating retry to poll for updated account nonce. Count ${i} of ${mirrorNodeGetContractResultRetries}. Waiting ${this.mirrorNodeClient.getMirrorNodeRetryDelay()} ms before initiating a new request`,
+            );
+          }
           await new Promise((r) => setTimeout(r, this.mirrorNodeClient.getMirrorNodeRetryDelay()));
         }
 
@@ -1652,7 +1744,9 @@ export class EthImpl implements Eth {
     );
     // log call data size
     const callDataSize = callData ? callData.length : 0;
-    this.logger.trace(`${requestIdPrefix} call data size: ${callDataSize}`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} call data size: ${callDataSize}`);
+    }
     // metrics for selector
     if (callDataSize >= constants.FUNCTION_SELECTOR_CHAR_LENGTH) {
       this.ethExecutionsCounter
@@ -1690,7 +1784,9 @@ export class EthImpl implements Eth {
         result = await this.callMirrorNode(call, gas, call.value, blockNumberOrTag, requestDetails);
       }
 
-      this.logger.debug(`${requestIdPrefix} eth_call response: ${JSON.stringify(result)}`);
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(`${requestIdPrefix} eth_call response: ${JSON.stringify(result)}`);
+      }
 
       return result;
     } catch (e: any) {
@@ -1794,14 +1890,16 @@ export class EthImpl implements Eth {
     const requestIdPrefix = requestDetails.formattedRequestId;
     let callData: IContractCallRequest = {};
     try {
-      this.logger.debug(
-        `${requestIdPrefix} Making eth_call on contract ${call.to} with gas ${gas} and call data "${call.data}" from "${call.from}" at blockBlockNumberOrTag: "${block}" using mirror-node.`,
-        call.to,
-        gas,
-        call.data,
-        call.from,
-        block,
-      );
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          `${requestIdPrefix} Making eth_call on contract ${call.to} with gas ${gas} and call data "${call.data}" from "${call.from}" at blockBlockNumberOrTag: "${block}" using mirror-node.`,
+          call.to,
+          gas,
+          call.data,
+          call.from,
+          block,
+        );
+      }
       callData = {
         ...call,
         ...(gas !== null ? { gas } : {}), // Add gas only if it's not null
@@ -1828,9 +1926,11 @@ export class EthImpl implements Eth {
         }
 
         if (e.isContractReverted()) {
-          this.logger.trace(
-            `${requestIdPrefix} mirror node eth_call request encountered contract revert. message: ${e.message}, details: ${e.detail}, data: ${e.data}`,
-          );
+          if (this.logger.isLevelEnabled('trace')) {
+            this.logger.trace(
+              `${requestIdPrefix} mirror node eth_call request encountered contract revert. message: ${e.message}, details: ${e.detail}, data: ${e.data}`,
+            );
+          }
           return predefined.CONTRACT_REVERT(e.detail || e.message, e.data);
         }
 
@@ -1839,11 +1939,13 @@ export class EthImpl implements Eth {
         if (e.isNotSupported() || e.isNotSupportedSystemContractOperaton()) {
           const errorTypeMessage =
             e.isNotSupported() || e.isNotSupportedSystemContractOperaton() ? 'Unsupported' : 'Unhandled';
-          this.logger.trace(
-            `${requestIdPrefix} ${errorTypeMessage} mirror node eth_call request, retrying with consensus node. details: ${JSON.stringify(
-              callData,
-            )} with error: "${e.message}"`,
-          );
+          if (this.logger.isLevelEnabled('trace')) {
+            this.logger.trace(
+              `${requestIdPrefix} ${errorTypeMessage} mirror node eth_call request, retrying with consensus node. details: ${JSON.stringify(
+                callData,
+              )} with error: "${e.message}"`,
+            );
+          }
           return await this.callConsensusNode(call, gas, requestDetails);
         }
       }
@@ -1872,13 +1974,15 @@ export class EthImpl implements Eth {
       gas = Number.parseInt(this.defaultGas);
     }
 
-    this.logger.debug(
-      `${requestIdPrefix} Making eth_call on contract ${call.to} with gas ${gas} and call data "${call.data}" from "${call.from}" using consensus-node.`,
-      call.to,
-      gas,
-      call.data,
-      call.from,
-    );
+    if (this.logger.isLevelEnabled('debug')) {
+      this.logger.debug(
+        `${requestIdPrefix} Making eth_call on contract ${call.to} with gas ${gas} and call data "${call.data}" from "${call.from}" using consensus-node.`,
+        call.to,
+        gas,
+        call.data,
+        call.from,
+      );
+    }
 
     // If "From" is distinct from blank, we check is a valid account
     if (call.from) {
@@ -1902,7 +2006,9 @@ export class EthImpl implements Eth {
       const cachedResponse = await this.cacheService.getAsync(cacheKey, EthImpl.ethCall, requestDetails);
 
       if (cachedResponse != undefined) {
-        this.logger.debug(`${requestIdPrefix} eth_call returned cached response: ${cachedResponse}`);
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(`${requestIdPrefix} eth_call returned cached response: ${cachedResponse}`);
+        }
         return cachedResponse;
       }
 
@@ -1984,7 +2090,9 @@ export class EthImpl implements Eth {
    */
   async getTransactionByHash(hash: string, requestDetails: RequestDetails): Promise<Transaction | null> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(`${requestIdPrefix} getTransactionByHash(hash=${hash})`, hash);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} getTransactionByHash(hash=${hash})`, hash);
+    }
 
     const contractResult = await this.mirrorNodeClient.getContractResultWithRetry(hash, requestDetails);
     if (contractResult === null || contractResult.hash === undefined) {
@@ -1999,7 +2107,9 @@ export class EthImpl implements Eth {
 
       // no tx found
       if (!syntheticLogs.length) {
-        this.logger.trace(`${requestIdPrefix} no tx for ${hash}`);
+        if (this.logger.isLevelEnabled('trace')) {
+          this.logger.trace(`${requestIdPrefix} no tx for ${hash}`);
+        }
         return null;
       }
 
@@ -2031,14 +2141,20 @@ export class EthImpl implements Eth {
    */
   async getTransactionReceipt(hash: string, requestDetails: RequestDetails): Promise<any> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(`${requestIdPrefix} getTransactionReceipt(${hash})`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} getTransactionReceipt(${hash})`);
+    }
 
     const cacheKey = `${constants.CACHE_KEY.ETH_GET_TRANSACTION_RECEIPT}_${hash}`;
     const cachedResponse = await this.cacheService.getAsync(cacheKey, EthImpl.ethGetTransactionReceipt, requestDetails);
     if (cachedResponse) {
-      this.logger.debug(
-        `${requestIdPrefix} getTransactionReceipt returned cached response: ${JSON.stringify(cachedResponse)}`,
-      );
+      if (this.logger.isLevelEnabled('debug')) {
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(
+            `${requestIdPrefix} getTransactionReceipt returned cached response: ${JSON.stringify(cachedResponse)}`,
+          );
+        }
+      }
       return cachedResponse;
     }
 
@@ -2055,7 +2171,9 @@ export class EthImpl implements Eth {
 
       // no tx found
       if (!syntheticLogs.length) {
-        this.logger.trace(`${requestIdPrefix} no receipt for ${hash}`);
+        if (this.logger.isLevelEnabled('trace')) {
+          this.logger.trace(`${requestIdPrefix} no receipt for ${hash}`);
+        }
         return null;
       }
 
@@ -2078,7 +2196,9 @@ export class EthImpl implements Eth {
         type: null, // null from HAPI transactions
       };
 
-      this.logger.trace(`${requestIdPrefix} receipt for ${hash} found in block ${receipt.blockNumber}`);
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(`${requestIdPrefix} receipt for ${hash} found in block ${receipt.blockNumber}`);
+      }
 
       await this.cacheService.set(
         cacheKey,
@@ -2129,7 +2249,9 @@ export class EthImpl implements Eth {
           : prepend0x(ASCIIToHex(receiptResponse.error_message));
       }
 
-      this.logger.trace(`${requestIdPrefix} receipt for ${hash} found in block ${receipt.blockNumber}`);
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(`${requestIdPrefix} receipt for ${hash} found in block ${receipt.blockNumber}`);
+      }
 
       await this.cacheService.set(
         cacheKey,
@@ -2216,9 +2338,11 @@ export class EthImpl implements Eth {
     // With values over the gas limit, the call will fail with BUSY error so we cap it at 15_000_000
     const gas = Number.parseInt(gasString);
     if (gas > constants.MAX_GAS_PER_SEC) {
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} eth_call gas amount (${gas}) exceeds network limit, capping gas to ${constants.MAX_GAS_PER_SEC}`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestDetails.formattedRequestId} eth_call gas amount (${gas}) exceeds network limit, capping gas to ${constants.MAX_GAS_PER_SEC}`,
+        );
+      }
       return constants.MAX_GAS_PER_SEC;
     }
 
@@ -2247,9 +2371,11 @@ export class EthImpl implements Eth {
       });
     }
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Synthetic transaction hashes will be populated in the block response`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Synthetic transaction hashes will be populated in the block response`,
+      );
+    }
 
     return transactionsArray;
   }
@@ -2302,9 +2428,11 @@ export class EthImpl implements Eth {
       // there are several hedera-specific validations that occur right before entering the evm
       // if a transaction has reverted there, we should not include that tx in the block response
       if (Utils.isRevertedDueToHederaSpecificValidation(contractResult)) {
-        this.logger.debug(
-          `${requestDetails.formattedRequestId} Transaction with hash ${contractResult.hash} is skipped due to hedera-specific validation failure (${contractResult.result})`,
-        );
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(
+            `${requestDetails.formattedRequestId} Transaction with hash ${contractResult.hash} is skipped due to hedera-specific validation failure (${contractResult.result})`,
+          );
+        }
         continue;
       }
       contractResult.from = await this.resolveEvmAddress(contractResult.from, requestDetails, [constants.TYPE_ACCOUNT]);
@@ -2512,7 +2640,9 @@ export class EthImpl implements Eth {
   }
 
   async maxPriorityFeePerGas(requestDetails: RequestDetails): Promise<string> {
-    this.logger.trace(`${requestDetails.formattedRequestId} maxPriorityFeePerGas()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} maxPriorityFeePerGas()`);
+    }
     return EthImpl.zeroHex;
   }
 

--- a/packages/relay/src/lib/poller.ts
+++ b/packages/relay/src/lib/poller.ts
@@ -74,7 +74,9 @@ export class Poller {
   public poll() {
     this.polls.forEach(async (poll) => {
       try {
-        this.logger.debug(`${LOGGER_PREFIX} Fetching data for tag: ${poll.tag}`);
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(`${LOGGER_PREFIX} Fetching data for tag: ${poll.tag}`);
+        }
 
         const { event, filters } = JSON.parse(poll.tag);
         let data;
@@ -104,13 +106,17 @@ export class Poller {
 
         if (Array.isArray(data)) {
           if (data.length) {
-            this.logger.trace(`${LOGGER_PREFIX} Received ${data.length} results from tag: ${poll.tag}`);
+            if (this.logger.isLevelEnabled('trace')) {
+              this.logger.trace(`${LOGGER_PREFIX} Received ${data.length} results from tag: ${poll.tag}`);
+            }
             data.forEach((d) => {
               poll.callback(d);
             });
           }
         } else {
-          this.logger.trace(`${LOGGER_PREFIX} Received 1 result from tag: ${poll.tag}`);
+          if (this.logger.isLevelEnabled('trace')) {
+            this.logger.trace(`${LOGGER_PREFIX} Received 1 result from tag: ${poll.tag}`);
+          }
           poll.callback(data);
         }
       } catch (error) {

--- a/packages/relay/src/lib/services/debugService/index.ts
+++ b/packages/relay/src/lib/services/debugService/index.ts
@@ -102,7 +102,9 @@ export class DebugService implements IDebugService {
     tracerConfig: ITracerConfig,
     requestDetails: RequestDetails,
   ): Promise<any> {
-    this.logger.trace(`${requestDetails.formattedRequestId} debug_traceTransaction(${transactionIdOrHash})`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} debug_traceTransaction(${transactionIdOrHash})`);
+    }
     try {
       DebugService.requireDebugAPIEnabled();
       if (tracer === TracerType.CallTracer) {

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -216,9 +216,13 @@ export class CommonService implements ICommonService {
     );
 
     if (blockNumberCached) {
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} returning cached value ${cacheKey}:${JSON.stringify(blockNumberCached)}`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestDetails.formattedRequestId} returning cached value ${cacheKey}:${JSON.stringify(
+            blockNumberCached,
+          )}`,
+        );
+      }
       return blockNumberCached;
     }
 

--- a/packages/relay/src/lib/services/ethService/ethFilterService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethFilterService/index.ts
@@ -94,7 +94,9 @@ export class FilterService implements IFilterService {
       requestDetails,
       constants.FILTER.TTL,
     );
-    this.logger.trace(`${requestDetails.formattedRequestId} created filter with TYPE=${type}, params: ${params}`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} created filter with TYPE=${type}, params: ${params}`);
+    }
     return filterId;
   }
 
@@ -123,9 +125,11 @@ export class FilterService implements IFilterService {
     topics?: any[],
   ): Promise<string> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(
-      `${requestIdPrefix} newFilter(fromBlock=${fromBlock}, toBlock=${toBlock}, address=${address}, topics=${topics})`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} newFilter(fromBlock=${fromBlock}, toBlock=${toBlock}, address=${address}, topics=${topics})`,
+      );
+    }
     try {
       FilterService.requireFiltersEnabled();
 
@@ -152,7 +156,9 @@ export class FilterService implements IFilterService {
 
   async newBlockFilter(requestDetails: RequestDetails): Promise<string> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(`${requestIdPrefix} newBlockFilter()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} newBlockFilter()`);
+    }
     try {
       FilterService.requireFiltersEnabled();
       return await this.createFilter(
@@ -169,7 +175,9 @@ export class FilterService implements IFilterService {
 
   public async uninstallFilter(filterId: string, requestDetails: RequestDetails): Promise<boolean> {
     const requestIdPrefix = requestDetails.formattedRequestId;
-    this.logger.trace(`${requestIdPrefix} uninstallFilter(${filterId})`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} uninstallFilter(${filterId})`);
+    }
     FilterService.requireFiltersEnabled();
 
     const cacheKey = `${constants.CACHE_KEY.FILTERID}_${filterId}`;
@@ -184,7 +192,9 @@ export class FilterService implements IFilterService {
   }
 
   public newPendingTransactionFilter(requestDetails: RequestDetails): JsonRpcError {
-    this.logger.trace(`${requestDetails.formattedRequestId} newPendingTransactionFilter()`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} newPendingTransactionFilter()`);
+    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -209,7 +219,9 @@ export class FilterService implements IFilterService {
   }
 
   public async getFilterChanges(filterId: string, requestDetails: RequestDetails): Promise<string[] | Log[]> {
-    this.logger.trace(`${requestDetails.formattedRequestId} getFilterChanges(${filterId})`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} getFilterChanges(${filterId})`);
+    }
     FilterService.requireFiltersEnabled();
 
     const cacheKey = `${constants.CACHE_KEY.FILTERID}_${filterId}`;

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -148,14 +148,18 @@ export class HbarLimitService implements IHbarLimitService {
    * @returns {Promise<void>} - A promise that resolves when the operation is complete.
    */
   async resetLimiter(requestDetails: RequestDetails): Promise<void> {
-    this.logger.trace(`${requestDetails.formattedRequestId} Resetting HBAR rate limiter...`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} Resetting HBAR rate limiter...`);
+    }
     await this.hbarSpendingPlanRepository.resetAmountSpentOfAllPlans(requestDetails);
     this.resetBudget();
     this.resetTemporaryMetrics();
     this.reset = this.getResetTimestamp();
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} HBAR Rate Limit reset: remainingBudget=${this.remainingBudget}, newResetTimestamp=${this.reset}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} HBAR Rate Limit reset: remainingBudget=${this.remainingBudget}, newResetTimestamp=${this.reset}`,
+      );
+    }
   }
 
   /**
@@ -189,7 +193,9 @@ export class HbarLimitService implements IHbarLimitService {
       return false;
     }
     const user = `(ethAddress=${ethAddress})`;
-    this.logger.trace(`${requestDetails.formattedRequestId} Checking if ${user} should be limited...`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestDetails.formattedRequestId} Checking if ${user} should be limited...`);
+    }
     let spendingPlan = await this.getSpendingPlan(ethAddress, requestDetails);
     if (!spendingPlan) {
       // Create a basic spending plan if none exists for the eth address or ip address
@@ -204,17 +210,19 @@ export class HbarLimitService implements IHbarLimitService {
     const exceedsLimit =
       spendingLimit.lte(spendingPlan.amountSpent) || spendingLimit.lt(spendingPlan.amountSpent + estimatedTxFee);
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} User ${
-        exceedsLimit ? 'has' : 'has NOT'
-      } exceeded HBAR rate limit threshold: user=${user}, amountSpent=${
-        spendingPlan.amountSpent
-      }, estimatedTxFee=${estimatedTxFee}, spendingLimit=${spendingLimit}, spandingPlanId=${
-        spendingPlan.id
-      }, subscriptionTier=${
-        spendingPlan.subscriptionTier
-      }, txConstructorName=${txConstructorName}, mode=${mode}, methodName=${methodName}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} User ${
+          exceedsLimit ? 'has' : 'has NOT'
+        } exceeded HBAR rate limit threshold: user=${user}, amountSpent=${
+          spendingPlan.amountSpent
+        }, estimatedTxFee=${estimatedTxFee}, spendingLimit=${spendingLimit}, spandingPlanId=${
+          spendingPlan.id
+        }, subscriptionTier=${
+          spendingPlan.subscriptionTier
+        }, txConstructorName=${txConstructorName}, mode=${mode}, methodName=${methodName}`,
+      );
+    }
 
     return exceedsLimit;
   }
@@ -233,7 +241,9 @@ export class HbarLimitService implements IHbarLimitService {
 
     const ipAddress = requestDetails.ipAddress;
     if (!ethAddress && !ipAddress) {
-      this.logger.trace('Cannot add expense to a spending plan without an eth address or ip address');
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace('Cannot add expense to a spending plan without an eth address or ip address');
+      }
       return;
     }
 
@@ -250,13 +260,15 @@ export class HbarLimitService implements IHbarLimitService {
       }
     }
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Spending plan expense update: planID=${spendingPlan.id}, subscriptionTier=${
-        spendingPlan.subscriptionTier
-      }, cost=${cost}, originalAmountSpent=${spendingPlan.amountSpent}, updatedAmountSpent=${
-        spendingPlan.amountSpent + cost
-      }`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Spending plan expense update: planID=${
+          spendingPlan.id
+        }, subscriptionTier=${spendingPlan.subscriptionTier}, cost=${cost}, originalAmountSpent=${
+          spendingPlan.amountSpent
+        }, updatedAmountSpent=${spendingPlan.amountSpent + cost}`,
+      );
+    }
 
     // Check if the spending plan is being used for the first time today
     if (spendingPlan.amountSpent === 0) {
@@ -268,9 +280,11 @@ export class HbarLimitService implements IHbarLimitService {
     // Done asynchronously in the background
     this.updateAverageAmountSpentPerSubscriptionTier(spendingPlan.subscriptionTier, requestDetails).then();
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} HBAR rate limit expense update: cost=${cost} tℏ, remainingBudget=${this.remainingBudget}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} HBAR rate limit expense update: cost=${cost} tℏ, remainingBudget=${this.remainingBudget}`,
+      );
+    }
   }
 
   /**
@@ -307,13 +321,15 @@ export class HbarLimitService implements IHbarLimitService {
       );
       return true;
     } else {
-      this.logger.trace(
-        `${requestDetails.formattedRequestId} Total HBAR rate limit NOT reached: remainingBudget=${
-          this.remainingBudget
-        }, totalBudget=${
-          this.totalBudget
-        }, estimatedTxFee=${estimatedTxFee}, resetTimestamp=${this.reset.getMilliseconds()}, txConstructorName=${txConstructorName} mode=${mode}, methodName=${methodName}`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestDetails.formattedRequestId} Total HBAR rate limit NOT reached: remainingBudget=${
+            this.remainingBudget
+          }, totalBudget=${
+            this.totalBudget
+          }, estimatedTxFee=${estimatedTxFee}, resetTimestamp=${this.reset.getMilliseconds()}, txConstructorName=${txConstructorName} mode=${mode}, methodName=${methodName}`,
+        );
+      }
       return false;
     }
   }
@@ -476,9 +492,11 @@ export class HbarLimitService implements IHbarLimitService {
       this.limitDuration,
     );
 
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Linking spending plan with ID ${spendingPlan.id} to eth address ${ethAddress}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Linking spending plan with ID ${spendingPlan.id} to eth address ${ethAddress}`,
+      );
+    }
     await this.ethAddressHbarSpendingPlanRepository.save(
       { ethAddress, planId: spendingPlan.id },
       requestDetails,

--- a/packages/relay/src/lib/services/metricService/metricService.ts
+++ b/packages/relay/src/lib/services/metricService/metricService.ts
@@ -218,9 +218,11 @@ export default class MetricService {
     requestDetails,
     originalCallerAddress,
   }: IExecuteQueryEventPayload): Promise<void> => {
-    this.logger.trace(
-      `${requestDetails.formattedRequestId} Capturing transaction fee charged to operator: executionMode=${executionMode} transactionId=${transactionId}, txConstructorName=${txConstructorName}, callerName=${callerName}, cost=${cost} tinybars`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestDetails.formattedRequestId} Capturing transaction fee charged to operator: executionMode=${executionMode} transactionId=${transactionId}, txConstructorName=${txConstructorName}, callerName=${callerName}, cost=${cost} tinybars`,
+      );
+    }
 
     await this.hbarLimitService.addExpense(cost, originalCallerAddress ?? '', requestDetails);
     this.captureMetrics(executionMode, txConstructorName, status, cost, gasUsed, callerName, interactingEntity);

--- a/packages/relay/src/lib/subscriptionController.ts
+++ b/packages/relay/src/lib/subscriptionController.ts
@@ -105,7 +105,9 @@ export class SubscriptionController implements Subs {
       // Check if the connection is already subscribed to this event
       const existingSub = this.subscriptions[tag].find((sub) => sub.connection.id === connection.id);
       if (existingSub) {
-        this.logger.debug(`Connection ${connection.id}: Attempting to subscribe to ${tag}; already subscribed`);
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(`Connection ${connection.id}: Attempting to subscribe to ${tag}; already subscribed`);
+        }
         return existingSub.subscriptionId;
       }
     }
@@ -139,7 +141,11 @@ export class SubscriptionController implements Subs {
       this.subscriptions[tag] = subs.filter((sub) => {
         const match = sub.connection.id === id && (!subId || subId === sub.subscriptionId);
         if (match) {
-          this.logger.debug(`Connection ${sub.connection.id}. Unsubscribing subId: ${sub.subscriptionId}; tag: ${tag}`);
+          if (this.logger.isLevelEnabled('debug')) {
+            this.logger.debug(
+              `Connection ${sub.connection.id}. Unsubscribing subId: ${sub.subscriptionId}; tag: ${tag}`,
+            );
+          }
           sub.endTimer();
           subCount++;
         }
@@ -148,7 +154,9 @@ export class SubscriptionController implements Subs {
       });
 
       if (!this.subscriptions[tag].length) {
-        this.logger.debug(`No subscribers for ${tag}. Removing from list.`);
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(`No subscribers for ${tag}. Removing from list.`);
+        }
         delete this.subscriptions[tag];
         this.poller.remove(tag);
       }
@@ -169,9 +177,11 @@ export class SubscriptionController implements Subs {
         // If the hash exists in the cache then the data has recently been sent to the subscriber
         if (!this.cache.get(hash)) {
           this.cache.set(hash, true);
-          this.logger.debug(
-            `Sending data from tag: ${tag} to subscriptionId: ${sub.subscriptionId}, connectionId: ${sub.connection.id}, data: ${subscriptionData}`,
-          );
+          if (this.logger.isLevelEnabled('debug')) {
+            this.logger.debug(
+              `Sending data from tag: ${tag} to subscriptionId: ${sub.subscriptionId}, connectionId: ${sub.connection.id}, data: ${subscriptionData}`,
+            );
+          }
           this.resultsSentToSubscribersCounter.labels('sub.subscriptionId', tag).inc();
           sub.connection.send(
             JSON.stringify({

--- a/packages/relay/tests/lib/poller.spec.ts
+++ b/packages/relay/tests/lib/poller.spec.ts
@@ -26,7 +26,7 @@ import { Poller } from '../../src/lib/poller';
 import sinon from 'sinon';
 import { Registry } from 'prom-client';
 
-const logger = pino();
+const logger = pino({ level: 'trace' });
 
 describe('Polling', async function () {
   this.timeout(20000);
@@ -207,7 +207,9 @@ describe('Polling', async function () {
 
     it('should poll single line of log data', async () => {
       const notifySubscriber = (data) => {
-        logger.debug(SINGLE_LINE);
+        if (logger.isLevelEnabled('debug')) {
+          logger.debug(SINGLE_LINE);
+        }
         expect(data).to.eq(logs);
         return;
       };
@@ -229,7 +231,9 @@ describe('Polling', async function () {
 
     it('should poll an array of log data', async () => {
       const notifySubscriber = (data) => {
-        logger.debug(ARRAY_OF_LOGS);
+        if (logger.isLevelEnabled('debug')) {
+          logger.debug(ARRAY_OF_LOGS);
+        }
         expect(data).to.deep.eq(logsArray);
         return;
       };

--- a/packages/relay/tests/lib/subscriptionController.spec.ts
+++ b/packages/relay/tests/lib/subscriptionController.spec.ts
@@ -28,7 +28,7 @@ import { Registry } from 'prom-client';
 import ConnectionLimiter from '@hashgraph/json-rpc-ws-server/src/metrics/connectionLimiter';
 import { overrideEnvsInMochaDescribe } from '../helpers';
 
-const logger = pino();
+const logger = pino({ level: 'trace' });
 const register = new Registry();
 const limiter = new ConnectionLimiter(logger, register);
 let ethImpl: EthImpl;

--- a/packages/relay/tests/redisInMemoryServer.ts
+++ b/packages/relay/tests/redisInMemoryServer.ts
@@ -53,7 +53,9 @@ export class RedisInMemoryServer {
   }
 
   async start(): Promise<void> {
-    this.logger.trace('Starting Redis in-memory server....');
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace('Starting Redis in-memory server....');
+    }
     const started = await this.inMemoryRedisServer.start();
     if (started) {
       const host = await this.getHost();
@@ -74,7 +76,9 @@ export class RedisInMemoryServer {
   }
 
   async stop(): Promise<void> {
-    this.logger.trace('Stopping Redis in-memory server....');
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace('Stopping Redis in-memory server....');
+    }
     const stopped = await this.inMemoryRedisServer.stop();
     if (stopped) {
       this.logger.info('Stopped Redis in-memory server successfully.');
@@ -87,7 +91,11 @@ export class RedisInMemoryServer {
     try {
       // Ensure that the instance is running -> throws error if instance cannot be started
       const instanceData = await this.inMemoryRedisServer.ensureInstance();
-      this.logger.debug(`Redis in-memory server health check passed, server is running on port ${instanceData.port}.`);
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          `Redis in-memory server health check passed, server is running on port ${instanceData.port}.`,
+        );
+      }
     } catch (error) {
       this.logger.warn(`Redis in-memory server health check failed: ${error}`);
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -205,18 +205,22 @@ const logAndHandleResponse = async (methodName: string, methodParams: any[], met
   try {
     const methodValidations = Validator.METHODS[methodName];
     if (methodValidations) {
-      logger.debug(
-        `${requestDetails.formattedRequestId} Validating method parameters for ${methodName}, params: ${JSON.stringify(
-          methodParams,
-        )}`,
-      );
+      if (logger.isLevelEnabled('debug')) {
+        logger.debug(
+          `${
+            requestDetails.formattedRequestId
+          } Validating method parameters for ${methodName}, params: ${JSON.stringify(methodParams)}`,
+        );
+      }
       Validator.validateParams(methodParams, methodValidations);
     }
     const response = await methodFunction(requestDetails);
     if (response instanceof JsonRpcError) {
       // log error only if it is not a contract revert, otherwise log it as debug
       if (response.code === predefined.CONTRACT_REVERT().code) {
-        logger.debug(`${requestDetails.formattedRequestId} ${response.message}`);
+        if (logger.isLevelEnabled('debug')) {
+          logger.debug(`${requestDetails.formattedRequestId} ${response.message}`);
+        }
       } else {
         logger.error(`${requestDetails.formattedRequestId} ${response.message}`);
       }

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -105,10 +105,12 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
 
     const verifyRemainingLimit = (expectedCost: number, remainingHbarsBefore: number, remainingHbarsAfter: number) => {
       const delta = transactionReecordCostTolerance * expectedCost;
-      global.logger.debug(`Tolerance: ${transactionReecordCostTolerance}`);
-      global.logger.debug(`Expected cost: ${expectedCost} ±${delta}`);
-      global.logger.debug(`Actual cost: ${remainingHbarsBefore - remainingHbarsAfter}`);
-      global.logger.debug(`Actual delta: ${(remainingHbarsBefore - remainingHbarsAfter) / (expectedCost * 100)}`);
+      if (global.logger.isLevelEnabled('debug')) {
+        global.logger.debug(`Tolerance: ${transactionReecordCostTolerance}`);
+        global.logger.debug(`Expected cost: ${expectedCost} ±${delta}`);
+        global.logger.debug(`Actual cost: ${remainingHbarsBefore - remainingHbarsAfter}`);
+        global.logger.debug(`Actual delta: ${(remainingHbarsBefore - remainingHbarsAfter) / (expectedCost * 100)}`);
+      }
       expect(remainingHbarsAfter).to.be.approximately(remainingHbarsBefore - expectedCost, delta);
     };
 
@@ -458,9 +460,11 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
             await Utils.wait(6000);
 
             const parentContractAddress = parentContract.target as string;
-            global.logger.trace(
-              `${requestDetails.formattedRequestId} Deploy parent contract on address ${parentContractAddress}`,
-            );
+            if (global.logger.isLevelEnabled('trace')) {
+              global.logger.trace(
+                `${requestDetails.formattedRequestId} Deploy parent contract on address ${parentContractAddress}`,
+              );
+            }
 
             expect(ethAddressSpendingPlanRepository.findByAddress(accounts[2].address, requestDetails)).to.be.rejected;
             const gasPrice = await relay.gasPrice(requestId);

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -120,9 +120,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         accounts[0].wallet,
       );
       parentContractAddress = parentContract.target as string;
-      global.logger.trace(
-        `${requestDetails.formattedRequestId} Deploy parent contract on address ${parentContractAddress}`,
-      );
+      if (global.logger.isLevelEnabled('trace')) {
+        global.logger.trace(
+          `${requestDetails.formattedRequestId} Deploy parent contract on address ${parentContractAddress}`,
+        );
+      }
 
       await accounts[0].wallet.sendTransaction({
         to: parentContractAddress,
@@ -132,9 +134,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       // @ts-ignore
       const createChildTx: ethers.ContractTransactionResponse = await parentContract.createChild(1);
 
-      global.logger.trace(
-        `${requestDetails.formattedRequestId} Contract call createChild on parentContract results in tx hash: ${createChildTx.hash}`,
-      );
+      if (global.logger.isLevelEnabled('trace')) {
+        global.logger.trace(
+          `${requestDetails.formattedRequestId} Contract call createChild on parentContract results in tx hash: ${createChildTx.hash}`,
+        );
+      }
       // get contract result details
       mirrorContractDetails = await mirrorNode.get(`/contracts/results/${createChildTx.hash}`, requestId);
 

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -134,7 +134,9 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
       accounts[0].wallet,
     );
     parentContractAddress = parentContract.target as string;
-    global.logger.trace(`${requestIdPrefix} Deploy parent contract on address ${parentContractAddress}`);
+    if (global.logger.isLevelEnabled('trace')) {
+      global.logger.trace(`${requestIdPrefix} Deploy parent contract on address ${parentContractAddress}`);
+    }
 
     const mirrorNodeContractRes = await mirrorNode.get(`/contracts/${parentContractAddress}`, requestId);
     const parentContractId = ContractId.fromString(mirrorNodeContractRes.contract_id);
@@ -148,9 +150,11 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     // @ts-ignore
     createChildTx = await parentContract.createChild(1);
 
-    global.logger.trace(
-      `${requestIdPrefix} Contract call createChild on parentContract results in tx hash: ${createChildTx.hash}`,
-    );
+    if (global.logger.isLevelEnabled('trace')) {
+      global.logger.trace(
+        `${requestIdPrefix} Contract call createChild on parentContract results in tx hash: ${createChildTx.hash}`,
+      );
+    }
 
     tokenId = await servicesNode.createToken(1000, requestId);
     htsAddress = Utils.idToEvmAddress(tokenId.toString());

--- a/packages/server/tests/clients/metricsClient.ts
+++ b/packages/server/tests/clients/metricsClient.ts
@@ -67,7 +67,9 @@ export default class MetricsClient {
    */
   async get(metric: string, requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    this.logger.debug(`${requestIdPrefix} [GET] Read all metrics from ${this.relayUrl}/metrics`);
+    if (this.logger.isLevelEnabled('debug')) {
+      this.logger.debug(`${requestIdPrefix} [GET] Read all metrics from ${this.relayUrl}/metrics`);
+    }
     const allMetrics = (await this.client.get('')).data;
     const allMetricsArray = allMetrics.split('\n');
     const matchPattern = `${metric} `;

--- a/packages/server/tests/clients/mirrorClient.ts
+++ b/packages/server/tests/clients/mirrorClient.ts
@@ -65,7 +65,9 @@ export default class MirrorClient {
 
   async get(path: string, requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    this.logger.debug(`${requestIdPrefix} [GET] MirrorNode ${path} endpoint`);
+    if (this.logger.isLevelEnabled('debug')) {
+      this.logger.debug(`${requestIdPrefix} [GET] MirrorNode ${path} endpoint`);
+    }
     return (await this.client.get(path)).data;
   }
 }

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -43,11 +43,13 @@ export default class RelayClient {
   async call(methodName: string, params: any[], requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
     const result = await this.provider.send(methodName, params);
-    this.logger.trace(
-      `${requestIdPrefix} [POST] to relay '${methodName}' with params [${JSON.stringify(
-        params,
-      )}] returned ${JSON.stringify(result)}`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} [POST] to relay '${methodName}' with params [${JSON.stringify(
+          params,
+        )}] returned ${JSON.stringify(result)}`,
+      );
+    }
     return result;
   }
 
@@ -86,9 +88,11 @@ export default class RelayClient {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
     try {
       const res = await this.call(methodName, params, requestId);
-      this.logger.trace(
-        `${requestIdPrefix} [POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`,
-      );
+      if (this.logger.isLevelEnabled('trace')) {
+        this.logger.trace(
+          `${requestIdPrefix} [POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`,
+        );
+      }
       Assertions.expectedError();
     } catch (e: any) {
       if (expectedRpcError.message.includes('execution reverted')) {
@@ -128,7 +132,9 @@ export default class RelayClient {
    */
   async getBalance(address: ethers.AddressLike, block: BlockTag = 'latest', requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    this.logger.debug(`${requestIdPrefix} [POST] to relay eth_getBalance for address ${address}]`);
+    if (this.logger.isLevelEnabled('debug')) {
+      this.logger.debug(`${requestIdPrefix} [POST] to relay eth_getBalance for address ${address}]`);
+    }
     return this.provider.getBalance(address, block);
   }
 
@@ -139,7 +145,9 @@ export default class RelayClient {
    */
   async getAccountNonce(evmAddress: string, requestId?: string): Promise<number> {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    this.logger.debug(`${requestIdPrefix} [POST] to relay for eth_getTransactionCount for address ${evmAddress}`);
+    if (this.logger.isLevelEnabled('debug')) {
+      this.logger.debug(`${requestIdPrefix} [POST] to relay for eth_getTransactionCount for address ${evmAddress}`);
+    }
     const nonce = await this.provider.send('eth_getTransactionCount', [evmAddress, 'latest']);
     return Number(nonce);
   }
@@ -153,7 +161,9 @@ export default class RelayClient {
    */
   async sendRawTransaction(signedTx, requestId?: string): Promise<string> {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    this.logger.debug(`${requestIdPrefix} [POST] to relay for eth_sendRawTransaction`);
+    if (this.logger.isLevelEnabled('debug')) {
+      this.logger.debug(`${requestIdPrefix} [POST] to relay for eth_sendRawTransaction`);
+    }
     return this.provider.send('eth_sendRawTransaction', [signedTx]);
   }
 

--- a/packages/server/tests/clients/servicesClient.ts
+++ b/packages/server/tests/clients/servicesClient.ts
@@ -126,9 +126,11 @@ export default class ServicesClient {
     );
     const address = wallet.address;
 
-    this.logger.trace(
-      `${requestIdPrefix} Create new Eth compatible account w alias: ${address} and balance ~${initialBalance} HBar`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} Create new Eth compatible account w alias: ${address} and balance ~${initialBalance} HBar`,
+      );
+    }
 
     const aliasCreationResponse = await this.executeTransaction(
       new TransferTransaction()
@@ -203,7 +205,9 @@ export default class ServicesClient {
   async createToken(initialSupply: number = 1000, requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
     const symbol = Math.random().toString(36).slice(2, 6).toUpperCase();
-    this.logger.trace(`${requestIdPrefix} symbol = ${symbol}`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} symbol = ${symbol}`);
+    }
     const resp = await this.executeAndGetTransactionReceipt(
       new TokenCreateTransaction()
         .setTokenName(`relay-acceptance token ${symbol}`)
@@ -215,7 +219,9 @@ export default class ServicesClient {
       requestId,
     );
 
-    this.logger.trace(`${requestIdPrefix} get token id from receipt`);
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(`${requestIdPrefix} get token id from receipt`);
+    }
     const tokenId = resp?.tokenId;
     this.logger.info(`${requestIdPrefix} token id = ${tokenId?.toString()}`);
     return tokenId!;
@@ -386,9 +392,11 @@ export default class ServicesClient {
     // Create a KeyList of both keys and specify that only 1 is required for signing transactions
     const keyList = new KeyList(keys, 1);
 
-    this.logger.trace(
-      `${requestIdPrefix} Create new Eth compatible account w ContractId key: ${contractId}, privateKey: ${privateKey}, alias: ${publicKey.toEvmAddress()} and balance ~${initialBalance} hb`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} Create new Eth compatible account w ContractId key: ${contractId}, privateKey: ${privateKey}, alias: ${publicKey.toEvmAddress()} and balance ~${initialBalance} hb`,
+      );
+    }
 
     const accountCreateTx = await new AccountCreateTransaction()
       .setInitialBalance(new Hbar(initialBalance))
@@ -414,9 +422,11 @@ export default class ServicesClient {
     const publicKey = privateKey.publicKey;
     const aliasAccountId = publicKey.toAccountId(0, 0);
 
-    this.logger.trace(
-      `${requestIdPrefix} Create new Eth compatible account w alias: ${aliasAccountId.toString()} and balance ~${initialBalance} hb`,
-    );
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        `${requestIdPrefix} Create new Eth compatible account w alias: ${aliasAccountId.toString()} and balance ~${initialBalance} hb`,
+      );
+    }
 
     const aliasCreationResponse = await this.executeTransaction(
       new TransferTransaction()

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -466,9 +466,11 @@ export default class Assertions {
    * @param tolerance
    */
   static expectWithinTolerance(expected: number, actual: number, tolerance: number) {
-    global.logger.debug(`Expected: ${expected} ±${tolerance}%`);
-    global.logger.debug(`Actual: ${actual}`);
-    global.logger.debug(`Actual delta: ${(actual - expected) / 100}%`);
+    if (global.logger.isLevelEnabled('debug')) {
+      global.logger.debug(`Expected: ${expected} ±${tolerance}%`);
+      global.logger.debug(`Actual: ${actual}`);
+      global.logger.debug(`Actual delta: ${(actual - expected) / 100}%`);
+    }
     const delta = tolerance * expected;
     expect(actual).to.be.approximately(expected, delta);
   }

--- a/packages/server/tests/helpers/utils.ts
+++ b/packages/server/tests/helpers/utils.ts
@@ -336,9 +336,11 @@ export class Utils {
         requestDetails.requestId,
         initialAmountInTinyBar,
       );
-      global.logger.trace(
-        `${requestDetails.formattedRequestId} Create new Eth compatible account w alias: ${account.address} and balance ~${initialAmountInTinyBar} wei`,
-      );
+      if (global.logger.isLevelEnabled('trace')) {
+        global.logger.trace(
+          `${requestDetails.formattedRequestId} Create new Eth compatible account w alias: ${account.address} and balance ~${initialAmountInTinyBar} wei`,
+        );
+      }
       accounts.push(account);
     }
     return accounts;

--- a/packages/ws-server/src/controllers/index.ts
+++ b/packages/ws-server/src/controllers/index.ts
@@ -71,7 +71,9 @@ const handleSendingRequestsToRelay = async ({
   logger,
   requestDetails,
 }: ISharedParams): Promise<IJsonRpcResponse> => {
-  logger.trace(`${requestDetails.formattedLogPrefix}: Submitting request=${JSON.stringify(request)} to relay.`);
+  if (logger.isLevelEnabled('trace')) {
+    logger.trace(`${requestDetails.formattedLogPrefix}: Submitting request=${JSON.stringify(request)} to relay.`);
+  }
   try {
     const resolvedParams = resolveParams(method, params);
     const [service, methodName] = method.split('_');
@@ -92,11 +94,13 @@ const handleSendingRequestsToRelay = async ({
     }
 
     if (!txRes) {
-      logger.trace(
-        `${requestDetails.formattedLogPrefix}: Fail to retrieve result for request=${JSON.stringify(
-          request,
-        )}. Result=${txRes}`,
-      );
+      if (logger.isLevelEnabled('trace')) {
+        logger.trace(
+          `${requestDetails.formattedLogPrefix}: Fail to retrieve result for request=${JSON.stringify(
+            request,
+          )}. Result=${txRes}`,
+        );
+      }
     }
 
     return jsonResp(request.id, null, txRes);

--- a/packages/ws-server/src/metrics/connectionLimiter.ts
+++ b/packages/ws-server/src/metrics/connectionLimiter.ts
@@ -202,7 +202,9 @@ export default class ConnectionLimiter {
     websocket.inactivityTTL = setTimeout(() => {
       if (websocket.readyState !== 3) {
         // 3 = CLOSED, Avoid closing already closed connections
-        this.logger.debug(`Closing connection ${websocket.id} due to reaching TTL (${maxInactivityTTL}ms)`);
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(`Closing connection ${websocket.id} due to reaching TTL (${maxInactivityTTL}ms)`);
+        }
         try {
           this.inactivityTTLCounter.inc();
           websocket.send(

--- a/packages/ws-server/src/utils/utils.ts
+++ b/packages/ws-server/src/utils/utils.ts
@@ -84,13 +84,11 @@ export const sendToClient = (
   logger: Logger,
   requestDetails: RequestDetails,
 ) => {
-  if (logger.isLevelEnabled('trace')) {
-    logger.trace(
-      `${requestDetails.formattedLogPrefix}: Sending result=${JSON.stringify(
-        response,
-      )} to client for request=${JSON.stringify(request)}`,
-    );
-  }
+  logger.trace(
+    `${requestDetails.formattedLogPrefix}: Sending result=${JSON.stringify(
+      response,
+    )} to client for request=${JSON.stringify(request)}`,
+  );
 
   connection.send(JSON.stringify(response));
   connection.limiter.resetInactivityTTLTimer(connection);

--- a/packages/ws-server/src/utils/utils.ts
+++ b/packages/ws-server/src/utils/utils.ts
@@ -84,11 +84,13 @@ export const sendToClient = (
   logger: Logger,
   requestDetails: RequestDetails,
 ) => {
-  logger.trace(
-    `${requestDetails.formattedLogPrefix}: Sending result=${JSON.stringify(
-      response,
-    )} to client for request=${JSON.stringify(request)}`,
-  );
+  if (logger.isLevelEnabled('trace')) {
+    logger.trace(
+      `${requestDetails.formattedLogPrefix}: Sending result=${JSON.stringify(
+        response,
+      )} to client for request=${JSON.stringify(request)}`,
+    );
+  }
 
   connection.send(JSON.stringify(response));
   connection.limiter.resetInactivityTTLTimer(connection);

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -122,7 +122,9 @@ app.ws.use(async (ctx: Koa.Context) => {
 
     // check if request is a batch request (array) or a signle request (JSON)
     if (Array.isArray(request)) {
-      logger.trace(`${requestDetails.formattedLogPrefix}: Receive batch request=${JSON.stringify(request)}`);
+      if (logger.isLevelEnabled('trace')) {
+        logger.trace(`${requestDetails.formattedLogPrefix}: Receive batch request=${JSON.stringify(request)}`);
+      }
 
       // Increment metrics for batch_requests
       wsMetricRegistry.getCounter('methodsCounter').labels(WS_CONSTANTS.BATCH_REQUEST_METHOD_NAME).inc();
@@ -161,7 +163,9 @@ app.ws.use(async (ctx: Koa.Context) => {
       // send to client
       sendToClient(ctx.websocket, request, responses, logger, requestDetails);
     } else {
-      logger.trace(`${requestDetails.formattedLogPrefix}: Receive single request=${JSON.stringify(request)}`);
+      if (logger.isLevelEnabled('trace')) {
+        logger.trace(`${requestDetails.formattedLogPrefix}: Receive single request=${JSON.stringify(request)}`);
+      }
 
       // process requests
       const response = await getRequestResult(


### PR DESCRIPTION
**Description**:
This PR optimizes logging performance by implementing proper log level guards using Pino's `isLevelEnabled` API. 
Changes made:
* Add `isLevelEnabled` checks before debug and trace logging calls
* Wrap existing debug/trace logs with level guards
* Implement consistent logging patterns across the codebase

Example of optimized logging:
```typescript
if (cachedResponse) {
  if (this.logger.isLevelEnabled('debug')) {
    this.logger.debug(
      `${requestIdPrefix} getTransactionReceipt returned cached response: ${JSON.stringify(cachedResponse)}`,
    );
  }
  return cachedResponse;
}

if (!syntheticLogs.length) {
  if (this.logger.isLevelEnabled('trace')) {
    this.logger.trace(`${requestIdPrefix} no receipt for ${hash}`);
  }
  return null;
}
```

**Related issue(s)**:
Fixes #1118

**Notes for reviewer**:
* The implemented guards prevent unnecessary string interpolation and JSON.stringify operations when debug/trace logging is disabled
* Pattern is consistently applied across debug and trace level logs
* No functional changes to the logging output - only performance optimization

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
  - Verified log output with different log levels
  - Confirmed debug/trace messages are properly guarded
  - Tested with logging enabled and disabled to ensure proper functionality