### PR TITLE
fix: Adds retry to send raw transaction

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -501,7 +501,7 @@ export class SDKClient {
         retryCount,
         requestDetails,
       );
-      const isFailed = transaction !== null ? true : false;
+      const isFailed = transaction !== null;
       return isFailed;
     } catch (e: any) {
       this.logger.error(

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -473,9 +473,10 @@ export class SDKClient {
       if (e instanceof SDKClientError && (e.isConnectionDropped() || e.isTimeoutExceeded())) {
         if (!(await this.isFailedTransaction(requestDetails, e.transactionId))) {
           txResponse = { transactionId: e.transactionId };
+        } else {
+          throw e;
         }
       }
-      throw e;
     }
 
     return {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -724,7 +724,7 @@ export class SDKClient {
         throw e;
       }
 
-      const sdkClientError = new SDKClientError(e, e.message);
+      const sdkClientError = new SDKClientError(e, e.message, transaction.transactionId?.toString());
 
       // Throw WRONG_NONCE error as more error handling logic for WRONG_NONCE is awaited in eth.sendRawTransactionErrorHandler().
       if (sdkClientError.status && sdkClientError.status === Status.WrongNonce) {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -795,9 +795,13 @@ export class SDKClient {
       );
 
       if (!transactionResponse) {
-        throw predefined.INTERNAL_ERROR(
-          `${requestDetails.formattedRequestId} Transaction execution returns a null value: transactionId=${transaction.transactionId}, callerName=${callerName}, txConstructorName=${txConstructorName}`,
-        );
+        if (sdkClientError.isConnectionDropped() || sdkClientError.isTimeoutExceeded()) {
+          throw sdkClientError;
+        } else {
+          throw predefined.INTERNAL_ERROR(
+            `${requestDetails.formattedRequestId} Transaction execution returns a null value: transactionId=${transaction.transactionId}, callerName=${callerName}, txConstructorName=${txConstructorName}`,
+          );
+        }
       }
       return transactionResponse;
     } finally {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -471,11 +471,13 @@ export class SDKClient {
       );
     } catch (e: any) {
       if (e instanceof SDKClientError && (e.isConnectionDropped() || e.isTimeoutExceeded())) {
-        if (!(await this.isFailedTransaction(requestDetails, e.transactionId))) {
-          txResponse = { transactionId: e.transactionId };
-        } else {
+        const isFailed = await this.isFailedTransaction(requestDetails, e.transactionId);
+        if (isFailed) {
           throw e;
         }
+        txResponse = { transactionId: e.transactionId };
+      } else {
+        throw e;
       }
     }
 

--- a/packages/relay/src/lib/errors/SDKClientError.ts
+++ b/packages/relay/src/lib/errors/SDKClientError.ts
@@ -32,7 +32,7 @@ export class SDKClientError extends Error {
       this.validNetworkError = true;
       this.status = e.status;
     }
-    this.failedTransactionId = transactionId ? transactionId : '';
+    this.failedTransactionId = transactionId || '';
     Object.setPrototypeOf(this, SDKClientError.prototype);
   }
 

--- a/packages/relay/src/lib/errors/SDKClientError.ts
+++ b/packages/relay/src/lib/errors/SDKClientError.ts
@@ -23,20 +23,25 @@ import { Status } from '@hashgraph/sdk';
 export class SDKClientError extends Error {
   public status: Status = Status.Unknown;
   private validNetworkError: boolean = false;
+  private failedTransactionId: string | undefined;
 
-  constructor(e: any, message?: string) {
+  constructor(e: any, message?: string, transactionId?: string) {
     super(e?.status?._code ? e.message : message);
 
     if (e?.status?._code) {
       this.validNetworkError = true;
       this.status = e.status;
     }
-
+    this.failedTransactionId = transactionId ? transactionId : '';
     Object.setPrototypeOf(this, SDKClientError.prototype);
   }
 
   get statusCode(): number {
     return this.status._code;
+  }
+
+  get transactionId(): string | undefined {
+    return this.failedTransactionId;
   }
 
   public isValidNetworkError(): boolean {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1689,12 +1689,12 @@ export class EthImpl implements Eth {
     {
       maxAttempts = 2,
       backOff = 500,
-      canRetry,
+      canRetry = (error: unknown) => Promise.resolve(true),
       onError = (e: SDKClientError) => {},
     }: {
       maxAttempts?: number;
       backOff?: number;
-      canRetry: (error: unknown) => Promise<boolean>;
+      canRetry?: (error: unknown) => Promise<boolean>;
       onError?: (error: SDKClientError) => void;
     },
   ): Promise<T | undefined> {
@@ -1703,7 +1703,8 @@ export class EthImpl implements Eth {
       try {
         return await sendRawTransaction();
       } catch (e: unknown) {
-        if (!canRetry(e) || count === maxAttempts - 1) {
+        const shouldRetry = await canRetry(e);
+        if (!shouldRetry || count === maxAttempts - 1) {
           throw e;
         }
         onError(e as SDKClientError);

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1568,16 +1568,30 @@ export class EthImpl implements Eth {
     let fileId: FileId | null = null;
     let txSubmitted = false;
     try {
-      const sendRawTransactionResult = await this.hapiService
-        .getSDKClient()
-        .submitEthereumTransaction(
-          transactionBuffer,
-          EthImpl.ethSendRawTransaction,
-          requestDetails,
-          originalCallerAddress,
-          networkGasPriceInWeiBars,
-          await this.getCurrentNetworkExchangeRateInCents(requestDetails),
-        );
+      const sendRawTransactionResult = await this.sendRawTransactionWithRetry(
+        async () =>
+          await this.hapiService
+            .getSDKClient()
+            .submitEthereumTransaction(
+              transactionBuffer,
+              EthImpl.ethSendRawTransaction,
+              requestDetails,
+              originalCallerAddress,
+              networkGasPriceInWeiBars,
+              await this.getCurrentNetworkExchangeRateInCents(requestDetails),
+            ),
+        {
+          canRetry: (e: unknown) => {
+            return e instanceof SDKClientError && (e.isConnectionDropped() || e.isTimeoutExceeded());
+          },
+          onError: (e: SDKClientError) => {
+            this.logger.warn(
+              `${requestIdPrefix} SDK Client has probably timed out, trying again with a new instance...`,
+            );
+            this.hapiService.decrementErrorCounter(e.statusCode);
+          },
+        },
+      );
 
       txSubmitted = true;
       fileId = sendRawTransactionResult!.fileId;
@@ -1630,6 +1644,47 @@ export class EthImpl implements Eth {
           .getSDKClient()
           .deleteFile(fileId, requestDetails, EthImpl.ethSendRawTransaction, fileId.toString(), originalCallerAddress)
           .then();
+      }
+    }
+  }
+
+  /**
+   * Sends a raw transaction with retry logic.
+   *
+   * @template T The type of the result returned by the sendRawTransaction function.
+   * @param {Function} sendRawTransaction The function responsible for sending the raw transaction.
+   * @param {object} options The options for retrying the transaction.
+   * @param {number} [options.maxAttempts=2] The maximum number of attempts to send the transaction.
+   * @param {number} [options.backOff=500] The backoff period in milliseconds between retry attempts.
+   * @param {(error: unknown) => boolean} [options.canRetry=(error) => true] A function that determines whether a retry attempt can be made based on the error received.
+   * @param {(error: SDKClientError) => void} [options.onError=(error) => {}] A function to handle errors that occur during retry attempts.
+   * @returns {Promise<T>} A promise resolving to the result of the transaction.
+   */
+  private async sendRawTransactionWithRetry<T>(
+    sendRawTransaction: () => T,
+    {
+      maxAttempts = 2,
+      backOff = 500,
+      canRetry = (e: unknown) => true,
+      onError = (e: SDKClientError) => {},
+    }: {
+      maxAttempts?: number;
+      backOff?: number;
+      canRetry?: (error: unknown) => boolean;
+      onError?: (error: SDKClientError) => void;
+    },
+  ): Promise<T | undefined> {
+    const delay = (backOff) => new Promise((resolve) => setTimeout(resolve, backOff));
+    for (let count = 0; count < maxAttempts; count++) {
+      try {
+        return await sendRawTransaction();
+      } catch (e: unknown) {
+        if (!canRetry(e) || count === maxAttempts - 1) {
+          throw e;
+        }
+        onError(e as SDKClientError);
+        // eslint-disable-next-line no-await-in-loop
+        await delay(backOff);
       }
     }
   }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1684,6 +1684,7 @@ export class EthImpl implements Eth {
    * @param {(error: SDKClientError) => void} [options.onError=(error) => {}] A function to handle errors that occur during retry attempts.
    * @returns {Promise<T>} A promise resolving to the result of the transaction.
    */
+  //backOff and maxAttempts are hardcoded since this is planned to be just a workaround for issue #3118
   private async sendRawTransactionWithRetry<T>(
     sendRawTransaction: () => T,
     {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -34,7 +34,7 @@ import { Transaction as EthersTransaction } from 'ethers';
 import HAPIService from './services/hapiService/hapiService';
 import { JsonRpcError, predefined } from './errors/JsonRpcError';
 import { Block, Log, Transaction, Transaction1559 } from './model';
-import { FileId, Hbar, PrecheckStatusError, TransactionId } from '@hashgraph/sdk';
+import { FileId, Hbar, PrecheckStatusError } from '@hashgraph/sdk';
 import { CacheService } from './services/cacheService/cacheService';
 import { CommonService, FilterService } from './services/ethService';
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -208,7 +208,7 @@ export default class HAPIService {
     this.clientMain = this.initClient(logger, this.hederaNetwork);
 
     this.cacheService = cacheService;
-    this.client = this.initSDKClient(logger);
+    this.client = this.initSDKClient(logger, register);
 
     const currentDateNow = Date.now();
     // @ts-ignore
@@ -287,7 +287,7 @@ export default class HAPIService {
       .inc(1);
 
     this.clientMain = this.initClient(this.logger, this.hederaNetwork);
-    this.client = this.initSDKClient(this.logger);
+    this.client = this.initSDKClient(this.logger, this.register);
     this.resetCounters();
   }
 
@@ -306,13 +306,14 @@ export default class HAPIService {
    * @param {Logger} logger
    * @returns SDK Client
    */
-  private initSDKClient(logger: Logger): SDKClient {
+  private initSDKClient(logger: Logger, register: Registry): SDKClient {
     return new SDKClient(
       this.clientMain,
       logger.child({ name: `consensus-node` }),
       this.cacheService,
       this.eventEmitter,
       this.hbarLimitService,
+      register,
     );
   }
 

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -137,6 +137,7 @@ describe('SdkClient', async function () {
       new CacheService(logger.child({ name: `cache` }), registry),
       eventEmitter,
       hbarLimitService,
+      register,
     );
 
     instance = axios.create({

--- a/packages/relay/tests/lib/services/metricService/metricService.spec.ts
+++ b/packages/relay/tests/lib/services/metricService/metricService.spec.ts
@@ -163,6 +163,7 @@ describe('Metric Service', function () {
       new CacheService(logger.child({ name: `cache` }), registry),
       eventEmitter,
       hbarLimitService,
+      register,
     );
     // Init new MetricService instance
     metricService = new MetricService(logger, sdkClient, mirrorNodeClient, registry, eventEmitter, hbarLimitService);


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Currently, we experience the SDk timing out in the CI and on mainnet, eventhough the transactions that fail do not take more than 10 seconds. More info in the issue below
**Related issue(s)**:

Workaround until  #3118 is solved
