### PR TITLE
ci(bug): Update permissions in JSON rpc relay for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -11,6 +11,7 @@ env:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   docker-image-publish:


### PR DESCRIPTION
**Description**:
Added `packages: write` permission per [the github documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-with-a-personal-access-token-classic) May need to modify other files modified by #3124

**Related Issue(s)**:
Relates to #3124
Relates to #3182

