### PR TITLE
fix: updated precheck.nonce() to handle higher nonce cases

### DIFF
--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -18,13 +18,14 @@
  *
  */
 
-import { JsonRpcError, predefined } from './errors/JsonRpcError';
-import { MirrorNodeClient } from './clients';
-import { EthImpl } from './eth';
-import { Logger } from 'pino';
-import constants from './constants';
 import { ethers, Transaction } from 'ethers';
+import { Logger } from 'pino';
+
 import { prepend0x } from '../formatters';
+import { MirrorNodeClient } from './clients';
+import constants from './constants';
+import { JsonRpcError, predefined } from './errors/JsonRpcError';
+import { EthImpl } from './eth';
 import { RequestDetails } from './types';
 
 /**
@@ -124,8 +125,10 @@ export class Precheck {
       );
     }
 
-    if (accountInfoNonce > tx.nonce) {
-      throw predefined.NONCE_TOO_LOW(tx.nonce, accountInfoNonce);
+    if (tx.nonce !== accountInfoNonce) {
+      throw tx.nonce < accountInfoNonce
+        ? predefined.NONCE_TOO_LOW(tx.nonce, accountInfoNonce)
+        : predefined.NONCE_TOO_HIGH(tx.nonce, accountInfoNonce);
     }
   }
 

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -19,9 +19,6 @@
  */
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
-import { expect, use } from 'chai';
-import sinon from 'sinon';
-import chaiAsPromised from 'chai-as-promised';
 import {
   FileAppendTransaction,
   FileId,
@@ -32,21 +29,25 @@ import {
   TransactionId,
   TransactionResponse,
 } from '@hashgraph/sdk';
-import { HbarLimitService } from '../../../src/lib/services/hbarLimitService';
+import MockAdapter from 'axios-mock-adapter';
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import { EventEmitter } from 'events';
 import pino from 'pino';
-import { SDKClient } from '../../../src/lib/clients';
-import { ACCOUNT_ADDRESS_1, DEFAULT_NETWORK_FEES, MAX_GAS_LIMIT_HEX, NO_TRANSACTIONS } from './eth-config';
+import { Counter } from 'prom-client';
+import sinon from 'sinon';
+
 import { Eth, JsonRpcError, predefined } from '../../../src';
+import { SDKClient } from '../../../src/lib/clients';
+import { SDKClientError } from '../../../src/lib/errors/SDKClientError';
+import { CacheService } from '../../../src/lib/services/cacheService/cacheService';
+import HAPIService from '../../../src/lib/services/hapiService/hapiService';
+import { HbarLimitService } from '../../../src/lib/services/hbarLimitService';
+import { RequestDetails } from '../../../src/lib/types';
 import RelayAssertions from '../../assertions';
 import { getRequestId, mockData, overrideEnvsInMochaDescribe, signTransaction } from '../../helpers';
+import { ACCOUNT_ADDRESS_1, DEFAULT_NETWORK_FEES, MAX_GAS_LIMIT_HEX, NO_TRANSACTIONS } from './eth-config';
 import { generateEthTestEnv } from './eth-helpers';
-import { SDKClientError } from '../../../src/lib/errors/SDKClientError';
-import { RequestDetails } from '../../../src/lib/types';
-import MockAdapter from 'axios-mock-adapter';
-import HAPIService from '../../../src/lib/services/hapiService/hapiService';
-import { CacheService } from '../../../src/lib/services/cacheService/cacheService';
-import { Counter } from 'prom-client';
 
 use(chaiAsPromised);
 
@@ -115,6 +116,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       balance: {
         balance: Hbar.from(100_000_000_000, HbarUnit.Hbar).to(HbarUnit.Tinybar),
       },
+      ethereum_nonce: 0,
     };
 
     beforeEach(() => {

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -19,33 +19,34 @@
  */
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
-import Ajv from 'ajv';
-import pino from 'pino';
-import Long from 'long';
-import axios from 'axios';
-import sinon from 'sinon';
-import { expect } from 'chai';
-import EventEmitter from 'events';
 import { AccountInfo, Hbar } from '@hashgraph/sdk';
+import { parseOpenRPCDocument, validateOpenRPCDocument } from '@open-rpc/schema-utils-js';
+import Ajv from 'ajv';
+import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { BigNumber } from 'bignumber.js';
-import { EthImpl } from '../../src/lib/eth';
-import constants from '../../src/lib/constants';
-import { RelayImpl } from '../../src/lib/relay';
+import { expect } from 'chai';
+import { ethers } from 'ethers';
+import EventEmitter from 'events';
+import Long from 'long';
+import pino from 'pino';
 import { register, Registry } from 'prom-client';
-import { NOT_FOUND_RES } from './eth/eth-config';
+import sinon from 'sinon';
+
+import openRpcSchema from '../../../../docs/openrpc.json';
 import { numberTo0x } from '../../src/formatters';
 import { SDKClient } from '../../src/lib/clients';
-import { RequestDetails } from '../../src/lib/types';
-import openRpcSchema from '../../../../docs/openrpc.json';
 import { MirrorNodeClient } from '../../src/lib/clients/mirrorNodeClient';
-import { HbarLimitService } from '../../src/lib/services/hbarLimitService';
-import ClientService from '../../src/lib/services/hapiService/hapiService';
-import { CacheService } from '../../src/lib/services/cacheService/cacheService';
-import { parseOpenRPCDocument, validateOpenRPCDocument } from '@open-rpc/schema-utils-js';
+import constants from '../../src/lib/constants';
+import { EthAddressHbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository';
 import { HbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository';
 import { IPAddressHbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository';
-import { EthAddressHbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/ethAddressHbarSpendingPlanRepository';
+import { EthImpl } from '../../src/lib/eth';
+import { RelayImpl } from '../../src/lib/relay';
+import { CacheService } from '../../src/lib/services/cacheService/cacheService';
+import ClientService from '../../src/lib/services/hapiService/hapiService';
+import { HbarLimitService } from '../../src/lib/services/hbarLimitService';
+import { RequestDetails } from '../../src/lib/types';
 import {
   blockHash,
   blockNumber,
@@ -75,6 +76,7 @@ import {
   overrideEnvsInMochaDescribe,
   signedTransactionHash,
 } from '../helpers';
+import { NOT_FOUND_RES } from './eth/eth-config';
 
 const logger = pino();
 const registry = new Registry();
@@ -199,6 +201,7 @@ describe('Open RPC Specification', function () {
       balance: {
         balance: 100000000000,
       },
+      ethereum_nonce: ethers.Transaction.from(signedTransactionHash).nonce,
     });
     mock
       .onGet(`accounts/0xbC989b7b17d18702663F44A6004cB538b9DfcBAc?limit=100`)


### PR DESCRIPTION
**Description**:
This PR updates precheck.nonce() to reject requests that have nonces higher than current nonce of the signer

**Related issue(s)**:

Fixes #3271 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
