### PR TITLE
fix: Wrong metrics in the report of the WS performance tests

### DIFF
--- a/k6/src/scenarios/test-ws/eth_chainId.js
+++ b/k6/src/scenarios/test-ws/eth_chainId.js
@@ -23,12 +23,14 @@ import { connectToWebSocket, isNonErrorResponse } from './common.js';
 
 const url = __ENV.WS_RELAY_BASE_URL;
 const methodName = 'eth_chainId';
+const scenarioName = methodName;
 
 const { options, run } = new TestScenarioBuilder()
-  .name(methodName) // use unique scenario name among all tests
+  .name(scenarioName) // use unique scenario name among all tests
   .request(() => connectToWebSocket(
     url,
     methodName,
+    scenarioName,
     [],
     { methodName: (r) => isNonErrorResponse(r) }
   ))

--- a/k6/src/scenarios/test-ws/eth_subscribe_logs.js
+++ b/k6/src/scenarios/test-ws/eth_subscribe_logs.js
@@ -25,13 +25,15 @@ import { connectToWebSocket, isNonErrorResponse } from './common.js';
 
 const url = __ENV.WS_RELAY_BASE_URL;
 const methodName = 'eth_subscribe';
+const scenarioName = methodName + '_logs';
 
 const { options, run } = new TestScenarioBuilder()
