### PR TITLE
feat: fix wrong cache key on `eth_getBlockByHash`

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2089,7 +2089,7 @@ export class EthImpl implements Eth {
       );
       return receipt;
     } else {
-      const effectiveGas = await this.getCurrentGasPriceForBlock(receiptResponse.blockHash, requestDetails);
+      const effectiveGas = await this.getCurrentGasPriceForBlock(receiptResponse.block_hash, requestDetails);
       // support stricter go-eth client which requires the transaction hash property on logs
       const logs = receiptResponse.logs.map((log) => {
         return new Log({


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

The mainnet log in this issue https://github.com/hashgraph/hedera-json-rpc-relay/issues/3228 shows incorrectness in the cache key.

Returning cached value **eth_getBlockByHash_undefined_false**:{"timestamp":"0x672b8a43","difficulty":"0x0","extraData":"0x","gasLimit":"0x1c9c380","baseFeePerGas":"0x19077fd3000","gasUsed":"0x128e00","logsBloom":"0x00000000000000102001000000000000000000000000000100000000000000100000000000000000804000000000800000000000000020000000004040220000010040000000200800000000000000000000000200000001000208000000000000000000120000000040000000200800000000002000000000200040000800000000a00000000000000800200000100000000000000000000000000000000000020080000004000000000000000000000000000000000000000000000000000000082001000000000000000000000000000200000000000000000020000020000010000000012004000000000000000000000000000080100000000000000010","miner":"0x0000000000000000000000000000000000000000","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","receiptsRoot":"0xcc412e69626441a403e43f13ec98131d07cd2447b5a14fedf73c944dabc6e166","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x954","stateRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","totalDifficulty":"0x0","transactions":["0xd6116fb5f24a499ea5f20fb610d3e2d9ae20c3a8c3c9832dc31e822bad1daf53"],"transactionsRoot":"0x057c1438ce427869a7aee23fad82c8718ba275662dfcdbf9ce3d3c4594c170b0","uncles":[],"withdrawals":[],"withdrawalsRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","number":"0x43ef5f9","hash":"0x057c1438ce427869a7aee23fad82c8718ba275662dfcdbf9ce3d3c4594c170b0","parentHash":"0x75a8fdf0df809c00a27de852177012330dc2f1946aaf5abcc1a7496f8a4d584b"} on eth_GetBlockByHash

**Related issue(s)**:

Fixes #3231

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
