### PR TITLE
fix: 3198 cherry pick npm package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "root",
+  "version": "0.60.0-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
+      "version": "0.60.0-SNAPSHOT",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "@ethereumjs/trie": "^6.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "0.60.0-SNAPSHOT",
+  "version": "0.59.0-rc2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "0.60.0-SNAPSHOT",
+      "version": "0.59.0-rc2",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "@ethereumjs/trie": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "root",
+  "version": "0.60.0-SNAPSHOT",
   "devDependencies": {
     "@hashgraph/hedera-local": "^2.31.0",
     "@open-rpc/schema-utils-js": "^1.16.1",
@@ -45,7 +46,7 @@
     "acceptancetest:api_batch1": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-1' --exit",
     "acceptancetest:api_batch2": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-2' --exit",
     "acceptancetest:api_batch3": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-3' --exit",
-    "acceptancetest:erc20": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@erc20' --exit",
+    "acceptancetest:erc20": "npm_package_version=0.0.1 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@erc20' --exit",
     "acceptancetest:ratelimiter": "nyc ts-mocha packages/ws-server/tests/acceptance/index.spec.ts -g '@web-socket-ratelimiter' --exit && ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@ratelimiter' --exit",
     "acceptancetest:hbarlimiter_batch1": "HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch1' --exit",
     "acceptancetest:hbarlimiter_batch2": "HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch2' --exit",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.60.0-SNAPSHOT",
+  "version": "0.59.0-rc2",
   "devDependencies": {
     "@hashgraph/hedera-local": "^2.31.0",
     "@open-rpc/schema-utils-js": "^1.16.1",
@@ -46,7 +46,7 @@
     "acceptancetest:api_batch1": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-1' --exit",
     "acceptancetest:api_batch2": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-2' --exit",
     "acceptancetest:api_batch3": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@api-batch-3' --exit",
-    "acceptancetest:erc20": "npm_package_version=0.0.1 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@erc20' --exit",
+    "acceptancetest:erc20": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@erc20' --exit",
     "acceptancetest:ratelimiter": "nyc ts-mocha packages/ws-server/tests/acceptance/index.spec.ts -g '@web-socket-ratelimiter' --exit && ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@ratelimiter' --exit",
     "acceptancetest:hbarlimiter_batch1": "HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch1' --exit",
     "acceptancetest:hbarlimiter_batch2": "HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch2' --exit",

--- a/packages/config-service/src/services/globalConfig.ts
+++ b/packages/config-service/src/services/globalConfig.ts
@@ -495,10 +495,11 @@ export class GlobalConfig {
       required: false,
       defaultValue: null,
     },
-    NPM_PACKAGE_VERSION: {
+    // the actual env var in the node process is npm_package_version
+    npm_package_version: {
       envName: 'npm_package_version',
       type: 'string',
-      required: false,
+      required: true,
       defaultValue: null,
     },
     OPERATOR_ID_ETH_SENDRAWTRANSACTION: {

--- a/packages/config-service/tests/src/services/validationService.spec.ts
+++ b/packages/config-service/tests/src/services/validationService.spec.ts
@@ -22,6 +22,7 @@ import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { GlobalConfig } from '../../../dist/services/globalConfig';
 import { ValidationService } from '../../../dist/services/validationService';
+import { overrideEnvsInMochaDescribe } from '../../../../relay/tests/helpers';
 
 chai.use(chaiAsPromised);
 
@@ -31,6 +32,7 @@ describe('ValidationService tests', async function () {
       CHAIN_ID: '0x12a',
       HEDERA_NETWORK: '{"127.0.0.1:50211":"0.0.3"}',
       MIRROR_NODE_URL: 'http://127.0.0.1:5551',
+      npm_package_version: '1.0.0',
       OPERATOR_ID_MAIN: '0.0.1002',
       OPERATOR_KEY_MAIN:
         '302000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
@@ -52,6 +54,30 @@ describe('ValidationService tests', async function () {
         }),
       ).to.throw('SERVER_PORT must be a valid number.');
       GlobalConfig.ENTRIES.SERVER_PORT.required = false;
+    });
+  });
+
+  describe('package-version', () => {
+    overrideEnvsInMochaDescribe({
+      npm_package_version: undefined,
+    });
+
+    const mandatoryStartUpFields = {
+      CHAIN_ID: '0x12a',
+      HEDERA_NETWORK: '{"127.0.0.1:50211":"0.0.3"}',
+      MIRROR_NODE_URL: 'http://127.0.0.1:5551',
+      OPERATOR_ID_MAIN: '0.0.1002',
+      OPERATOR_KEY_MAIN:
+        '302000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+      SERVER_PORT: '7546',
+    };
+
+    it('should fail fast if npm_package_version is not set', async () => {
+      expect(() =>
+        ValidationService.startUp({
+          ...mandatoryStartUpFields,
+        }),
+      ).to.throw('npm_package_version is a mandatory and the relay cannot operate without its value.');
     });
   });
 

--- a/packages/server/tests/acceptance/index.spec.ts
+++ b/packages/server/tests/acceptance/index.spec.ts
@@ -82,9 +82,6 @@ global.relayIsLocal = RELAY_URL === LOCAL_RELAY_URL;
 describe('RPC Server Acceptance Tests', function () {
   this.timeout(240 * 1000); // 240 seconds
 
-  let relayServer; // Relay Server
-  let socketServer;
-
   global.servicesNode = new ServicesClient(
     NETWORK,
     OPERATOR_ID,


### PR DESCRIPTION
**Description**:
Cherry-picked fix for the `web3_clientVersion` method.

The ConfigService was using an all caps version of the npm_package_version of the env var definition but in a node context the env var is lowercase: npm_package_version. Nothing was being returned from the web3_clientVersion method.

**Related issue(s)**:

Fixes #3198 

**Notes for reviewer**:
Simply changing the case of the env var definition in the GlobalConfig.ts class prevents updating conditional logic that already works. Adding the version number to the root package.json file allows it to be loaded by the ConfigService.ts which loads before the acceptance tests framework.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
