### PR TITLE
fix: Capture the npm_package_version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "root",
+  "version": "0.60.0-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
+      "version": "0.60.0-SNAPSHOT",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "@ethereumjs/trie": "^6.2.1",
@@ -10305,7 +10307,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -10668,7 +10669,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -21997,7 +21997,7 @@
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.2",
-        "semver": "^6.3.1"
+        "semver": "^7.5.3"
       }
     },
     "@babel/generator": {
@@ -22022,7 +22022,7 @@
         "@babel/helper-validator-option": "^7.22.5",
         "browserslist": "^4.21.9",
         "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
+        "semver": "^7.5.3"
       },
       "dependencies": {
         "lru-cache": {
@@ -22381,7 +22381,7 @@
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
+            "semver": "^7.5.3",
             "validate-npm-package-license": "^3.0.1"
           }
         },
@@ -22467,7 +22467,7 @@
             "fs-extra": "^0.30.0",
             "memorystream": "^0.3.1",
             "require-from-string": "^1.1.0",
-            "semver": "^5.3.0",
+            "semver": "^7.5.3",
             "yargs": "^4.7.1"
           }
         },
@@ -24370,7 +24370,7 @@
       "integrity": "sha512-da51j1RCHm+uXpQNM0KJ7qbhUJLTp6Avw8GdL+PQCbZ4lBwKAo8jjJ5rRjf1odsN1+zKl+JF7SMmKZB8PY229Q==",
       "requires": {
         "long": "^4.0.0",
-        "protobufjs": "^7.2.5"
+        "protobufjs": "^7.2.4"
       }
     },
     "@hashgraph/sdk": {
@@ -24846,7 +24846,7 @@
         "read-cmd-shim": "4.0.0",
         "resolve-from": "5.0.0",
         "rimraf": "^4.4.1",
-        "semver": "^7.3.4",
+        "semver": "^7.5.3",
         "set-blocking": "^2.0.0",
         "signal-exit": "3.0.7",
         "slash": "^3.0.0",
@@ -25123,7 +25123,7 @@
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^3.0.1",
         "read-package-json-fast": "^3.0.2",
-        "semver": "^7.3.7",
+        "semver": "^7.5.3",
         "ssri": "^10.0.6",
         "treeverse": "^3.0.0",
         "walk-up-path": "^3.0.1"
@@ -25165,7 +25165,7 @@
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
       "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
       "requires": {
-        "semver": "^7.3.5"
+        "semver": "^7.5.3"
       }
     },
     "@npmcli/git": {
@@ -25180,7 +25180,7 @@
         "proc-log": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
-        "semver": "^7.3.5",
+        "semver": "^7.5.3",
         "which": "^4.0.0"
       },
       "dependencies": {
@@ -25288,7 +25288,7 @@
         "json-parse-even-better-errors": "^3.0.0",
         "pacote": "^18.0.0",
         "proc-log": "^4.1.0",
-        "semver": "^7.3.5"
+        "semver": "^7.5.3"
       }
     },
     "@npmcli/name-from-folder": {
@@ -27474,7 +27474,7 @@
       "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
       "dev": true,
       "requires": {
-        "semver": "^7.0.0"
+        "semver": "^7.5.3"
       }
     },
     "byte-size": {
@@ -28127,7 +28127,7 @@
           "requires": {
             "hosted-git-info": "^4.0.1",
             "is-core-module": "^2.5.0",
-            "semver": "^7.3.4",
+            "semver": "^7.5.3",
             "validate-npm-package-license": "^3.0.1"
           }
         }
@@ -28148,7 +28148,7 @@
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
         "meow": "^8.1.2",
-        "semver": "^7.0.0",
+        "semver": "^7.5.3",
         "split": "^1.0.1"
       }
     },
@@ -30504,7 +30504,7 @@
       "integrity": "sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==",
       "requires": {
         "meow": "^8.1.2",
-        "semver": "^7.0.0"
+        "semver": "^7.5.3"
       }
     },
     "git-up": {
@@ -31002,7 +31002,7 @@
         "npm-package-arg": "^11.0.0",
         "promzard": "^1.0.0",
         "read": "^3.0.1",
-        "semver": "^7.3.5",
+        "semver": "^7.5.3",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^5.0.0"
       }
@@ -31480,7 +31480,7 @@
         "@babel/core": "^7.7.5",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
+        "semver": "^7.5.3"
       }
     },
     "istanbul-lib-processinfo": {
@@ -32929,7 +32929,7 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.3"
       }
     },
     "make-error": {
@@ -33198,7 +33198,7 @@
           "requires": {
             "hosted-git-info": "^4.0.1",
             "is-core-module": "^2.5.0",
-            "semver": "^7.3.4",
+            "semver": "^7.5.3",
             "validate-npm-package-license": "^3.0.1"
           }
         },
@@ -33241,7 +33241,7 @@
               "requires": {
                 "hosted-git-info": "^2.1.4",
                 "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
+                "semver": "^7.5.3",
                 "validate-npm-package-license": "^3.0.1"
               }
             },
@@ -33836,7 +33836,7 @@
         "make-fetch-happen": "^13.0.0",
         "nopt": "^7.0.0",
         "proc-log": "^4.1.0",
-        "semver": "^7.3.5",
+        "semver": "^7.5.3",
         "tar": "^6.2.1",
         "which": "^4.0.0"
       },
