### PR TITLE
fix WS_NEW_HEADS_ENABLED default

### DIFF
--- a/packages/config-service/src/services/globalConfig.ts
+++ b/packages/config-service/src/services/globalConfig.ts
@@ -710,7 +710,7 @@ export class GlobalConfig {
       envName: 'WS_NEW_HEADS_ENABLED',
       type: 'boolean',
       required: false,
-      defaultValue: null,
+      defaultValue: true,
     },
     WS_PING_INTERVAL: {
       envName: 'WS_PING_INTERVAL',


### PR DESCRIPTION
**Description**:
Restores the behavior of defaulting to true for the env var. 

Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/3227

This change was originally made in https://github.com/hashgraph/hedera-json-rpc-relay/pull/2361, but seems to have been lost in https://github.com/hashgraph/hedera-json-rpc-relay/pull/3047 (more specific [at this line](https://github.com/hashgraph/hedera-json-rpc-relay/pull/3047/files#diff-e45c74081ee1bad0af083d6197bf6d533f97228588695bcd20322cca1bcaa142R77))


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
