### PR TITLE
fix: modified sendRawTransaction to also poll MN for transaction's validity for Timeout and ConnectionDropped error

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -69,8 +69,6 @@ import {
   ITransactionRecordMetric,
   RequestDetails,
 } from '../types';
-import { MirrorNodeClient } from './mirrorNodeClient';
-import { Registry } from 'prom-client';
 
 const _ = require('lodash');
 
@@ -125,14 +123,6 @@ export class SDKClient {
   private readonly hbarLimitService: HbarLimitService;
 
   /**
-   * An instance of the MirrorNodeClient
-   * @private
-   * @readonly
-   * @type {MirrorNodeClient}
-   */
-  private readonly mirrorNodeClient: MirrorNodeClient;
-
-  /**
    * Constructs an instance of the SDKClient and initializes various services and settings.
    *
    * @param {Client} clientMain - The primary Hedera client instance used for executing transactions and queries.
@@ -146,7 +136,6 @@ export class SDKClient {
     cacheService: CacheService,
     eventEmitter: EventEmitter,
     hbarLimitService: HbarLimitService,
-    register: Registry,
   ) {
     this.clientMain = clientMain;
 
@@ -162,13 +151,6 @@ export class SDKClient {
     this.hbarLimitService = hbarLimitService;
     this.maxChunks = Number(ConfigService.get('FILE_APPEND_MAX_CHUNKS')) || 20;
     this.fileAppendChunkSize = Number(ConfigService.get('FILE_APPEND_CHUNK_SIZE')) || 5120;
-    this.mirrorNodeClient = new MirrorNodeClient(
-      // @ts-ignore
-      ConfigService.get('MIRROR_NODE_URL') || '',
-      logger,
-      register,
-      cacheService,
-    );
   }
 
   /**
@@ -459,59 +441,17 @@ export class SDKClient {
       Hbar.fromTinybars(Math.floor(networkGasPriceInTinyBars * constants.MAX_GAS_PER_SEC)),
     );
 
-    let txResponse;
-    try {
-      txResponse = await this.executeTransaction(
+    return {
+      fileId,
+      txResponse: await this.executeTransaction(
         ethereumTransaction,
         callerName,
         interactingEntity,
         requestDetails,
         true,
         originalCallerAddress,
-      );
-    } catch (e: any) {
-      if (e instanceof SDKClientError && (e.isConnectionDropped() || e.isTimeoutExceeded())) {
-        const isFailed = await this.isFailedTransaction(requestDetails, e.transactionId);
-        if (isFailed) {
-          throw e;
-        }
-        txResponse = { transactionId: e.transactionId };
-      } else {
-        throw e;
-      }
-    }
-
-    return {
-      fileId,
-      txResponse,
+      ),
     };
-  }
-
-  /**
-   * Checks if a transaction has failed by querying the mirror node.
-   *
-   * @param {RequestDetails} requestDetails - The details of the request.
-   * @param {string} [transactionId] - The ID of the transaction to check.
-   * @returns {Promise<boolean>} - A promise that resolves to `true` if the transaction has failed, `false` otherwise.
-   */
-  async isFailedTransaction(requestDetails: RequestDetails, transactionId?: string): Promise<boolean> {
-    const retryCount = 5;
-    try {
-      const transaction = await this.mirrorNodeClient.repeatedRequest(
-        this.mirrorNodeClient.getTransactionById.name,
-        [transactionId, requestDetails],
-        retryCount,
-        requestDetails,
-      );
-      const isFailed = transaction !== null;
-      return isFailed;
-    } catch (e: any) {
-      this.logger.error(
-        e,
-        `${requestDetails.formattedRequestId} Failed to check if transaction ${transactionId} is failed`,
-      );
-      return true;
-    }
   }
 
   /**
@@ -781,22 +721,28 @@ export class SDKClient {
       return transactionResponse;
     } catch (e: any) {
       if (e instanceof JsonRpcError) {
+        this.logger.warn(
+          e,
+          `${requestDetails.formattedRequestId} Failed to execute ${txConstructorName} transaction due to a JsonRpcError: transactionId=${transaction.transactionId}, callerName=${callerName}, status=${e.code} message=${e.message}`,
+        );
         throw e;
       }
 
       const sdkClientError = new SDKClientError(e, e.message, transaction.transactionId?.toString());
+      this.logger.warn(
+        sdkClientError,
+        `${requestDetails.formattedRequestId} Failed to execute ${txConstructorName} transaction due to an SDKClientError: transactionId=${transaction.transactionId}, callerName=${callerName}, status=${sdkClientError.status}(${sdkClientError.status._code}) message=${sdkClientError.message}`,
+      );
 
-      // Throw WRONG_NONCE error as more error handling logic for WRONG_NONCE is awaited in eth.sendRawTransactionErrorHandler().
+      // WRONG_NONCE is one of the special errors where the SDK still returns a valid transactionResponse.
+      // Throw the WRONG_NONCE error, as additional handling logic is expected in a higher layer.
       if (sdkClientError.status && sdkClientError.status === Status.WrongNonce) {
         throw sdkClientError;
       }
 
-      this.logger.warn(
-        sdkClientError,
-        `${requestDetails.formattedRequestId} Fail to execute ${txConstructorName} transaction: transactionId=${transaction.transactionId}, callerName=${callerName}, status=${sdkClientError.status}(${sdkClientError.status._code}) message=${sdkClientError.message}`,
-      );
-
       if (!transactionResponse) {
+        // Transactions may experience "SDK timeout exceeded" or "Connection Dropped" errors from the SDK, yet they may still be able to reach the consensus layer.
+        // Throw Connection Drop and Timeout errors as additional handling logic is expected in a higher layer.
         if (sdkClientError.isConnectionDropped() || sdkClientError.isTimeoutExceeded()) {
           throw sdkClientError;
         } else {

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -721,18 +721,10 @@ export class SDKClient {
       return transactionResponse;
     } catch (e: any) {
       if (e instanceof JsonRpcError) {
-        this.logger.warn(
-          e,
-          `${requestDetails.formattedRequestId} Failed to execute ${txConstructorName} transaction due to a JsonRpcError: transactionId=${transaction.transactionId}, callerName=${callerName}, status=${e.code} message=${e.message}`,
-        );
         throw e;
       }
 
       const sdkClientError = new SDKClientError(e, e.message, transaction.transactionId?.toString());
-      this.logger.warn(
-        sdkClientError,
-        `${requestDetails.formattedRequestId} Failed to execute ${txConstructorName} transaction due to an SDKClientError: transactionId=${transaction.transactionId}, callerName=${callerName}, status=${sdkClientError.status}(${sdkClientError.status._code}) message=${sdkClientError.message}`,
-      );
 
       // WRONG_NONCE is one of the special errors where the SDK still returns a valid transactionResponse.
       // Throw the WRONG_NONCE error, as additional handling logic is expected in a higher layer.

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1585,9 +1585,6 @@ export class EthImpl implements Eth {
       fileId = sendRawTransactionResult.fileId;
       submittedTransactionId = sendRawTransactionResult.txResponse.transactionId?.toString();
       if (!constants.TRANSACTION_ID_REGEX.test(submittedTransactionId)) {
-        this.logger.warn(
-          `${requestIdPrefix} Transaction successfully submitted but returned invalid transactionID: transactionId==${submittedTransactionId}`,
-        );
         throw predefined.INTERNAL_ERROR(
           `Transaction successfully submitted but returned invalid transactionID: transactionId==${submittedTransactionId}`,
         );

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -208,7 +208,7 @@ export default class HAPIService {
     this.clientMain = this.initClient(logger, this.hederaNetwork);
 
     this.cacheService = cacheService;
-    this.client = this.initSDKClient(logger, register);
+    this.client = this.initSDKClient(logger);
 
     const currentDateNow = Date.now();
     // @ts-ignore
@@ -287,7 +287,7 @@ export default class HAPIService {
       .inc(1);
 
     this.clientMain = this.initClient(this.logger, this.hederaNetwork);
-    this.client = this.initSDKClient(this.logger, this.register);
+    this.client = this.initSDKClient(this.logger);
     this.resetCounters();
   }
 
@@ -306,14 +306,13 @@ export default class HAPIService {
    * @param {Logger} logger
    * @returns SDK Client
    */
-  private initSDKClient(logger: Logger, register: Registry): SDKClient {
+  private initSDKClient(logger: Logger): SDKClient {
     return new SDKClient(
       this.clientMain,
       logger.child({ name: `consensus-node` }),
       this.cacheService,
       this.eventEmitter,
       this.hbarLimitService,
-      register,
     );
   }
 

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -311,7 +311,6 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       sdkClientStub.executeTransaction
         .onCall(0)
         .throws(new SDKClientError({ status: 21 }, 'timeout exceeded', transactionId));
-      sdkClientStub.isFailedTransaction.resolves(false);
       const signed = await signTransaction(transaction);
 
       const resultingHash = await ethImpl.sendRawTransaction(signed, requestDetails);
@@ -325,14 +324,11 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
 
       sdkClientStub.createFile.resolves(new FileId(0, 0, 5644));
       sdkClientStub.executeTransaction.onCall(0).throws(new SDKClientError({ status: 21 }, 'timeout exceeded'));
-      sdkClientStub.isFailedTransaction.resolves(true);
       const signed = await signTransaction(transaction);
 
       const response = (await ethImpl.sendRawTransaction(signed, requestDetails)) as JsonRpcError;
-      console.log(response);
       expect(response).to.be.instanceOf(JsonRpcError);
       expect(response.message).to.include('timeout exceeded');
-      sinon.assert.called(sdkClientStub.isFailedTransaction);
     });
 
     it('should call mirror node upon connection dropped and throw error if not found', async function () {
@@ -342,14 +338,11 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
 
       sdkClientStub.createFile.resolves(new FileId(0, 0, 5644));
       sdkClientStub.executeTransaction.onCall(0).throws(new SDKClientError({ status: 21 }, 'Connection dropped'));
-      sdkClientStub.isFailedTransaction.resolves(true);
       const signed = await signTransaction(transaction);
 
       const response = (await ethImpl.sendRawTransaction(signed, requestDetails)) as JsonRpcError;
-      console.log(response);
       expect(response).to.be.instanceOf(JsonRpcError);
       expect(response.message).to.include('Connection dropped');
-      sinon.assert.called(sdkClientStub.isFailedTransaction);
     });
   });
 });

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -243,6 +243,23 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       expect(resultingHash).to.equal(ethereumHash);
     });
 
