### PR TITLE
fix: Added the root package.json file to the

### DIFF
--- a/scripts/.bump-version.js
+++ b/scripts/.bump-version.js
@@ -34,6 +34,7 @@ replace({
   regex: packageRegex,
   replacement: `"version": "${newVersion}"`,
   paths: [
+    "package.json",
     "packages/config-service/package.json",
     "packages/relay/package.json",
     "packages/server/package.json",


### PR DESCRIPTION
.bump-version.js script.

The root `package.json` file now needs to be included in the `.bump-version.js` script.

**Related issue(s)**:

Fixes #3220 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
