### PR TITLE
chore: Bump threshold of memory leak alerts

### DIFF
--- a/packages/server/tests/helpers/utils.ts
+++ b/packages/server/tests/helpers/utils.ts
@@ -38,8 +38,8 @@ import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services'
 import { RequestDetails } from '@hashgraph/json-rpc-relay/dist/lib/types';
 
 export class Utils {
-  static readonly HEAP_SIZE_DIFF_MEMORY_LEAK_THRESHOLD: number = 1e6; // 1 MB
-  static readonly HEAP_SIZE_DIFF_SNAPSHOT_THRESHOLD: number = 1.5e6; // 1.5 MB
+  static readonly HEAP_SIZE_DIFF_MEMORY_LEAK_THRESHOLD: number = 4e6; // 4 MB
+  static readonly HEAP_SIZE_DIFF_SNAPSHOT_THRESHOLD: number = 4e6; // 5 MB
   static readonly WARM_UP_TEST_COUNT: number = 3;
 
   /**

--- a/packages/server/tests/helpers/utils.ts
+++ b/packages/server/tests/helpers/utils.ts
@@ -39,7 +39,7 @@ import { RequestDetails } from '@hashgraph/json-rpc-relay/dist/lib/types';
 
 export class Utils {
   static readonly HEAP_SIZE_DIFF_MEMORY_LEAK_THRESHOLD: number = 4e6; // 4 MB
-  static readonly HEAP_SIZE_DIFF_SNAPSHOT_THRESHOLD: number = 4e6; // 5 MB
+  static readonly HEAP_SIZE_DIFF_SNAPSHOT_THRESHOLD: number = 5e6; // 5 MB
   static readonly WARM_UP_TEST_COUNT: number = 3;
 
   /**


### PR DESCRIPTION
**Description**:

This PR bumps the memory leak threshold to 4MB to avoid having false-positive detections in PRs

**Related issue(s)**:

Fixes #3168

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