+    it('should throw internal error if ContractResult from mirror node contains a null hash', async function () {
+      restMock.onGet(contractResultEndpoint).reply(200, { hash: null });
+
+      sdkClientStub.submitEthereumTransaction.resolves({
+        txResponse: {
+          transactionId: TransactionId.fromString(transactionIdServicesFormat),
+        } as unknown as TransactionResponse,
+        fileId: null,
+      });
+      const signed = await signTransaction(transaction);
+
+      const response = await ethImpl.sendRawTransaction(signed, requestDetails);
+
+      expect(response).to.be.instanceOf(JsonRpcError);
+      expect((response as JsonRpcError).message).to.include(`Transaction returned a null transaction hash`);
+    });
+
     it('should not send second transaction upon succession', async function () {
       restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
 

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -35,7 +35,7 @@ import {
 import { HbarLimitService } from '../../../src/lib/services/hbarLimitService';
 import { EventEmitter } from 'events';
 import pino from 'pino';
-import { MirrorNodeClient, SDKClient } from '../../../src/lib/clients';
+import { SDKClient } from '../../../src/lib/clients';
 import { ACCOUNT_ADDRESS_1, DEFAULT_NETWORK_FEES, MAX_GAS_LIMIT_HEX, NO_TRANSACTIONS } from './eth-config';
 import { Eth, JsonRpcError, predefined } from '../../../src';
 import RelayAssertions from '../../assertions';
@@ -46,14 +46,11 @@ import { RequestDetails } from '../../../src/lib/types';
 import MockAdapter from 'axios-mock-adapter';
 import HAPIService from '../../../src/lib/services/hapiService/hapiService';
 import { CacheService } from '../../../src/lib/services/cacheService/cacheService';
-import * as utils from '../../../src/formatters';
 
 use(chaiAsPromised);
 
 let sdkClientStub: sinon.SinonStubbedInstance<SDKClient>;
-let mirrorNodeStub: sinon.SinonStubbedInstance<MirrorNodeClient>;
 let getSdkClientStub: sinon.SinonStub;
-let formatTransactionIdWithoutQueryParamsStub: sinon.SinonStub;
 
 describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function () {
   this.timeout(10000);
@@ -74,7 +71,6 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
     await cacheService.clear(requestDetails);
     restMock.reset();
     sdkClientStub = sinon.createStubInstance(SDKClient);
-    mirrorNodeStub = sinon.createStubInstance(MirrorNodeClient);
     getSdkClientStub = sinon.stub(hapiServiceInstance, 'getSDKClient').returns(sdkClientStub);
     restMock.onGet('network/fees').reply(200, DEFAULT_NETWORK_FEES);
   });
@@ -168,6 +164,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       });
 
       const resultingHash = await ethImpl.sendRawTransaction(signed, requestDetails);
