### PR TITLE
fix: skipped title check CI job for forked PRs

### DIFF
--- a/.github/workflows/flow-pr-title-check.yml
+++ b/.github/workflows/flow-pr-title-check.yml
@@ -39,6 +39,7 @@ jobs:
   title-check:
     name: Title Check
     runs-on: smart-contracts-linux-medium
+    if: ${{ !github.event.pull_request.base.repo.fork }}
     permissions:
       statuses: write
     steps:


### PR DESCRIPTION
**Description**:
Title check CI job fail for PRs that are from a forked repository due to the lack of the secret.GITHUB_TOKEN. This PR adds an option to skip the check if the PRs are from forked repos.


**Related issue(s)**:

Fixes #3195 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
