### PR TITLE
fix: A series of small changes to stabilize tests

### DIFF
--- a/packages/server/tests/helpers/utils.ts
+++ b/packages/server/tests/helpers/utils.ts
@@ -256,13 +256,17 @@ export class Utils {
     requestId: any,
     mirrorNodeServer: any,
   ) => {
+    const gasPriceDeviation = parseFloat(ConfigService.get('TEST_GAS_PRICE_DEVIATION') ?? '0.2');
+    const gasPrice = await rpcServer.gasPrice(requestId);
+    const gasPriceWithDeviation = gasPrice * (1 + gasPriceDeviation);
+
     const transaction = {
       value: ONE_TINYBAR,
       gasLimit: numberTo0x(30000),
       chainId: Number(CHAIN_ID),
       to: accounts[1].address,
       nonce: await rpcServer.getAccountNonce(accounts[0].address, requestId),
-      maxFeePerGas: await rpcServer.gasPrice(requestId),
+      maxFeePerGas: gasPriceWithDeviation,
     };
 
     const signedTx = await accounts[0].wallet.signTransaction(transaction);

--- a/packages/ws-server/tests/acceptance/call.spec.ts
+++ b/packages/ws-server/tests/acceptance/call.spec.ts
@@ -100,7 +100,7 @@ describe('@web-socket-batch-1 eth_call', async function () {
   });
 
   afterEach(async () => {
-    if (ethersWsProvider) await ethersWsProvider.destroy();
+    ethersWsProvider = await WsTestHelper.closeWebsocketConnections(ethersWsProvider);
   });
 
   after(async () => {

--- a/packages/ws-server/tests/acceptance/getBlockByNumber.spec.ts
+++ b/packages/ws-server/tests/acceptance/getBlockByNumber.spec.ts
@@ -44,7 +44,7 @@ describe('@web-socket-batch-1 eth_getBlockByNumber', async function () {
   });
 
   afterEach(async () => {
-    if (ethersWsProvider) await ethersWsProvider.destroy();
+    ethersWsProvider = await WsTestHelper.closeWebsocketConnections(ethersWsProvider);
   });
 
   after(async () => {
@@ -63,8 +63,10 @@ describe('@web-socket-batch-1 eth_getBlockByNumber', async function () {
 
     it(`@release Should execute eth_getBlockByNumber on Standard Web Socket and handle valid requests correctly`, async () => {
       const expectedResult = await global.relay.call(METHOD_NAME, ['latest', false]);
-      const response = await WsTestHelper.sendRequestToStandardWebSocket(METHOD_NAME, [expectedResult.number, true]);
-      await Utils.wait(1000);
+      const response = await WsTestHelper.sendRequestToStandardWebSocketWithResolve(METHOD_NAME, [
+        expectedResult.number,
+        true,
+      ]);
       WsTestHelper.assertJsonRpcObject(response);
       expect(response.result).to.deep.eq(expectedResult);
     });

--- a/packages/ws-server/tests/acceptance/getTransactionReceipt.spec.ts
+++ b/packages/ws-server/tests/acceptance/getTransactionReceipt.spec.ts
@@ -92,7 +92,7 @@ describe('@web-socket-batch-2 eth_getTransactionReceipt', async function () {
   });
 
   afterEach(async () => {
-    if (ethersWsProvider) await ethersWsProvider.destroy();
+    ethersWsProvider = await WsTestHelper.closeWebsocketConnections(ethersWsProvider);
   });
 
   after(async () => {

--- a/packages/ws-server/tests/acceptance/newFilter.spec.ts
+++ b/packages/ws-server/tests/acceptance/newFilter.spec.ts
@@ -83,7 +83,7 @@ describe('@web-socket-batch-2 eth_newFilter', async function () {
     }
 
     it(`@release Should execute eth_newFilter on Standard Web Socket and handle valid requests correctly`, async () => {
-      const response = await WsTestHelper.sendRequestToStandardWebSocket(METHOD_NAME, [wsFilterObj]);
+      const response = await WsTestHelper.sendRequestToStandardWebSocketWithResolve(METHOD_NAME, [wsFilterObj]);
       WsTestHelper.assertJsonRpcObject(response);
       const filterId = response.result;
 

--- a/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
+++ b/packages/ws-server/tests/acceptance/subscribeNewHeads.spec.ts
@@ -136,10 +136,7 @@ describe('@web-socket-batch-3 eth_subscribe newHeads', async function () {
   });
 
   afterEach(async () => {
-    if (wsProvider) {
-      await wsProvider.destroy();
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    wsProvider = await WsTestHelper.closeWebsocketConnections(wsProvider);
   });
 
   describe('Configuration', async function () {

--- a/packages/ws-server/tests/acceptance/validations.spec.ts
+++ b/packages/ws-server/tests/acceptance/validations.spec.ts
@@ -51,14 +51,14 @@ describe('@release @web-socket-batch-1 JSON-RPC requests validation', async func
 
   WsTestHelper.overrideEnvsInMochaDescribe({ REQUEST_ID_IS_OPTIONAL: true });
 
-  let ethersWsProvider: WebSocketProvider;
+  let ethersWsProvider: WebSocketProvider | null;
 
   beforeEach(async () => {
     ethersWsProvider = new ethers.WebSocketProvider(WsTestConstant.WS_RELAY_URL);
   });
 
   afterEach(async () => {
-    if (ethersWsProvider) await ethersWsProvider.destroy();
+    ethersWsProvider = await WsTestHelper.closeWebsocketConnections(ethersWsProvider);
   });
 
   after(async () => {


### PR DESCRIPTION

**Description**:
This PR adds the checking of connection as part of a connection handling process for the `afterEach` hook in the tests.  It also removes a `Utils.wait` by resolving a promise before continuing, and adds some gas deviation.

**Related issue(s)**:

Fixes #3204 