+
       expect(eventEmitterMock.emit.callCount).to.equal(1);
       expect(hbarLimiterMock.shouldLimit.callCount).to.equal(1);
       expect(resultingHash).to.equal(ethereumHash);
@@ -189,7 +186,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
     it('should return a computed hash if unable to retrieve EthereumHash from record due to contract revert', async function () {
       const signed = await signTransaction(transaction);
 
-      restMock.onGet(`transactions/${transactionId}`).reply(200, null);
+      restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
 
       const resultingHash = await ethImpl.sendRawTransaction(signed, requestDetails);
       expect(resultingHash).to.equal(ethereumHash);
@@ -199,11 +196,10 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       const signed = await signTransaction(transaction);
 
       restMock.onGet(contractResultEndpoint).reply(404, mockData.notFound);
-      restMock.onGet(`transactions/${transactionId}?nonce=0`).reply(200, null);
 
       sdkClientStub.submitEthereumTransaction.resolves({
         txResponse: {
-          transactionId: '',
+          transactionId: transactionIdServicesFormat,
         } as unknown as TransactionResponse,
         fileId: null,
       });
@@ -295,54 +291,41 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       );
     });
 
-    it('should call mirror node upon time out and return successful if found', async function () {
-      const transactionId = '0.0.902';
-      const contractResultEndpoint = `contracts/results/${transactionId}`;
-      formatTransactionIdWithoutQueryParamsStub = sinon.stub(utils, 'formatTransactionIdWithoutQueryParams');
-      formatTransactionIdWithoutQueryParamsStub.returns(transactionId);
+    ['timeout exceeded', 'Connection dropped'].forEach((error) => {
+      it(`should poll mirror node upon ${error} error for valid transaction and return correct transaction hash`, async function () {
+        restMock
+          .onGet(contractResultEndpoint)
+          .replyOnce(404, mockData.notFound)
+          .onGet(contractResultEndpoint)
+          .reply(200, { hash: ethereumHash });
 
-      restMock.onGet(contractResultEndpoint).reply(200, { hash: ethereumHash });
+        sdkClientStub.submitEthereumTransaction
+          .onCall(0)
+          .throws(new SDKClientError({ status: 21 }, error, transactionIdServicesFormat));
 
-      sdkClientStub.submitEthereumTransaction.restore();
-      mirrorNodeStub.repeatedRequest = sinon.stub();
-      mirrorNodeStub.getTransactionById = sinon.stub();
-      sdkClientStub.deleteFile.resolves();
-      sdkClientStub.createFile.resolves(new FileId(0, 0, 5644));
-      sdkClientStub.executeTransaction
-        .onCall(0)
-        .throws(new SDKClientError({ status: 21 }, 'timeout exceeded', transactionId));
-      const signed = await signTransaction(transaction);
+        const signed = await signTransaction(transaction);
 
-      const resultingHash = await ethImpl.sendRawTransaction(signed, requestDetails);
-      expect(resultingHash).to.equal(ethereumHash);
-    });
+        const resultingHash = await ethImpl.sendRawTransaction(signed, requestDetails);
+        expect(resultingHash).to.equal(ethereumHash);
+      });
 
-    it('should call mirror node upon time out and throw error if not found', async function () {
-      sdkClientStub.submitEthereumTransaction.restore();
-      mirrorNodeStub.repeatedRequest = sinon.stub();
-      mirrorNodeStub.getTransactionById = sinon.stub();
+      it(`should poll mirror node upon ${error} error for valid transaction and return correct ${error} error if no transaction is found`, async function () {
+        restMock
+          .onGet(contractResultEndpoint)
+          .replyOnce(404, mockData.notFound)
+          .onGet(contractResultEndpoint)
+          .reply(200, null);
 
-      sdkClientStub.createFile.resolves(new FileId(0, 0, 5644));
-      sdkClientStub.executeTransaction.onCall(0).throws(new SDKClientError({ status: 21 }, 'timeout exceeded'));
-      const signed = await signTransaction(transaction);
+        sdkClientStub.submitEthereumTransaction
+          .onCall(0)
+          .throws(new SDKClientError({ status: 21 }, error, transactionIdServicesFormat));
 
-      const response = (await ethImpl.sendRawTransaction(signed, requestDetails)) as JsonRpcError;
-      expect(response).to.be.instanceOf(JsonRpcError);
-      expect(response.message).to.include('timeout exceeded');
-    });
+        const signed = await signTransaction(transaction);
 
-    it('should call mirror node upon connection dropped and throw error if not found', async function () {
-      sdkClientStub.submitEthereumTransaction.restore();
-      mirrorNodeStub.repeatedRequest = sinon.stub();
-      mirrorNodeStub.getTransactionById = sinon.stub();
-
-      sdkClientStub.createFile.resolves(new FileId(0, 0, 5644));
-      sdkClientStub.executeTransaction.onCall(0).throws(new SDKClientError({ status: 21 }, 'Connection dropped'));
-      const signed = await signTransaction(transaction);
-
-      const response = (await ethImpl.sendRawTransaction(signed, requestDetails)) as JsonRpcError;
-      expect(response).to.be.instanceOf(JsonRpcError);
-      expect(response.message).to.include('Connection dropped');
+        const response = (await ethImpl.sendRawTransaction(signed, requestDetails)) as JsonRpcError;
+        expect(response).to.be.instanceOf(JsonRpcError);
+        expect(response.message).to.include(error);
+      });
     });
   });
 });

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -137,7 +137,6 @@ describe('SdkClient', async function () {
       new CacheService(logger.child({ name: `cache` }), registry),
       eventEmitter,
       hbarLimitService,
-      register,
     );
 
     instance = axios.create({

--- a/packages/relay/tests/lib/services/metricService/metricService.spec.ts
+++ b/packages/relay/tests/lib/services/metricService/metricService.spec.ts
@@ -163,7 +163,6 @@ describe('Metric Service', function () {
       new CacheService(logger.child({ name: `cache` }), registry),
       eventEmitter,
       hbarLimitService,
-      register,
     );
     // Init new MetricService instance
     metricService = new MetricService(logger, sdkClient, mirrorNodeClient, registry, eventEmitter, hbarLimitService);


### PR DESCRIPTION
**Description**:
- Modifies EthImpl.sendRawTransaction() to poll the MN for the transaction's validity not only for transactions that were successfully submitted to the network but also in cases of Timeout and ConnectionDropped errors.
- Removes the MN instance in SDKClient.
- Fixes unit tests in eth_sendRawTransaction.spec.ts to align with the new update.

**Related issue(s)**:

Fixes #3207

**Notes for reviewer**:
- The primary focus is on the `EthImpl.sendRawTransaction`. Please refer to the code comments for a clearer understanding of the rationale behind the changes.
- The sdkClient.ts was only modified to remove the MN instance and update a couple of log message and code comments

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
