### PR TITLE
fix: `eth_getBlockByHash` is using invalid cache record

### DIFF
--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -40,7 +40,7 @@ const logger = pino();
 const noTransactions = '?transactions=false';
 const requestDetails = new RequestDetails({ requestId: getRequestId(), ipAddress: '0.0.0.0' });
 
-describe('MirrorNodeClient', async function () {
+describe.only('MirrorNodeClient', async function () {
   this.timeout(20000);
 
   const registry = new Registry();
@@ -623,6 +623,37 @@ describe('MirrorNodeClient', async function () {
     expect(result.v).equal(detailedContractResult.v);
     expect(result.block_number).equal(detailedContractResult.block_number);
     expect(mock.history.get.length).to.eq(2); // is called twice
+  });
+
+  it('`getContractResultsWithRetry` by hash retries once because of block_hash equals 0x', async () => {
+    const hash = '0x2a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb3391';
+    mock.onGet(`contracts/results/${hash}`).replyOnce(200, { ...detailedContractResult, block_hash: '0x' });
+    mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
+
+    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    expect(result).to.exist;
+    expect(result.block_hash).equal(detailedContractResult.block_hash);
+    expect(mock.history.get.length).to.eq(2);
+  });
+
+  it('`getContractResultsWithRetry` by hash retries once because of missing transaction_index, block_number and block_hash equals 0x', async () => {
+    const hash = '0x2a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6393';
+    mock
+      .onGet(`contracts/results/${hash}`)
+      .replyOnce(200, {
+        ...detailedContractResult,
+        transaction_index: undefined,
+        block_number: undefined,
+        block_hash: '0x',
+      });
+    mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
+
+    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    expect(result).to.exist;
+    expect(result.transaction_index).equal(detailedContractResult.transaction_index);
+    expect(result.block_number).equal(detailedContractResult.block_number);
+    expect(result.block_hash).equal(detailedContractResult.block_hash);
+    expect(mock.history.get.length).to.eq(2);
   });
 
   it('`getContractResults` detailed', async () => {

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -40,7 +40,7 @@ const logger = pino();
 const noTransactions = '?transactions=false';
 const requestDetails = new RequestDetails({ requestId: getRequestId(), ipAddress: '0.0.0.0' });
 
-describe.only('MirrorNodeClient', async function () {
+describe('MirrorNodeClient', async function () {
   this.timeout(20000);
 
   const registry = new Registry();
@@ -638,14 +638,12 @@ describe.only('MirrorNodeClient', async function () {
 
   it('`getContractResultsWithRetry` by hash retries once because of missing transaction_index, block_number and block_hash equals 0x', async () => {
     const hash = '0x2a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6393';
-    mock
-      .onGet(`contracts/results/${hash}`)
-      .replyOnce(200, {
-        ...detailedContractResult,
-        transaction_index: undefined,
-        block_number: undefined,
-        block_hash: '0x',
-      });
+    mock.onGet(`contracts/results/${hash}`).replyOnce(200, {
+      ...detailedContractResult,
+      transaction_index: undefined,
+      block_number: undefined,
+      block_hash: '0x',
+    });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
     const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);


### PR DESCRIPTION
**Description**:

We are getting alerts on intermittent `eth_getTransactionReceipt` calls with a 500 response.  Tracing through the logs we can see that the `getBlockByHash` call is missing a valid hash, right after the call to the mirror node on the `contracts/results` endpoint.  

**Steps to reproduce**:

1. Look through the logs for an `eth_getTransactionReceipt` call with a 500 response.
2. Note the request ID and trace through the logs the path of the request.
3. Notice the call to `getBlockByHash` is missing a valid hash.

```
[34mDEBUG[39m (rpc-server/84 on mainnet-hashio-85fd789b7-twzsv): [36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] Validating method parameters for eth_getTransactionReceipt, params: ["0x411f2d52652ad237296f85041e382194d3fd5a7fb006e269975dede4652b70fc"][39m"
timestamp: "2024-11-11T15:30:19.138608570Z"

[36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] getTransactionReceipt(0x411f2d52652ad237296f85041e382194d3fd5a7fb006e269975dede4652b70fc)

[36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] [GET] contracts/results/0x411f2d52652ad237296f85041e382194d3fd5a7fb006e269975dede4652b70fc 200 4 ms

[36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] [GET] contracts/results/0x411f2d52652ad237296f85041e382194d3fd5a7fb006e269975dede4652b70fc 200 2 ms

[36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] getBlockByHash(hash=0x, showDetails=false)

[36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] [GET] blocks/NaN 400 status

[36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] Failed to retrieve block for hash 0x

[36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] Error invoking RPC: Invalid parameter: hashOrNumber

[36m[Request ID: 51841ec6-3dc9-4dad-af6a-07c4c3f01e02] [POST]: eth_getTransactionReceipt 500 20 ms
```

**Related issue(s)**:

Fixes #3250

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
