### PR TITLE
fix:  Strip leading zeros in signature v and s values coming from the mirror node, in tests.

### DIFF
--- a/packages/ws-server/tests/acceptance/getTransactionByHash.spec.ts
+++ b/packages/ws-server/tests/acceptance/getTransactionByHash.spec.ts
@@ -117,6 +117,7 @@ describe('@web-socket-batch-2 eth_getTransactionByHash', async function () {
       expect(txReceipt.to).to.be.eq(accounts[1].address.toLowerCase());
       expect(txReceipt.blockHash).to.be.eq(expectedTxReceipt.block_hash.slice(0, 66));
       expect(txReceipt.hash).to.be.eq(expectedTxReceipt.hash);
+      // Must convert to quantity to compare and remove leading zeros
       expect(txReceipt.r).to.be.eq(ethers.toQuantity(expectedTxReceipt.r));
       expect(txReceipt.s).to.be.eq(ethers.toQuantity(expectedTxReceipt.s));
       expect(Number(txReceipt.v)).to.be.eq(expectedTxReceipt.v);
@@ -136,6 +137,7 @@ describe('@web-socket-batch-2 eth_getTransactionByHash', async function () {
       expect(txReceipt.to).to.be.eq(accounts[1].address.toLowerCase());
       expect(txReceipt.blockHash).to.be.eq(expectedTxReceipt.block_hash.slice(0, 66));
       expect(txReceipt.hash).to.be.eq(expectedTxReceipt.hash);
+      // Must convert to quantity to compare and remove leading zeros
       expect(txReceipt.r).to.be.eq(ethers.toQuantity(expectedTxReceipt.r));
       expect(txReceipt.s).to.be.eq(ethers.toQuantity(expectedTxReceipt.s));
       expect(Number(txReceipt.v)).to.be.eq(expectedTxReceipt.v);

--- a/packages/ws-server/tests/acceptance/getTransactionByHash.spec.ts
+++ b/packages/ws-server/tests/acceptance/getTransactionByHash.spec.ts
@@ -117,8 +117,8 @@ describe('@web-socket-batch-2 eth_getTransactionByHash', async function () {
       expect(txReceipt.to).to.be.eq(accounts[1].address.toLowerCase());
       expect(txReceipt.blockHash).to.be.eq(expectedTxReceipt.block_hash.slice(0, 66));
       expect(txReceipt.hash).to.be.eq(expectedTxReceipt.hash);
-      expect(txReceipt.r).to.be.eq(expectedTxReceipt.r);
-      expect(txReceipt.s).to.be.eq(expectedTxReceipt.s);
+      expect(txReceipt.r).to.be.eq(ethers.toQuantity(expectedTxReceipt.r));
+      expect(txReceipt.s).to.be.eq(ethers.toQuantity(expectedTxReceipt.s));
       expect(Number(txReceipt.v)).to.be.eq(expectedTxReceipt.v);
     });
   });
@@ -136,8 +136,8 @@ describe('@web-socket-batch-2 eth_getTransactionByHash', async function () {
       expect(txReceipt.to).to.be.eq(accounts[1].address.toLowerCase());
       expect(txReceipt.blockHash).to.be.eq(expectedTxReceipt.block_hash.slice(0, 66));
       expect(txReceipt.hash).to.be.eq(expectedTxReceipt.hash);
-      expect(txReceipt.r).to.be.eq(expectedTxReceipt.r);
-      expect(txReceipt.s).to.be.eq(expectedTxReceipt.s);
+      expect(txReceipt.r).to.be.eq(ethers.toQuantity(expectedTxReceipt.r));
+      expect(txReceipt.s).to.be.eq(ethers.toQuantity(expectedTxReceipt.s));
       expect(Number(txReceipt.v)).to.be.eq(expectedTxReceipt.v);
     });
   });


### PR DESCRIPTION
**Description**:
Test fix. Ethereum transaction signatures v and s values need to have leading zeros stripped before being evaluated.



**Related issue(s)**:

Fixes #3239 

**Notes for reviewer**:

Leading zeros on signature r and s values are stripped in the formatters.formatContractResult in the relay before the results are returned. On the mirror node they are stored with the leading zero. e.g.
The transaction hash `0xc5a3df675c99f634d9d81a8092fc65db54d7c28dc21126439329e92598976d2d` on testnet returns a signature s value of:
`0x091027721aff181da255f7bda0cf5b834a0d5099b46dc636b1dbd50a30e33383` from the [mirror](https://testnet.mirrornode.hedera.com/api/v1/contracts/results/0xc5a3df675c99f634d9d81a8092fc65db54d7c28dc21126439329e92598976d2d) node.
The eth_getTransactionReceipt response from the relay returns a signature s value of `0x91027721aff181da255f7bda0cf5b834a0d5099b46dc636b1dbd50a30e33383`

```
curl --location 'https://testnet.hashio.io/api' \
--header 'Content-Type: application/json' \
--header 'Request-Id: testRequest' \
--data '{
  "id": 1,
  "jsonrpc": "2.0",
  "params": [
    "0xc5a3df675c99f634d9d81a8092fc65db54d7c28dc21126439329e92598976d2d"
  ],
  "method": "eth_getTransactionByHash"
}'
```

The leading zeros in the v and s signature values will cause json: cannot unmarshal hex number with leading zero digits into Go struct field txJSON.s of type *hexutil.Big in the go-ethereum client.

Some tests verify the signature v and s values using the response from the mirror node, but these values need to strip the leading zeros before being evaluated.


