### PR TITLE
fix: Allow the HBar Rate Limiter to be disabled.

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -129,6 +129,7 @@ jobs:
       - ratelimiter
       - hbarlimiter_batch_1
       - hbarlimiter_batch_2
+      - hbarlimiter_batch_3
       - tokencreate
       - tokenmanagement
       - htsprecompilev1

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -55,6 +55,12 @@ jobs:
     with:
       testfilter: hbarlimiter_batch2
 
+  hbarlimiter_batch_3:
+    name: HBar Limiter Batch 3
+    uses: ./.github/workflows/acceptance-workflow.yml
+    with:
+      testfilter: hbarlimiter_batch3
+
   tokencreate:
     name: Token Create
     uses: ./.github/workflows/acceptance-workflow.yml

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "acceptancetest:ratelimiter": "nyc ts-mocha packages/ws-server/tests/acceptance/index.spec.ts -g '@web-socket-ratelimiter' --exit && ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@ratelimiter' --exit",
     "acceptancetest:hbarlimiter_batch1": "HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch1' --exit",
     "acceptancetest:hbarlimiter_batch2": "HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch2' --exit",
+    "acceptancetest:hbarlimiter_batch3": "HBAR_RATE_LIMIT_TINYBAR=0 HBAR_RATE_LIMIT_BASIC=1000000000 HBAR_RATE_LIMIT_EXTENDED=1500000000 HBAR_RATE_LIMIT_PRIVILEGED=2000000000 nyc ts-mocha packages/server/tests/acceptance/index.spec.ts -g '@hbarlimiter-batch3' --exit",
     "acceptancetest:tokencreate": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@tokencreate' --exit",
     "acceptancetest:tokenmanagement": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@tokenmanagement' --exit",
     "acceptancetest:htsprecompilev1": "nyc ts-mocha packages/server/tests/acceptance/index.spec.ts  -g '@htsprecompilev1' --exit",

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -145,7 +145,7 @@ export default {
   // @ts-ignore
   HBAR_RATE_LIMIT_DURATION: parseInt(ConfigService.get('HBAR_RATE_LIMIT_DURATION') || '86400000'), // 1 day
   // @ts-ignore
-  HBAR_RATE_LIMIT_TOTAL: BigNumber(ConfigService.get('HBAR_RATE_LIMIT_TINYBAR') || '800000000000'), // 8000 HBARs
+  HBAR_RATE_LIMIT_TOTAL: BigNumber(ConfigService.get('HBAR_RATE_LIMIT_TINYBAR') ?? '800000000000'), // 8000 HBARs
   // @ts-ignore
   HBAR_RATE_LIMIT_BASIC: BigNumber(ConfigService.get('HBAR_RATE_LIMIT_BASIC') || '1120000000'), // 11.2 HBARs
   // @ts-ignore

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -145,6 +145,8 @@ export default {
   // @ts-ignore
   HBAR_RATE_LIMIT_DURATION: parseInt(ConfigService.get('HBAR_RATE_LIMIT_DURATION') || '86400000'), // 1 day
   // @ts-ignore
+  // The logical OR operator || returns the first truthy value and 0 is falsy.
+  // The nullish coalescing operator ?? falls back to the default value when the left-hand operand is null or undefined, not when it's 0 or any other falsy value.
   HBAR_RATE_LIMIT_TOTAL: BigNumber(ConfigService.get('HBAR_RATE_LIMIT_TINYBAR') ?? '800000000000'), // 8000 HBARs
   // @ts-ignore
   HBAR_RATE_LIMIT_BASIC: BigNumber(ConfigService.get('HBAR_RATE_LIMIT_BASIC') || '1120000000'), // 11.2 HBARs

--- a/packages/relay/src/lib/services/hbarLimitService/IHbarLimitService.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/IHbarLimitService.ts
@@ -31,4 +31,5 @@ export interface IHbarLimitService {
     estimatedTxFee?: number,
   ): Promise<boolean>;
   addExpense(cost: number, ethAddress: string, requestDetails: RequestDetails, ipAddress?: string): Promise<void>;
+  isEnabled(): boolean;
 }

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -96,7 +96,7 @@ export class HbarLimitService implements IHbarLimitService {
     this.reset = this.getResetTimestamp();
     this.remainingBudget = this.totalBudget;
 
-    if (this.remainingBudget.toTinybars().isZero()) {
+    if (this.remainingBudget.toTinybars().lte(0)) {
       this.disableRateLimiter = true;
     }
 
@@ -153,6 +153,13 @@ export class HbarLimitService implements IHbarLimitService {
   }
 
   /**
+   * Checks if the rate limiter is enabled.
+   */
+  isEnabled(): boolean {
+    return !this.disableRateLimiter;
+  }
+
+  /**
    * Resets the {@link HbarSpendingPlan#amountSpent} field for all existing plans.
    * @param {RequestDetails} requestDetails - The request details used for logging and tracking.
    * @returns {Promise<void>} - A promise that resolves when the operation is complete.
@@ -191,7 +198,7 @@ export class HbarLimitService implements IHbarLimitService {
     requestDetails: RequestDetails,
     estimatedTxFee: number = 0,
   ): Promise<boolean> {
-    if (this.disableRateLimiter) {
+    if (!this.isEnabled()) {
       return false;
     }
 

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -257,6 +257,10 @@ export class HbarLimitService implements IHbarLimitService {
    * @returns {Promise<void>} - A promise that resolves when the expense has been added.
    */
   async addExpense(cost: number, ethAddress: string, requestDetails: RequestDetails): Promise<void> {
+    if (!this.isEnabled()) {
+      return;
+    }
+
     const newRemainingBudget = this.remainingBudget.toTinybars().sub(cost);
     this.remainingBudget = Hbar.fromTinybars(newRemainingBudget);
     this.hbarLimitRemainingGauge.set(newRemainingBudget.toNumber());

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -96,7 +96,7 @@ export class HbarLimitService implements IHbarLimitService {
     this.reset = this.getResetTimestamp();
     this.remainingBudget = this.totalBudget;
 
-    if (this.remainingBudget.toTinybars().lte(0)) {
+    if (this.totalBudget.toTinybars().lte(0)) {
       this.disableRateLimiter = true;
     }
 

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -38,7 +38,7 @@ export class HbarLimitService implements IHbarLimitService {
   };
 
   /**
-   * Disables the rate limiter.
+   * Flag to turn off the HBarRateLimitService.
    * @private
    */
   private readonly disableRateLimiter: boolean = false;

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -41,7 +41,7 @@ export class HbarLimitService implements IHbarLimitService {
    * Flag to turn off the HBarRateLimitService.
    * @private
    */
-  private readonly disableRateLimiter: boolean = false;
+  private readonly isHBarRateLimiterEnabled: boolean = true;
 
   /**
    * Counts the number of times the rate limit has been reached.
@@ -97,7 +97,7 @@ export class HbarLimitService implements IHbarLimitService {
     this.remainingBudget = this.totalBudget;
 
     if (this.totalBudget.toTinybars().lte(0)) {
-      this.disableRateLimiter = true;
+      this.isHBarRateLimiterEnabled = false;
     }
 
     const metricCounterName = 'rpc_relay_hbar_rate_limit';
@@ -157,7 +157,7 @@ export class HbarLimitService implements IHbarLimitService {
    * returns {boolean} - `true` if the rate limiter is enabled, otherwise `false`.
    */
   isEnabled(): boolean {
-    return !this.disableRateLimiter;
+    return this.isHBarRateLimiterEnabled;
   }
 
   /**

--- a/packages/relay/src/lib/services/hbarLimitService/index.ts
+++ b/packages/relay/src/lib/services/hbarLimitService/index.ts
@@ -154,6 +154,7 @@ export class HbarLimitService implements IHbarLimitService {
 
   /**
    * Checks if the rate limiter is enabled.
+   * returns {boolean} - `true` if the rate limiter is enabled, otherwise `false`.
    */
   isEnabled(): boolean {
     return !this.disableRateLimiter;

--- a/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
+++ b/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
@@ -494,6 +494,29 @@ describe('HBAR Rate Limit Service', function () {
         expect(result).to.be.false;
       });
     });
+
+    describe('It should be able to disable the rate limiter', function () {
+      const hbarLimitServiceDisabled = new HbarLimitService(
+        hbarSpendingPlanRepositoryStub,
+        ethAddressHbarSpendingPlanRepositoryStub,
+        ipAddressHbarSpendingPlanRepositoryStub,
+        logger,
+        register,
+        Hbar.fromTinybars(0),
+        limitDuration,
+      );
+      it('should return false if the rate limiter is disabled by setting HBAR_RATE_LIMIT_TINYBAR to zero', async function () {
+        // hbarLimitServiceDisabled.disableRateLimiter();
+        const result = await hbarLimitServiceDisabled.shouldLimit(
+          mode,
+          methodName,
+          txConstructorName,
+          '',
+          requestDetails,
+        );
+        expect(result).to.be.false;
+      });
+    });
   });
 
   describe('getSpendingPlan', function () {

--- a/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
+++ b/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
@@ -495,7 +495,7 @@ describe('HBAR Rate Limit Service', function () {
       });
     });
 
-    describe('It should be able to disable the rate limiter', function () {
+    describe('disable the rate limiter', function () {
       const hbarLimitServiceDisabled = new HbarLimitService(
         hbarSpendingPlanRepositoryStub,
         ethAddressHbarSpendingPlanRepositoryStub,
@@ -505,6 +505,7 @@ describe('HBAR Rate Limit Service', function () {
         Hbar.fromTinybars(0),
         limitDuration,
       );
+
       it('should return false if the rate limiter is disabled by setting HBAR_RATE_LIMIT_TINYBAR to zero', async function () {
         const spendingPlan = createSpendingPlan(
           mockPlanId,
@@ -527,6 +528,10 @@ describe('HBAR Rate Limit Service', function () {
 
         // Rate limiter is disabled, so it should return false
         expect(result).to.be.false;
+      });
+
+      it('should return undefined if the rate limiter is disabled and addExpense is called', async function () {
+        expect(await hbarLimitServiceDisabled.addExpense(100, mockEthAddress, requestDetails)).to.be.undefined;
       });
     });
   });

--- a/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
+++ b/packages/relay/tests/lib/services/hbarLimitService/hbarLimitService.spec.ts
@@ -506,14 +506,26 @@ describe('HBAR Rate Limit Service', function () {
         limitDuration,
       );
       it('should return false if the rate limiter is disabled by setting HBAR_RATE_LIMIT_TINYBAR to zero', async function () {
-        // hbarLimitServiceDisabled.disableRateLimiter();
+        const spendingPlan = createSpendingPlan(
+          mockPlanId,
+          HbarLimitService.TIER_LIMITS[SubscriptionTier.BASIC].toTinybars().sub(mockEstimatedTxFee).add(1),
+        );
+        ethAddressHbarSpendingPlanRepositoryStub.findByAddress.resolves({
+          ethAddress: mockEthAddress,
+          planId: mockPlanId,
+        });
+        hbarSpendingPlanRepositoryStub.findByIdWithDetails.resolves(spendingPlan);
+
         const result = await hbarLimitServiceDisabled.shouldLimit(
           mode,
           methodName,
           txConstructorName,
-          '',
+          mockEthAddress,
           requestDetails,
+          mockEstimatedTxFee,
         );
+
+        // Rate limiter is disabled, so it should return false
         expect(result).to.be.false;
       });
     });

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -900,6 +900,9 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
       it('should eventually exhaust the hbar limit for a BASIC user after multiple deployments of large contracts, and not throw an error', async function () {
         // confirm that HBAR_RATE_LIMIT_TINYBAR is set to zero
         expect(ConfigService.get('HBAR_RATE_LIMIT_TINYBAR')).to.eq(0);
+        // This should set the remaining HBAR limit to zero
+        const remainingHbarsBefore = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
+        expect(remainingHbarsBefore).to.eq(0);
         let deploymentCounts = 0;
 
         const operatorBalanceBefore = (await mirrorNode.get(`/accounts/${operatorAccount}`, requestId)).balance.balance;
@@ -913,9 +916,9 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
         const amountSpent = operatorBalanceBefore - operatorBalanceAfter;
         expect(amountSpent).to.be.gt(maxBasicSpendingLimit);
 
-        // Verify that remaining HBAR limit is zero or negative
+        // Verify that remaining HBAR limit is zero
         const remainingHbarsAfter = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
-        expect(remainingHbarsAfter).to.be.lte(0);
+        expect(remainingHbarsAfter).to.be.eq(0);
 
         // Confirm that deployments continued even after the limit was exhausted
         expect(deploymentCounts).to.be.gte(1);

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -889,10 +889,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
     });
 
     describe('@hbarlimiter-batch3 Unlimited', () => {
-      const accounts: AliasAccount[] = [];
-
-      beforeEach(async function () {
-        logger.info(`${requestDetails.formattedRequestId} Creating accounts`);
+      before(async function () {
         logger.info(
           `${requestDetails.formattedRequestId} HBAR_RATE_LIMIT_TINYBAR: ${ConfigService.get(
             'HBAR_RATE_LIMIT_TINYBAR',

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -898,24 +898,6 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
             'HBAR_RATE_LIMIT_TINYBAR',
           )}`,
         );
-
-        const initialAccount: AliasAccount = global.accounts[0];
-
-        const neededAccounts: number = 1;
-        accounts.push(
-          ...(await Utils.createMultipleAliasAccounts(
-            mirrorNode,
-            initialAccount,
-            neededAccounts,
-            initialBalance,
-            requestDetails,
-          )),
-        );
-        global.accounts.push(...accounts);
-        const basicPlans = await hbarSpendingPlanRepository.findAllActiveBySubscriptionTier(
-          [SubscriptionTier.BASIC],
-          requestDetails,
-        );
       });
 
       it('should eventually exhaust the hbar limit for a BASIC user after multiple deployments of large contracts, and not throw an error', async function () {
@@ -926,14 +908,14 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
         let hbarSpendingPlan: IDetailedHbarSpendingPlan | null = null;
 
         for (deploymentCounts = 0; deploymentCounts < 3; deploymentCounts++) {
-          const tx = await deployContract(largeContractJson, accounts[0].wallet);
+          const tx = await deployContract(largeContractJson, global.accounts[0].wallet);
           await tx.waitForDeployment();
 
           expectedTxCost ||= await getExpectedCostOfLastLargeTx(largeContractJson.bytecode);
 
           if (!hbarSpendingPlan) {
             const ethSpendingPlan = await ethAddressSpendingPlanRepository.findByAddress(
-              accounts[0].wallet.address,
+              global.accounts[0].wallet.address,
               requestDetails,
             );
             hbarSpendingPlan = await hbarSpendingPlanRepository.findByIdWithDetails(
@@ -946,7 +928,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
         }
         if (!hbarSpendingPlan) {
           const ethSpendingPlan = await ethAddressSpendingPlanRepository.findByAddress(
-            accounts[0].wallet.address,
+            global.accounts[0].wallet.address,
             requestDetails,
           );
           hbarSpendingPlan = await hbarSpendingPlanRepository.findByIdWithDetails(
@@ -964,7 +946,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
 
         // Confirm that deployments continued even after the limit was exhausted
         expect(deploymentCounts).to.be.gte(1);
-        await expect(deployContract(largeContractJson, accounts[0].wallet)).to.be.fulfilled;
+        await expect(deployContract(largeContractJson, global.accounts[0].wallet)).to.be.fulfilled;
       });
     });
   }


### PR DESCRIPTION
This fix allows the HBar Rate Limiter to be disabled by setting the `HBAR_RATE_LIMIT_TINYBAR` to `0`

**Related issue(s)**:

Fixes #3251 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
