### PR TITLE
chore: Upgrade node version to 20.

### DIFF
--- a/.github/workflows/conformity-workflow.yml
+++ b/.github/workflows/conformity-workflow.yml
@@ -27,10 +27,10 @@ jobs:
           repository: 'ethereum/execution-apis'
           path: 'execution-apis'
 
-      - name: Use Node.js TLS 18
+      - name: Use Node.js TLS 20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install dependencies
         run: npm install
@@ -59,10 +59,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - name: Use Node.js TLS 18
+      - name: Use Node.js TLS 20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 18
+          node-version: 20
       
       - name: Install make
         run: sudo apt-get update; sudo apt-get install build-essential -y

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -34,8 +34,6 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20
-          #cache: "npm" Disabling this as it causes the workflow to hang, trying to retrieve the cache. Not removing it, because it could be retuned in the future.
-          #cache-dependency-path: "**/package-lock.json"
 
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y make gcc g++

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y make gcc g++
 
-      - name: Use Node.js TLS 18
+      - name: Use Node.js TLS 20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20


### PR DESCRIPTION
**Description**:
This PR upgrades any leftover references from node version 18, to node version 20.  It updates github workflows and cleans up some leftover commented out code.  

**Related issue(s)**:

Fixes #3156 

**Notes for reviewer**:
Node version 20 was already referenced in the README.md and in most of the workflows.  The conformity tests had some remaining version 18 references that were updated.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
