### PR TITLE
fix: updated .github/release.yaml to include `internal` and `github_action` labeled PRs

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -10,3 +10,5 @@ changelog:
       labels: ['documentation']
     - title: 'Dependency Upgrades'
       labels: ['dependencies']
+    - title: 'Internal Changes'
+      labels: ['internal', 'github_action']


### PR DESCRIPTION

**Description**:
This PR modified the .github/release.yaml to include `internal` and `github_action` labeled PRs

Fixes #3172 

**Notes for reviewer**:


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
