### PR TITLE
fix: Added the TEST_INITIAL_ACCOUNT_STARTING_BALANCE to the GlobalCon…

### DIFF
--- a/packages/config-service/src/services/globalConfig.ts
+++ b/packages/config-service/src/services/globalConfig.ts
@@ -610,6 +610,12 @@ export class GlobalConfig {
       required: false,
       defaultValue: null,
     },
+    TEST_INITIAL_ACCOUNT_STARTING_BALANCE: {
+      envName: 'TEST_INITIAL_ACCOUNT_STARTING_BALANCE',
+      type: 'number',
+      required: false,
+      defaultValue: null,
+    },
     TEST_TRANSACTION_RECORD_COST_TOLERANCE: {
       envName: 'TEST_TRANSACTION_RECORD_COST_TOLERANCE',
       type: 'number',


### PR DESCRIPTION

**Description**:
This PR added the `TEST_INITIAL_ACCOUNT_STARTING_BALANCE` environment variable to the `GlobalConfig` class.  This is required in order for it to be used, and it is used in the `@release-light` acceptance test suite to control the amount of HBar spent.

**Related issue(s)**:

Fixes #3237 

**Notes for reviewer**:
Tests were not added because:
1. This is not a required setting to run the relay.  It's a documented test setting for running tests.
2. Existing tests cover this type of setting.  
3. This can be verified by running the `@release-light` test suite and observing the initial allocation of test HBars:
```
[2024-11-08 18:08:38.066 +0000] TRACE (relay-test-client/676 on Admins-Laptop-2.hsd1.co.comcast.net): [Request ID: [Request ID: rpc_batch1Test]] [POST] to relay 'eth_gasPrice' with params [[]] returned "0x184d3c1bc00"
[2024-11-08 18:08:42.819 +0000] DEBUG (mirror-node-test-client/676 on Admins-Laptop-2.hsd1.co.comcast.net): [Request ID: rpc_batch1Test] [GET] MirrorNode /accounts/0x33900F9590A2564BF2722FD61825c4584Fd0715B endpoint
[2024-11-08 18:08:42.936 +0000] TRACE (rpc-acceptance-test/676 on Admins-Laptop-2.hsd1.co.comcast.net): [Request ID: rpc_batch1Test] Create new Eth compatible account w alias: 0x33900F9590A2564BF2722FD61825c4584Fd0715B and balance ~5000000000 wei
```

