### PR TITLE
fix: Adds retry to send raw transaction (#3161)

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -69,6 +69,8 @@ import {
   ITransactionRecordMetric,
   RequestDetails,
 } from '../types';
+import { MirrorNodeClient } from './mirrorNodeClient';
+import { Registry } from 'prom-client';
 
 const _ = require('lodash');
 
@@ -123,6 +125,14 @@ export class SDKClient {
   private readonly hbarLimitService: HbarLimitService;
 
   /**
+   * An instance of the MirrorNodeClient
+   * @private
+   * @readonly
+   * @type {MirrorNodeClient}
+   */
+  private readonly mirrorNodeClient: MirrorNodeClient;
+
+  /**
    * Constructs an instance of the SDKClient and initializes various services and settings.
    *
    * @param {Client} clientMain - The primary Hedera client instance used for executing transactions and queries.
@@ -136,6 +146,7 @@ export class SDKClient {
     cacheService: CacheService,
     eventEmitter: EventEmitter,
     hbarLimitService: HbarLimitService,
+    register: Registry,
   ) {
     this.clientMain = clientMain;
 
@@ -151,6 +162,13 @@ export class SDKClient {
     this.hbarLimitService = hbarLimitService;
     this.maxChunks = Number(ConfigService.get('FILE_APPEND_MAX_CHUNKS')) || 20;
     this.fileAppendChunkSize = Number(ConfigService.get('FILE_APPEND_CHUNK_SIZE')) || 5120;
+    this.mirrorNodeClient = new MirrorNodeClient(
+      // @ts-ignore
+      ConfigService.get('MIRROR_NODE_URL') || '',
+      logger,
+      register,
+      cacheService,
+    );
   }
 
   /**
@@ -441,17 +459,59 @@ export class SDKClient {
       Hbar.fromTinybars(Math.floor(networkGasPriceInTinyBars * constants.MAX_GAS_PER_SEC)),
     );
 
-    return {
-      fileId,
-      txResponse: await this.executeTransaction(
+    let txResponse;
+    try {
+      txResponse = await this.executeTransaction(
         ethereumTransaction,
         callerName,
         interactingEntity,
         requestDetails,
         true,
         originalCallerAddress,
-      ),
+      );
+    } catch (e: any) {
+      if (e instanceof SDKClientError && (e.isConnectionDropped() || e.isTimeoutExceeded())) {
+        const isFailed = await this.isFailedTransaction(requestDetails, e.transactionId);
+        if (isFailed) {
+          throw e;
+        }
+        txResponse = { transactionId: e.transactionId };
+      } else {
+        throw e;
+      }
+    }
+
+    return {
+      fileId,
+      txResponse,
     };
+  }
+
+  /**
+   * Checks if a transaction has failed by querying the mirror node.
+   *
+   * @param {RequestDetails} requestDetails - The details of the request.
+   * @param {string} [transactionId] - The ID of the transaction to check.
+   * @returns {Promise<boolean>} - A promise that resolves to `true` if the transaction has failed, `false` otherwise.
+   */
+  async isFailedTransaction(requestDetails: RequestDetails, transactionId?: string): Promise<boolean> {
+    const retryCount = 5;
+    try {
+      const transaction = await this.mirrorNodeClient.repeatedRequest(
+        this.mirrorNodeClient.getTransactionById.name,
+        [transactionId, requestDetails],
+        retryCount,
+        requestDetails,
+      );
+      const isFailed = transaction !== null;
+      return isFailed;
+    } catch (e: any) {
+      this.logger.error(
+        e,
+        `${requestDetails.formattedRequestId} Failed to check if transaction ${transactionId} is failed`,
+      );
+      return true;
+    }
   }
 
   /**
@@ -724,7 +784,7 @@ export class SDKClient {
         throw e;
       }
 
-      const sdkClientError = new SDKClientError(e, e.message);
+      const sdkClientError = new SDKClientError(e, e.message, transaction.transactionId?.toString());
 
       // Throw WRONG_NONCE error as more error handling logic for WRONG_NONCE is awaited in eth.sendRawTransactionErrorHandler().
       if (sdkClientError.status && sdkClientError.status === Status.WrongNonce) {
@@ -737,9 +797,13 @@ export class SDKClient {
       );
 
       if (!transactionResponse) {
-        throw predefined.INTERNAL_ERROR(
-          `${requestDetails.formattedRequestId} Transaction execution returns a null value: transactionId=${transaction.transactionId}, callerName=${callerName}, txConstructorName=${txConstructorName}`,
-        );
+        if (sdkClientError.isConnectionDropped() || sdkClientError.isTimeoutExceeded()) {
+          throw sdkClientError;
+        } else {
+          throw predefined.INTERNAL_ERROR(
+            `${requestDetails.formattedRequestId} Transaction execution returns a null value: transactionId=${transaction.transactionId}, callerName=${callerName}, txConstructorName=${txConstructorName}`,
+          );
+        }
       }
       return transactionResponse;
     } finally {

--- a/packages/relay/src/lib/errors/SDKClientError.ts
+++ b/packages/relay/src/lib/errors/SDKClientError.ts
@@ -23,20 +23,25 @@ import { Status } from '@hashgraph/sdk';
 export class SDKClientError extends Error {
   public status: Status = Status.Unknown;
   private validNetworkError: boolean = false;
+  private failedTransactionId: string | undefined;
 
-  constructor(e: any, message?: string) {
+  constructor(e: any, message?: string, transactionId?: string) {
     super(e?.status?._code ? e.message : message);
 
     if (e?.status?._code) {
       this.validNetworkError = true;
       this.status = e.status;
     }
-
+    this.failedTransactionId = transactionId || '';
     Object.setPrototypeOf(this, SDKClientError.prototype);
   }
 
   get statusCode(): number {
     return this.status._code;
+  }
+
+  get transactionId(): string | undefined {
+    return this.failedTransactionId;
   }
 
   public isValidNetworkError(): boolean {

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -208,7 +208,7 @@ export default class HAPIService {
     this.clientMain = this.initClient(logger, this.hederaNetwork);
 
     this.cacheService = cacheService;
-    this.client = this.initSDKClient(logger);
+    this.client = this.initSDKClient(logger, register);
 
     const currentDateNow = Date.now();
     // @ts-ignore
@@ -287,7 +287,7 @@ export default class HAPIService {
       .inc(1);
 
     this.clientMain = this.initClient(this.logger, this.hederaNetwork);
-    this.client = this.initSDKClient(this.logger);
+    this.client = this.initSDKClient(this.logger, this.register);
     this.resetCounters();
   }
 
@@ -306,13 +306,14 @@ export default class HAPIService {
    * @param {Logger} logger
    * @returns SDK Client
    */
-  private initSDKClient(logger: Logger): SDKClient {
+  private initSDKClient(logger: Logger, register: Registry): SDKClient {
     return new SDKClient(
       this.clientMain,
       logger.child({ name: `consensus-node` }),
       this.cacheService,
       this.eventEmitter,
       this.hbarLimitService,
+      register,
     );
   }
 

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -137,6 +137,7 @@ describe('SdkClient', async function () {
       new CacheService(logger.child({ name: `cache` }), registry),
       eventEmitter,
       hbarLimitService,
+      register,
     );
 
     instance = axios.create({

--- a/packages/relay/tests/lib/services/metricService/metricService.spec.ts
+++ b/packages/relay/tests/lib/services/metricService/metricService.spec.ts
@@ -163,6 +163,7 @@ describe('Metric Service', function () {
       new CacheService(logger.child({ name: `cache` }), registry),
       eventEmitter,
       hbarLimitService,
+      register,
     );
     // Init new MetricService instance
     metricService = new MetricService(logger, sdkClient, mirrorNodeClient, registry, eventEmitter, hbarLimitService);


### PR DESCRIPTION
Addresses issue: #3160 

* Adds retry to eth send raw transaction



* Adds mirror node check before retry and expands SDKClientError object to include transactionId



* Adds unit tests



* Adds improvements



* adds relevant comment for hardcoded values



* removes retry and adds mirror node check in the sdk client



* Adds unit tests



* Addresses PR comments



* Changes the error thrown when timeout occurs to SDKClientError



* Ensure other error types are thrown



---------

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