-  .name(methodName + '_logs') // use unique scenario name among all tests
+  .name(scenarioName) // use unique scenario name among all tests
   .request((testParameters) => {
     return connectToWebSocket(
       url,
       methodName,
+      scenarioName,
       [subscribeEvents.logs, { address: testParameters.contractsAddresses[0] }],
       { methodName: (r) => isNonErrorResponse(r) }
     );

--- a/k6/src/scenarios/test-ws/eth_subscribe_newHeads.js
+++ b/k6/src/scenarios/test-ws/eth_subscribe_newHeads.js
@@ -24,12 +24,14 @@ import { connectToWebSocket, isNonErrorResponse } from './common.js';
 
 const url = __ENV.WS_RELAY_BASE_URL;
 const methodName = 'eth_subscribe';
+const scenarioName = methodName + '_newHeads';
 
 const { options, run } = new TestScenarioBuilder()
-  .name(methodName + '_newHeads') // use unique scenario name among all tests
+  .name(scenarioName) // use unique scenario name among all tests
   .request(() => connectToWebSocket(
     url,
     methodName,
+    scenarioName,
     [subscribeEvents.newHeads],
     { methodName: (r) => isNonErrorResponse(r) }
   ))

--- a/k6/src/scenarios/test-ws/eth_subscribe_newPendingTransactions.js
+++ b/k6/src/scenarios/test-ws/eth_subscribe_newPendingTransactions.js
@@ -24,12 +24,14 @@ import { connectToWebSocket, isErrorResponse } from './common.js';
 
 const url = __ENV.WS_RELAY_BASE_URL;
 const methodName = 'eth_subscribe';
+const scenarioName = methodName + '_newPendingTransactions';
 
 const { options, run } = new TestScenarioBuilder()
   .name(methodName + '_newPendingTransactions') // use unique scenario name among all tests
   .request(() => connectToWebSocket(
     url,
     methodName,
+    scenarioName,
     [subscribeEvents.newPendingTransactions],
     { methodName: (r) => isErrorResponse(r) }
   ))

--- a/k6/src/scenarios/ws-apis.js
+++ b/k6/src/scenarios/ws-apis.js
@@ -23,7 +23,7 @@ import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
 
 import { markdownReport } from '../lib/common.js';
 import { setupTestParameters } from '../lib/bootstrapEnvParameters.js';
-import { funcs, options, scenarioDurationGauge } from './test-ws/index.js';
+import { funcs, options } from './test-ws/index.js';
 
 function handleSummary(data) {
   return {
@@ -35,7 +35,6 @@ function handleSummary(data) {
 function run(testParameters) {
   const scenario = exec.scenario;
   funcs[scenario.name](testParameters, scenario.iterationInTest, exec.vu.idInInstance - 1, exec.vu.iterationInScenario);
-  scenarioDurationGauge.add(Date.now() - scenario.startTime, { scenario: scenario.name });
 }
 
 export { handleSummary, options, run };


### PR DESCRIPTION
**Description**:

### Problem

The current report of the k6 performance tests for the WS-server is currently misleading:
- the scenario duration is not correctly captured since the actual duration should be taken from the moment that the JSON-RPC request is sent to the WS server until the moment a message with the JSON-RPC response is received from the WS server. Instead, the `scenarioDurationGauge` is currently only tracking the duration of the request which establishes connection with the WS server and not the actual JSON-RPC request.

### Solution

Refactor the current tests to capture valid scenario duration metrics in the report (through the `scenarioDurationGauge`)

**Related issue(s)**:

Fixes #3167

**Notes for reviewer**:

Results after running the WS performance tests against testnet:

```bash
     checks.......................................................................: 100.00% ✓ 4318      ✗ 0     
     ✓ { scenario:eth_chainId }...................................................: 100.00% ✓ 1656      ✗ 0     
     ✓ { scenario:eth_subscribe_logs }............................................: 100.00% ✓ 519       ✗ 0     
     ✓ { scenario:eth_subscribe_newHeads }........................................: 100.00% ✓ 1141      ✗ 0     
     ✓ { scenario:eth_subscribe_newPendingTransactions }..........................: 100.00% ✓ 1002      ✗ 0     
     data_received................................................................: 16 MB   43 kB/s
     data_sent....................................................................: 3.4 MB  8.9 kB/s
     http_req_blocked.............................................................: avg=28.05ms  min=14.37ms  med=18.95ms max=59.93ms  p(90)=48.59ms  p(95)=54.26ms 
     http_req_connecting..........................................................: avg=6.92ms   min=5.36ms   med=7.28ms  max=7.78ms   p(90)=7.7ms    p(95)=7.74ms  
     http_req_duration............................................................: avg=78.83ms  min=61.15ms  med=67.91ms max=118.36ms p(90)=104.64ms p(95)=111.5ms 
       { expected_response:true }.................................................: avg=78.83ms  min=61.15ms  med=67.91ms max=118.36ms p(90)=104.64ms p(95)=111.5ms 
     ✓ { scenario:eth_chainId,expected_response:true }............................: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
     ✓ { scenario:eth_subscribe_logs,expected_response:true }.....................: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
     ✓ { scenario:eth_subscribe_newHeads,expected_response:true }.................: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
     ✓ { scenario:eth_subscribe_newPendingTransactions,expected_response:true }...: avg=0s       min=0s       med=0s      max=0s       p(90)=0s       p(95)=0s      
     http_req_failed..............................................................: 0.00%   ✓ 0         ✗ 4     
     http_req_receiving...........................................................: avg=151.75µs min=104µs    med=128µs   max=247µs    p(90)=213.7µs  p(95)=230.34µs
     http_req_sending.............................................................: avg=97µs     min=57µs     med=91.5µs  max=148µs    p(90)=136.9µs  p(95)=142.44µs
     http_req_tls_handshaking.....................................................: avg=10.47ms  min=7.9ms    med=9.49ms  max=14.98ms  p(90)=13.5ms   p(95)=14.24ms 
     http_req_waiting.............................................................: avg=78.58ms  min=60.9ms   med=67.63ms max=118.17ms p(90)=104.46ms p(95)=111.31ms
     http_reqs....................................................................: 4       0.010594/s
     ✗ { scenario:eth_chainId }...................................................: 0       0/s
     ✗ { scenario:eth_subscribe_logs }............................................: 0       0/s
     ✗ { scenario:eth_subscribe_newHeads }........................................: 0       0/s
     ✗ { scenario:eth_subscribe_newPendingTransactions }..........................: 0       0/s
     iteration_duration...........................................................: avg=7.54s    min=307.56ms med=2.32s   max=35.28s   p(90)=23.58s   p(95)=27.29s  
     iterations...................................................................: 4445    11.772777/s
     scenario_duration............................................................: 166     min=142     max=4757
     ✓ { scenario:eth_chainId }...................................................: 1311    min=142     max=4757
     ✓ { scenario:eth_subscribe_logs }............................................: 297     min=144     max=3513
     ✓ { scenario:eth_subscribe_newHeads }........................................: 289     min=142     max=2205
     ✓ { scenario:eth_subscribe_newPendingTransactions }..........................: 166     min=142     max=3074
     vus..........................................................................: 9       min=9       max=100 
     vus_max......................................................................: 100     min=100     max=100 
     ws_connecting................................................................: avg=7.29s    min=163.66ms med=2.68s   max=34.77s   p(90)=23.09s   p(95)=26.82s  
     ws_msgs_received.............................................................: 4318    11.436412/s
     ws_msgs_sent.................................................................: 4352    11.526463/s
     ws_session_duration..........................................................: avg=7.55s    min=307.5ms  med=2.37s   max=35.28s   p(90)=23.58s   p(95)=27.29s  

running (6m17.6s), 000/100 VUs, 4440 complete and 241 interrupted iterations
eth_chainId                    ✓ [======================================] 100 VUs  1m30s
eth_subscribe_logs             ✓ [======================================] 100 VUs  1m30s
eth_subscribe_newHeads         ✓ [======================================] 100 VUs  1m30s
eth_subscribe_newPendingTra... ✓ [======================================] 100 VUs  1m30s
```

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