@@ -34017,7 +34017,7 @@
       "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-6.3.0.tgz",
       "integrity": "sha512-W29RiK/xtpCGqn6f3ixfRYGk+zRyr+Ew9F2E20BfXxT5/euLdA/Nm7fO7OeTGuAmTs30cpgInyJ0cYe708YTZw==",
       "requires": {
-        "semver": "^7.1.1"
+        "semver": "^7.5.3"
       }
     },
     "npm-normalize-package-bin": {
@@ -34067,7 +34067,7 @@
         "npm-install-checks": "^6.0.0",
         "npm-normalize-package-bin": "^3.0.0",
         "npm-package-arg": "^11.0.0",
-        "semver": "^7.3.5"
+        "semver": "^7.5.3"
       }
     },
     "npm-registry-fetch": {
@@ -35448,7 +35448,7 @@
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
+            "semver": "^7.5.3",
             "validate-npm-package-license": "^3.0.1"
           }
         },
@@ -37825,7 +37825,7 @@
           "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
           "requires": {
             "pify": "^4.0.1",
-            "semver": "^5.6.0"
+            "semver": "^7.5.3"
           }
         },
         "pify": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "root",
+  "version": "0.60.0-SNAPSHOT",
   "devDependencies": {
     "@hashgraph/hedera-local": "^2.31.0",
     "@open-rpc/schema-utils-js": "^1.16.1",
@@ -45,7 +46,7 @@
     "acceptancetest:api_batch1": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-1' --exit",
     "acceptancetest:api_batch2": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-2' --exit",
     "acceptancetest:api_batch3": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-3' --exit",
-    "acceptancetest:erc20": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@erc20' --exit",
+    "acceptancetest:erc20": "npm_package_version=0.0.1 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@erc20' --exit",
     "acceptancetest:ratelimiter": "nyc ts-mocha packages/ws-server/tests/acceptance/index.spec.ts -g '@web-socket-ratelimiter' --exit && ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@ratelimiter' --exit",
     "acceptancetest:hbarlimiter_batch1": "HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch1' --exit",
     "acceptancetest:hbarlimiter_batch2": "HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch2' --exit",

--- a/packages/config-service/src/services/globalConfig.ts
+++ b/packages/config-service/src/services/globalConfig.ts
@@ -495,10 +495,11 @@ export class GlobalConfig {
       required: false,
       defaultValue: null,
     },
-    NPM_PACKAGE_VERSION: {
+    // the actual env var in the node process is npm_package_version
+    npm_package_version: {
       envName: 'npm_package_version',
       type: 'string',
-      required: false,
+      required: true,
       defaultValue: null,
     },
     OPERATOR_ID_ETH_SENDRAWTRANSACTION: {

--- a/packages/config-service/tests/src/services/validationService.spec.ts
+++ b/packages/config-service/tests/src/services/validationService.spec.ts
@@ -22,6 +22,7 @@ import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { GlobalConfig } from '../../../dist/services/globalConfig';
 import { ValidationService } from '../../../dist/services/validationService';
+import { overrideEnvsInMochaDescribe } from '../../../../relay/tests/helpers';
 
 chai.use(chaiAsPromised);
 
@@ -31,6 +32,7 @@ describe('ValidationService tests', async function () {
       CHAIN_ID: '0x12a',
       HEDERA_NETWORK: '{"127.0.0.1:50211":"0.0.3"}',
       MIRROR_NODE_URL: 'http://127.0.0.1:5551',
+      npm_package_version: '1.0.0',
       OPERATOR_ID_MAIN: '0.0.1002',
       OPERATOR_KEY_MAIN:
         '302000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
@@ -52,6 +54,30 @@ describe('ValidationService tests', async function () {
         }),
       ).to.throw('SERVER_PORT must be a valid number.');
       GlobalConfig.ENTRIES.SERVER_PORT.required = false;
+    });
+  });
+
+  describe('package-version', () => {
+    overrideEnvsInMochaDescribe({
+      npm_package_version: undefined,
+    });
+
+    const mandatoryStartUpFields = {
+      CHAIN_ID: '0x12a',
+      HEDERA_NETWORK: '{"127.0.0.1:50211":"0.0.3"}',
+      MIRROR_NODE_URL: 'http://127.0.0.1:5551',
+      OPERATOR_ID_MAIN: '0.0.1002',
+      OPERATOR_KEY_MAIN:
+        '302000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+      SERVER_PORT: '7546',
+    };
+
+    it('should fail fast if npm_package_version is not set', async () => {
+      expect(() =>
+        ValidationService.startUp({
+          ...mandatoryStartUpFields,
+        }),
+      ).to.throw('npm_package_version is a mandatory and the relay cannot operate without its value.');
     });
   });
 

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -82,9 +82,6 @@ global.relayIsLocal = RELAY_URL === LOCAL_RELAY_URL;
 describe('RPC Server Acceptance Tests', function () {
   this.timeout(240 * 1000); // 240 seconds
 
-  let relayServer; // Relay Server
-  let socketServer;
-
   global.servicesNode = new ServicesClient(
     NETWORK,
     OPERATOR_ID,


### PR DESCRIPTION
**Description**:
The ConfigService was using an all caps version of the `npm_package_version` of the env var definition but in a node context the env var is lowercase: `npm_package_version`.  Nothing was being returned from the `web3_clientVersion` method.

**Related issue(s)**:

Fixes #3197

**Notes for reviewer**:
Simply changing the case of the env var definition in the `GlobalConfig.ts` class prevents updating conditional logic that already works.  Adding the version number to the root package.json file allows it to be loaded by the `ConfigService.ts` which loads before the acceptance tests framework.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
