### PR TITLE
feat: expose node account id in relay logging of failed transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20678,7 +20678,7 @@
       "dependencies": {
         "@ethersproject/asm": "^5.7.0",
         "@hashgraph/json-rpc-config-service": "file:../config-service",
-        "@hashgraph/sdk": "^2.53.0",
+        "@hashgraph/sdk": "^2.54.0-beta.1",
         "@keyvhq/core": "^1.6.9",
         "axios": "^1.4.0",
         "axios-retry": "^3.5.1",
@@ -20746,9 +20746,9 @@
       }
     },
     "packages/relay/node_modules/@hashgraph/sdk": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
-      "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+      "version": "2.54.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.54.0-beta.1.tgz",
+      "integrity": "sha512-rXbwp24fr04LJcOtISabwtKtb0qiRHGa3ltY1KALJ0fEYlUogSEf8DmCeOzNWiZEyy9boCequlRajAkJ+1OF3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
@@ -21047,7 +21047,7 @@
         "uuid": "^3.3.2"
       },
       "devDependencies": {
-        "@hashgraph/sdk": "^2.53.0",
+        "@hashgraph/sdk": "^2.54.0-beta.1",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -21110,9 +21110,9 @@
       }
     },
     "packages/server/node_modules/@hashgraph/sdk": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
-      "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+      "version": "2.54.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.54.0-beta.1.tgz",
+      "integrity": "sha512-rXbwp24fr04LJcOtISabwtKtb0qiRHGa3ltY1KALJ0fEYlUogSEf8DmCeOzNWiZEyy9boCequlRajAkJ+1OF3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -21647,7 +21647,7 @@
         "pino-pretty": "^7.6.1"
       },
       "devDependencies": {
-        "@hashgraph/sdk": "^2.53.0",
+        "@hashgraph/sdk": "^2.54.0-beta.1",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -21707,9 +21707,9 @@
       }
     },
     "packages/ws-server/node_modules/@hashgraph/sdk": {
-      "version": "2.53.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
-      "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+      "version": "2.54.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.54.0-beta.1.tgz",
+      "integrity": "sha512-rXbwp24fr04LJcOtISabwtKtb0qiRHGa3ltY1KALJ0fEYlUogSEf8DmCeOzNWiZEyy9boCequlRajAkJ+1OF3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -24076,7 +24076,7 @@
       "requires": {
         "@ethersproject/asm": "^5.7.0",
         "@hashgraph/json-rpc-config-service": "file:../config-service",
-        "@hashgraph/sdk": "^2.53.0",
+        "@hashgraph/sdk": "^2.54.0-beta.1",
         "@keyvhq/core": "^1.6.9",
         "@types/chai": "^4.3.0",
         "@types/mocha": "^9.1.0",
@@ -24122,9 +24122,9 @@
           }
         },
         "@hashgraph/sdk": {
-          "version": "2.53.0",
-          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
-          "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+          "version": "2.54.0-beta.1",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.54.0-beta.1.tgz",
+          "integrity": "sha512-rXbwp24fr04LJcOtISabwtKtb0qiRHGa3ltY1KALJ0fEYlUogSEf8DmCeOzNWiZEyy9boCequlRajAkJ+1OF3A==",
           "requires": {
             "@ethersproject/abi": "^5.7.0",
             "@ethersproject/bignumber": "^5.7.0",
@@ -24337,7 +24337,7 @@
       "requires": {
         "@hashgraph/json-rpc-config-service": "file:../config-service",
         "@hashgraph/json-rpc-relay": "file:../relay",
-        "@hashgraph/sdk": "^2.53.0",
+        "@hashgraph/sdk": "^2.54.0-beta.1",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -24390,9 +24390,9 @@
           }
         },
         "@hashgraph/sdk": {
-          "version": "2.53.0",
-          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
-          "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+          "version": "2.54.0-beta.1",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.54.0-beta.1.tgz",
+          "integrity": "sha512-rXbwp24fr04LJcOtISabwtKtb0qiRHGa3ltY1KALJ0fEYlUogSEf8DmCeOzNWiZEyy9boCequlRajAkJ+1OF3A==",
           "dev": true,
           "requires": {
             "@ethersproject/abi": "^5.7.0",
@@ -24788,7 +24788,7 @@
         "@hashgraph/json-rpc-config-service": "file:../config-service",
         "@hashgraph/json-rpc-relay": "file:../relay",
         "@hashgraph/json-rpc-server": "file:../server",
-        "@hashgraph/sdk": "^2.53.0",
+        "@hashgraph/sdk": "^2.54.0-beta.1",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -24838,9 +24838,9 @@
           }
         },
         "@hashgraph/sdk": {
-          "version": "2.53.0",
-          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
-          "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+          "version": "2.54.0-beta.1",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.54.0-beta.1.tgz",
+          "integrity": "sha512-rXbwp24fr04LJcOtISabwtKtb0qiRHGa3ltY1KALJ0fEYlUogSEf8DmCeOzNWiZEyy9boCequlRajAkJ+1OF3A==",
           "dev": true,
           "requires": {
             "@ethersproject/abi": "^5.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2299,6 +2299,7 @@
       "version": "1.4.8-beta.8",
       "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.8.tgz",
       "integrity": "sha512-RK1SL5B6IGsYM4HyepC24rsMGr1qOvHFbNiJPlK+AGV5lApjxGpyNVWC80GusYqwRD9B1ljw43wJBSbHdaZIgw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "asn1js": "^3.0.5",
@@ -2693,6 +2694,7 @@
       "version": "2.51.0",
       "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.51.0.tgz",
       "integrity": "sha512-+RtBs8wmPr9g93fDSMCnQnAX27w+i5itw0bbYDFiAcFZ0F3Vb+TyxdPw7jfcHRgFDvwkyblEsPBzG7DO2lt5Ow==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
@@ -2730,6 +2732,7 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
       "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -2739,6 +2742,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -2748,6 +2752,7 @@
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
       "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
@@ -2770,6 +2775,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
       "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^4.0.0",
@@ -2780,6 +2786,7 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
       "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "colorette": "^2.0.7",
@@ -2805,18 +2812,21 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
       "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@hashgraph/sdk/node_modules/process-warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
       "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@hashgraph/sdk/node_modules/readable-stream": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
       "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
@@ -2833,6 +2843,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -2842,6 +2853,7 @@
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
       "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -2851,6 +2863,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -2860,6 +2873,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
       "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
@@ -20664,7 +20678,7 @@
       "dependencies": {
         "@ethersproject/asm": "^5.7.0",
         "@hashgraph/json-rpc-config-service": "file:../config-service",
-        "@hashgraph/sdk": "^2.50.0-beta.3",
+        "@hashgraph/sdk": "^2.53.0",
         "@keyvhq/core": "^1.6.9",
         "axios": "^1.4.0",
         "axios-retry": "^3.5.1",
@@ -20693,6 +20707,103 @@
         "typescript": "^4.6.4"
       }
     },
+    "packages/relay/node_modules/@hashgraph/cryptography": {
+      "version": "1.4.8-beta.9",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.9.tgz",
+      "integrity": "sha512-U6XeX2TsTg7XT6tDRJOfVTO17ltvjcfMtoK42OCUbN28UPBHuxO7ZOy7z0qVqtjX8knOwbURTjrt9bIrU96AsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "bignumber.js": "^9.1.1",
+        "bn.js": "^5.2.1",
+        "buffer": "^6.0.3",
+        "crypto-js": "^4.2.0",
+        "elliptic": "^6.5.4",
+        "js-base64": "^3.7.4",
+        "node-forge": "^1.3.1",
+        "spark-md5": "^3.0.2",
+        "tweetnacl": "^1.0.3",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "expo": "^49.0.16",
+        "expo-crypto": "^10.1.2",
+        "expo-random": "^12.1.2"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-crypto": {
+          "optional": true
+        },
+        "expo-random": {
+          "optional": true
+        }
+      }
+    },
+    "packages/relay/node_modules/@hashgraph/sdk": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
+      "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@grpc/grpc-js": "1.8.2",
+        "@hashgraph/cryptography": "1.4.8-beta.9",
+        "@hashgraph/proto": "2.15.0-beta.4",
+        "axios": "^1.6.4",
+        "bignumber.js": "^9.1.1",
+        "bn.js": "^5.1.1",
+        "crypto-js": "^4.2.0",
+        "js-base64": "^3.7.4",
+        "long": "^4.0.0",
+        "pino": "^8.14.1",
+        "pino-pretty": "^10.0.0",
+        "protobufjs": "7.2.5",
+        "rfc4648": "^1.5.3",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "expo": "^49.0.16"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "packages/relay/node_modules/@hashgraph/sdk/node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
     "packages/relay/node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -20707,13 +20818,21 @@
     "packages/relay/node_modules/@types/node": {
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     },
     "packages/relay/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "packages/relay/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "packages/relay/node_modules/ethers": {
       "version": "6.13.2",
@@ -20746,6 +20865,144 @@
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
       "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+    },
+    "packages/relay/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/relay/node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "packages/relay/node_modules/pino-pretty": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+      "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "packages/relay/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
+    "packages/relay/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "license": "MIT"
+    },
+    "packages/relay/node_modules/protobufjs": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "packages/relay/node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
+    "packages/relay/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/relay/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "packages/relay/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "packages/relay/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "packages/relay/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "packages/relay/node_modules/tslib": {
       "version": "2.4.0",
@@ -20790,7 +21047,7 @@
         "uuid": "^3.3.2"
       },
       "devDependencies": {
-        "@hashgraph/sdk": "^2.50.0-beta.3",
+        "@hashgraph/sdk": "^2.53.0",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -20805,12 +21062,138 @@
         "axios-retry": "^3.5.1",
         "chai": "^4.3.6",
         "ethers": "^6.7.0",
-        "execution-apis": "git+ssh://git@github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
+        "execution-apis": "git://github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
         "mocha": "^10.6.0",
         "shelljs": "^0.8.5",
         "ts-mocha": "^9.0.2",
         "ts-node": "^10.8.1",
         "typescript": "^4.5.5"
+      }
+    },
+    "packages/server/node_modules/@hashgraph/cryptography": {
+      "version": "1.4.8-beta.9",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.9.tgz",
+      "integrity": "sha512-U6XeX2TsTg7XT6tDRJOfVTO17ltvjcfMtoK42OCUbN28UPBHuxO7ZOy7z0qVqtjX8knOwbURTjrt9bIrU96AsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "bignumber.js": "^9.1.1",
+        "bn.js": "^5.2.1",
+        "buffer": "^6.0.3",
+        "crypto-js": "^4.2.0",
+        "elliptic": "^6.5.4",
+        "js-base64": "^3.7.4",
+        "node-forge": "^1.3.1",
+        "spark-md5": "^3.0.2",
+        "tweetnacl": "^1.0.3",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "expo": "^49.0.16",
+        "expo-crypto": "^10.1.2",
+        "expo-random": "^12.1.2"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-crypto": {
+          "optional": true
+        },
+        "expo-random": {
+          "optional": true
+        }
+      }
+    },
+    "packages/server/node_modules/@hashgraph/sdk": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
+      "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@grpc/grpc-js": "1.8.2",
+        "@hashgraph/cryptography": "1.4.8-beta.9",
+        "@hashgraph/proto": "2.15.0-beta.4",
+        "axios": "^1.6.4",
+        "bignumber.js": "^9.1.1",
+        "bn.js": "^5.1.1",
+        "crypto-js": "^4.2.0",
+        "js-base64": "^3.7.4",
+        "long": "^4.0.0",
+        "pino": "^8.14.1",
+        "pino-pretty": "^10.0.0",
+        "protobufjs": "7.2.5",
+        "rfc4648": "^1.5.3",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "expo": "^49.0.16"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "packages/server/node_modules/@hashgraph/sdk/node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "packages/server/node_modules/@hashgraph/sdk/node_modules/pino-pretty": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+      "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
       }
     },
     "packages/server/node_modules/@noble/curves": {
@@ -20844,6 +21227,16 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/server/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "packages/server/node_modules/diff": {
@@ -21011,12 +21404,106 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "packages/server/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "packages/server/node_modules/path-to-regexp": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
       "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "packages/server/node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "packages/server/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/server/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/server/node_modules/protobufjs": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "packages/server/node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "packages/server/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/server/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "packages/server/node_modules/serialize-javascript": {
@@ -21026,6 +21513,26 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "packages/server/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "packages/server/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "packages/server/node_modules/statuses": {
@@ -21049,6 +21556,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "packages/server/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "packages/server/node_modules/tslib": {
@@ -21130,7 +21647,7 @@
         "pino-pretty": "^7.6.1"
       },
       "devDependencies": {
-        "@hashgraph/sdk": "^2.50.0-beta.3",
+        "@hashgraph/sdk": "^2.53.0",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -21148,6 +21665,132 @@
         "ts-mocha": "^9.0.2",
         "ts-node": "^10.8.1",
         "typescript": "^4.5.5"
+      }
+    },
+    "packages/ws-server/node_modules/@hashgraph/cryptography": {
+      "version": "1.4.8-beta.9",
+      "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.9.tgz",
+      "integrity": "sha512-U6XeX2TsTg7XT6tDRJOfVTO17ltvjcfMtoK42OCUbN28UPBHuxO7ZOy7z0qVqtjX8knOwbURTjrt9bIrU96AsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "bignumber.js": "^9.1.1",
+        "bn.js": "^5.2.1",
+        "buffer": "^6.0.3",
+        "crypto-js": "^4.2.0",
+        "elliptic": "^6.5.4",
+        "js-base64": "^3.7.4",
+        "node-forge": "^1.3.1",
+        "spark-md5": "^3.0.2",
+        "tweetnacl": "^1.0.3",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "expo": "^49.0.16",
+        "expo-crypto": "^10.1.2",
+        "expo-random": "^12.1.2"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-crypto": {
+          "optional": true
+        },
+        "expo-random": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ws-server/node_modules/@hashgraph/sdk": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
+      "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@grpc/grpc-js": "1.8.2",
+        "@hashgraph/cryptography": "1.4.8-beta.9",
+        "@hashgraph/proto": "2.15.0-beta.4",
+        "axios": "^1.6.4",
+        "bignumber.js": "^9.1.1",
+        "bn.js": "^5.1.1",
+        "crypto-js": "^4.2.0",
+        "js-base64": "^3.7.4",
+        "long": "^4.0.0",
+        "pino": "^8.14.1",
+        "pino-pretty": "^10.0.0",
+        "protobufjs": "7.2.5",
+        "rfc4648": "^1.5.3",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "expo": "^49.0.16"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "packages/ws-server/node_modules/@hashgraph/sdk/node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "packages/ws-server/node_modules/@hashgraph/sdk/node_modules/pino-pretty": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+      "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^3.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.0.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
       }
     },
     "packages/ws-server/node_modules/@noble/curves": {
@@ -21181,6 +21824,16 @@
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/ws-server/node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "packages/ws-server/node_modules/diff": {
@@ -21348,12 +22001,106 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "packages/ws-server/node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "packages/ws-server/node_modules/path-to-regexp": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
       "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ==",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "packages/ws-server/node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "packages/ws-server/node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/ws-server/node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/ws-server/node_modules/protobufjs": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "packages/ws-server/node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "packages/ws-server/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/ws-server/node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "packages/ws-server/node_modules/serialize-javascript": {
@@ -21363,6 +22110,26 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "packages/ws-server/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "packages/ws-server/node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "packages/ws-server/node_modules/statuses": {
@@ -21386,6 +22153,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "packages/ws-server/node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "packages/ws-server/node_modules/tslib": {
@@ -23070,6 +23847,7 @@
       "version": "1.4.8-beta.8",
       "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.8.tgz",
       "integrity": "sha512-RK1SL5B6IGsYM4HyepC24rsMGr1qOvHFbNiJPlK+AGV5lApjxGpyNVWC80GusYqwRD9B1ljw43wJBSbHdaZIgw==",
+      "dev": true,
       "requires": {
         "asn1js": "^3.0.5",
         "bignumber.js": "^9.1.1",
@@ -23298,7 +24076,7 @@
       "requires": {
         "@ethersproject/asm": "^5.7.0",
         "@hashgraph/json-rpc-config-service": "file:../config-service",
-        "@hashgraph/sdk": "^2.50.0-beta.3",
+        "@hashgraph/sdk": "^2.53.0",
         "@keyvhq/core": "^1.6.9",
         "@types/chai": "^4.3.0",
         "@types/mocha": "^9.1.0",
@@ -23325,6 +24103,69 @@
         "typescript": "^4.6.4"
       },
       "dependencies": {
+        "@hashgraph/cryptography": {
+          "version": "1.4.8-beta.9",
+          "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.9.tgz",
+          "integrity": "sha512-U6XeX2TsTg7XT6tDRJOfVTO17ltvjcfMtoK42OCUbN28UPBHuxO7ZOy7z0qVqtjX8knOwbURTjrt9bIrU96AsQ==",
+          "requires": {
+            "asn1js": "^3.0.5",
+            "bignumber.js": "^9.1.1",
+            "bn.js": "^5.2.1",
+            "buffer": "^6.0.3",
+            "crypto-js": "^4.2.0",
+            "elliptic": "^6.5.4",
+            "js-base64": "^3.7.4",
+            "node-forge": "^1.3.1",
+            "spark-md5": "^3.0.2",
+            "tweetnacl": "^1.0.3",
+            "utf8": "^3.0.0"
+          }
+        },
+        "@hashgraph/sdk": {
+          "version": "2.53.0",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
+          "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+          "requires": {
+            "@ethersproject/abi": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@grpc/grpc-js": "1.8.2",
+            "@hashgraph/cryptography": "1.4.8-beta.9",
+            "@hashgraph/proto": "2.15.0-beta.4",
+            "axios": "^1.6.4",
+            "bignumber.js": "^9.1.1",
+            "bn.js": "^5.1.1",
+            "crypto-js": "^4.2.0",
+            "js-base64": "^3.7.4",
+            "long": "^4.0.0",
+            "pino": "^8.14.1",
+            "pino-pretty": "^10.0.0",
+            "protobufjs": "7.2.5",
+            "rfc4648": "^1.5.3",
+            "utf8": "^3.0.0"
+          },
+          "dependencies": {
+            "pino": {
+              "version": "8.21.0",
+              "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+              "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+              "requires": {
+                "atomic-sleep": "^1.0.0",
+                "fast-redact": "^3.1.1",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.2.0",
+                "pino-std-serializers": "^6.0.0",
+                "process-warning": "^3.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^3.7.0",
+                "thread-stream": "^2.6.0"
+              }
+            }
+          }
+        },
         "@noble/curves": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -23336,13 +24177,17 @@
         "@types/node": {
           "version": "17.0.45",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
+          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
         },
         "aes-js": {
           "version": "4.0.0-beta.5",
           "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
           "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "dateformat": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
         },
         "ethers": {
           "version": "6.13.2",
@@ -23365,6 +24210,115 @@
             }
           }
         },
+        "on-exit-leak-free": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+          "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="
+        },
+        "pino-abstract-transport": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+          "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+          "requires": {
+            "readable-stream": "^4.0.0",
+            "split2": "^4.0.0"
+          }
+        },
+        "pino-pretty": {
+          "version": "10.3.1",
+          "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+          "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+          "requires": {
+            "colorette": "^2.0.7",
+            "dateformat": "^4.6.3",
+            "fast-copy": "^3.0.0",
+            "fast-safe-stringify": "^2.1.1",
+            "help-me": "^5.0.0",
+            "joycon": "^3.1.1",
+            "minimist": "^1.2.6",
+            "on-exit-leak-free": "^2.1.0",
+            "pino-abstract-transport": "^1.0.0",
+            "pump": "^3.0.0",
+            "readable-stream": "^4.0.0",
+            "secure-json-parse": "^2.4.0",
+            "sonic-boom": "^3.0.0",
+            "strip-json-comments": "^3.1.1"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+        },
+        "process-warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+        },
+        "protobufjs": {
+          "version": "7.2.5",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+          "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          },
+          "dependencies": {
+            "long": {
+              "version": "5.2.3",
+              "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+              "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        },
+        "real-require": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+          "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
+        },
+        "sonic-boom": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+          "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+          "requires": {
+            "atomic-sleep": "^1.0.0"
+          }
+        },
+        "split2": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+        },
+        "thread-stream": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+          "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+          "requires": {
+            "real-require": "^0.2.0"
+          }
+        },
         "tslib": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -23383,7 +24337,7 @@
       "requires": {
         "@hashgraph/json-rpc-config-service": "file:../config-service",
         "@hashgraph/json-rpc-relay": "file:../relay",
-        "@hashgraph/sdk": "^2.50.0-beta.3",
+        "@hashgraph/sdk": "^2.53.0",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -23400,7 +24354,7 @@
         "co-body": "6.2.0",
         "dotenv": "^16.0.0",
         "ethers": "^6.7.0",
-        "execution-apis": "git+ssh://git@github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
+        "execution-apis": "git://github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
         "koa": "^2.13.4",
         "koa-body-parser": "^0.2.1",
         "koa-cors": "^0.0.16",
@@ -23416,6 +24370,94 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "@hashgraph/cryptography": {
+          "version": "1.4.8-beta.9",
+          "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.9.tgz",
+          "integrity": "sha512-U6XeX2TsTg7XT6tDRJOfVTO17ltvjcfMtoK42OCUbN28UPBHuxO7ZOy7z0qVqtjX8knOwbURTjrt9bIrU96AsQ==",
+          "dev": true,
+          "requires": {
+            "asn1js": "^3.0.5",
+            "bignumber.js": "^9.1.1",
+            "bn.js": "^5.2.1",
+            "buffer": "^6.0.3",
+            "crypto-js": "^4.2.0",
+            "elliptic": "^6.5.4",
+            "js-base64": "^3.7.4",
+            "node-forge": "^1.3.1",
+            "spark-md5": "^3.0.2",
+            "tweetnacl": "^1.0.3",
+            "utf8": "^3.0.0"
+          }
+        },
+        "@hashgraph/sdk": {
+          "version": "2.53.0",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
+          "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@grpc/grpc-js": "1.8.2",
+            "@hashgraph/cryptography": "1.4.8-beta.9",
+            "@hashgraph/proto": "2.15.0-beta.4",
+            "axios": "^1.6.4",
+            "bignumber.js": "^9.1.1",
+            "bn.js": "^5.1.1",
+            "crypto-js": "^4.2.0",
+            "js-base64": "^3.7.4",
+            "long": "^4.0.0",
+            "pino": "^8.14.1",
+            "pino-pretty": "^10.0.0",
+            "protobufjs": "7.2.5",
+            "rfc4648": "^1.5.3",
+            "utf8": "^3.0.0"
+          },
+          "dependencies": {
+            "pino": {
+              "version": "8.21.0",
+              "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+              "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+              "dev": true,
+              "requires": {
+                "atomic-sleep": "^1.0.0",
+                "fast-redact": "^3.1.1",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.2.0",
+                "pino-std-serializers": "^6.0.0",
+                "process-warning": "^3.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^3.7.0",
+                "thread-stream": "^2.6.0"
+              }
+            },
+            "pino-pretty": {
+              "version": "10.3.1",
+              "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+              "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+              "dev": true,
+              "requires": {
+                "colorette": "^2.0.7",
+                "dateformat": "^4.6.3",
+                "fast-copy": "^3.0.0",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^5.0.0",
+                "joycon": "^3.1.1",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.0.0",
+                "pump": "^3.0.0",
+                "readable-stream": "^4.0.0",
+                "secure-json-parse": "^2.4.0",
+                "sonic-boom": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+              }
+            }
+          }
+        },
         "@noble/curves": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -23445,6 +24487,12 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
+        },
+        "dateformat": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+          "dev": true
         },
         "diff": {
           "version": "5.2.0",
@@ -23565,10 +24613,85 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
+        "on-exit-leak-free": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+          "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+          "dev": true
+        },
         "path-to-regexp": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
           "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ=="
+        },
+        "pino-abstract-transport": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+          "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^4.0.0",
+            "split2": "^4.0.0"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+          "dev": true
+        },
+        "process-warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+          "dev": true
+        },
+        "protobufjs": {
+          "version": "7.2.5",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+          "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+          "dev": true,
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          },
+          "dependencies": {
+            "long": {
+              "version": "5.2.3",
+              "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+              "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+              "dev": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        },
+        "real-require": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+          "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+          "dev": true
         },
         "serialize-javascript": {
           "version": "6.0.2",
@@ -23578,6 +24701,21 @@
           "requires": {
             "randombytes": "^2.1.0"
           }
+        },
+        "sonic-boom": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+          "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+          "dev": true,
+          "requires": {
+            "atomic-sleep": "^1.0.0"
+          }
+        },
+        "split2": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+          "dev": true
         },
         "statuses": {
           "version": "2.0.1",
@@ -23591,6 +24729,15 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "thread-stream": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+          "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+          "dev": true,
+          "requires": {
+            "real-require": "^0.2.0"
           }
         },
         "tslib": {
@@ -23641,7 +24788,7 @@
         "@hashgraph/json-rpc-config-service": "file:../config-service",
         "@hashgraph/json-rpc-relay": "file:../relay",
         "@hashgraph/json-rpc-server": "file:../server",
-        "@hashgraph/sdk": "^2.50.0-beta.3",
+        "@hashgraph/sdk": "^2.53.0",
         "@koa/cors": "^5.0.0",
         "@types/chai": "^4.3.0",
         "@types/cors": "^2.8.12",
@@ -23671,6 +24818,94 @@
         "typescript": "^4.5.5"
       },
       "dependencies": {
+        "@hashgraph/cryptography": {
+          "version": "1.4.8-beta.9",
+          "resolved": "https://registry.npmjs.org/@hashgraph/cryptography/-/cryptography-1.4.8-beta.9.tgz",
+          "integrity": "sha512-U6XeX2TsTg7XT6tDRJOfVTO17ltvjcfMtoK42OCUbN28UPBHuxO7ZOy7z0qVqtjX8knOwbURTjrt9bIrU96AsQ==",
+          "dev": true,
+          "requires": {
+            "asn1js": "^3.0.5",
+            "bignumber.js": "^9.1.1",
+            "bn.js": "^5.2.1",
+            "buffer": "^6.0.3",
+            "crypto-js": "^4.2.0",
+            "elliptic": "^6.5.4",
+            "js-base64": "^3.7.4",
+            "node-forge": "^1.3.1",
+            "spark-md5": "^3.0.2",
+            "tweetnacl": "^1.0.3",
+            "utf8": "^3.0.0"
+          }
+        },
+        "@hashgraph/sdk": {
+          "version": "2.53.0",
+          "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.53.0.tgz",
+          "integrity": "sha512-NpKGzWGzMoKa37VZ1ph+wAKQ4QRLKQazAcNFLftDugAFSLVHrFJRJkwu8j2M0BLC99faLQkkvjwSGsUtWu1JFg==",
+          "dev": true,
+          "requires": {
+            "@ethersproject/abi": "^5.7.0",
+            "@ethersproject/bignumber": "^5.7.0",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/rlp": "^5.7.0",
+            "@grpc/grpc-js": "1.8.2",
+            "@hashgraph/cryptography": "1.4.8-beta.9",
+            "@hashgraph/proto": "2.15.0-beta.4",
+            "axios": "^1.6.4",
+            "bignumber.js": "^9.1.1",
+            "bn.js": "^5.1.1",
+            "crypto-js": "^4.2.0",
+            "js-base64": "^3.7.4",
+            "long": "^4.0.0",
+            "pino": "^8.14.1",
+            "pino-pretty": "^10.0.0",
+            "protobufjs": "7.2.5",
+            "rfc4648": "^1.5.3",
+            "utf8": "^3.0.0"
+          },
+          "dependencies": {
+            "pino": {
+              "version": "8.21.0",
+              "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+              "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+              "dev": true,
+              "requires": {
+                "atomic-sleep": "^1.0.0",
+                "fast-redact": "^3.1.1",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.2.0",
+                "pino-std-serializers": "^6.0.0",
+                "process-warning": "^3.0.0",
+                "quick-format-unescaped": "^4.0.3",
+                "real-require": "^0.2.0",
+                "safe-stable-stringify": "^2.3.1",
+                "sonic-boom": "^3.7.0",
+                "thread-stream": "^2.6.0"
+              }
+            },
+            "pino-pretty": {
+              "version": "10.3.1",
+              "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
+              "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+              "dev": true,
+              "requires": {
+                "colorette": "^2.0.7",
+                "dateformat": "^4.6.3",
+                "fast-copy": "^3.0.0",
+                "fast-safe-stringify": "^2.1.1",
+                "help-me": "^5.0.0",
+                "joycon": "^3.1.1",
+                "minimist": "^1.2.6",
+                "on-exit-leak-free": "^2.1.0",
+                "pino-abstract-transport": "^1.0.0",
+                "pump": "^3.0.0",
+                "readable-stream": "^4.0.0",
+                "secure-json-parse": "^2.4.0",
+                "sonic-boom": "^3.0.0",
+                "strip-json-comments": "^3.1.1"
+              }
+            }
+          }
+        },
         "@noble/curves": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -23700,6 +24935,12 @@
           "requires": {
             "balanced-match": "^1.0.0"
           }
+        },
+        "dateformat": {
+          "version": "4.6.3",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+          "dev": true
         },
         "diff": {
           "version": "5.2.0",
@@ -23820,10 +25061,85 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
           "dev": true
         },
+        "on-exit-leak-free": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+          "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+          "dev": true
+        },
         "path-to-regexp": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.1.0.tgz",
           "integrity": "sha512-Bqn3vc8CMHty6zuD+tG23s6v2kwxslHEhTj4eYaVKGIEB+YX/2wd0/rgXLFD9G9id9KCtbVy/3ZgmvZjpa0UdQ=="
+        },
+        "pino-abstract-transport": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+          "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^4.0.0",
+            "split2": "^4.0.0"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+          "dev": true
+        },
+        "process-warning": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+          "dev": true
+        },
+        "protobufjs": {
+          "version": "7.2.5",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+          "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+          "dev": true,
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          },
+          "dependencies": {
+            "long": {
+              "version": "5.2.3",
+              "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+              "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+              "dev": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "4.5.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+          "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "buffer": "^6.0.3",
+            "events": "^3.3.0",
+            "process": "^0.11.10",
+            "string_decoder": "^1.3.0"
+          }
+        },
+        "real-require": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+          "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+          "dev": true
         },
         "serialize-javascript": {
           "version": "6.0.2",
@@ -23833,6 +25149,21 @@
           "requires": {
             "randombytes": "^2.1.0"
           }
+        },
+        "sonic-boom": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+          "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+          "dev": true,
+          "requires": {
+            "atomic-sleep": "^1.0.0"
+          }
+        },
+        "split2": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+          "dev": true
         },
         "statuses": {
           "version": "2.0.1",
@@ -23846,6 +25177,15 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "thread-stream": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+          "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+          "dev": true,
+          "requires": {
+            "real-require": "^0.2.0"
           }
         },
         "tslib": {
@@ -23903,6 +25243,7 @@
       "version": "2.51.0",
       "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.51.0.tgz",
       "integrity": "sha512-+RtBs8wmPr9g93fDSMCnQnAX27w+i5itw0bbYDFiAcFZ0F3Vb+TyxdPw7jfcHRgFDvwkyblEsPBzG7DO2lt5Ow==",
+      "dev": true,
       "requires": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -23927,17 +25268,20 @@
         "dateformat": {
           "version": "4.6.3",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="
+          "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+          "dev": true
         },
         "on-exit-leak-free": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
-          "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="
+          "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+          "dev": true
         },
         "pino": {
           "version": "8.21.0",
           "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
           "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+          "dev": true,
           "requires": {
             "atomic-sleep": "^1.0.0",
             "fast-redact": "^3.1.1",
@@ -23956,6 +25300,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
           "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+          "dev": true,
           "requires": {
             "readable-stream": "^4.0.0",
             "split2": "^4.0.0"
@@ -23965,6 +25310,7 @@
           "version": "10.3.1",
           "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-10.3.1.tgz",
           "integrity": "sha512-az8JbIYeN/1iLj2t0jR9DV48/LQ3RC6hZPpapKPkb84Q+yTidMCpgWxIT3N0flnBDilyBQ1luWNpOeJptjdp/g==",
+          "dev": true,
           "requires": {
             "colorette": "^2.0.7",
             "dateformat": "^4.6.3",
@@ -23985,17 +25331,20 @@
         "pino-std-serializers": {
           "version": "6.2.2",
           "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
-          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA=="
+          "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+          "dev": true
         },
         "process-warning": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
-          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ=="
+          "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
+          "dev": true
         },
         "readable-stream": {
           "version": "4.5.2",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
           "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+          "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "buffer": "^6.0.3",
@@ -24007,12 +25356,14 @@
         "real-require": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
-          "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="
+          "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+          "dev": true
         },
         "sonic-boom": {
           "version": "3.8.1",
           "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
           "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+          "dev": true,
           "requires": {
             "atomic-sleep": "^1.0.0"
           }
@@ -24020,12 +25371,14 @@
         "split2": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+          "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+          "dev": true
         },
         "thread-stream": {
           "version": "2.7.0",
           "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
           "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+          "dev": true,
           "requires": {
             "real-require": "^0.2.0"
           }

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@hashgraph/json-rpc-config-service": "file:../config-service",
     "@ethersproject/asm": "^5.7.0",
-    "@hashgraph/sdk": "^2.53.0",
+    "@hashgraph/sdk": "^2.54.0-beta.1",
     "@keyvhq/core": "^1.6.9",
     "axios": "^1.4.0",
     "axios-retry": "^3.5.1",

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -50,7 +50,7 @@
   "dependencies": {
     "@hashgraph/json-rpc-config-service": "file:../config-service",
     "@ethersproject/asm": "^5.7.0",
-    "@hashgraph/sdk": "^2.50.0-beta.3",
+    "@hashgraph/sdk": "^2.53.0",
     "@keyvhq/core": "^1.6.9",
     "axios": "^1.4.0",
     "axios-retry": "^3.5.1",

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -728,6 +728,13 @@ export class SDKClient {
         throw e;
       }
 
+      // Log the target node account ID, right now, it's populated only for MaxAttemptsOrTimeout error
+      if (e?.nodeAccountId) {
+        this.logger.info(
+          `${requestDetails.formattedRequestId} Transaction failed to execute against node with id: ${e.nodeAccountId}`
+        );
+      }
+
       const sdkClientError = new SDKClientError(e, e.message, transaction.transactionId?.toString());
 
       // WRONG_NONCE is one of the special errors where the SDK still returns a valid transactionResponse.

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -818,6 +818,12 @@ export class SDKClient {
         `${requestDetails.formattedRequestId} Successfully execute all ${transactionResponses.length} ${txConstructorName} transactions: callerName=${callerName}, status=${Status.Success}(${Status.Success._code})`,
       );
     } catch (e: any) {
+      // Log the target node account ID, right now, it's populated only for MaxAttemptsOrTimeout error
+      if (e?.nodeAccountId) {
+        this.logger.info(
+          `${requestDetails.formattedRequestId} Transaction failed to execute against node with id: ${e.nodeAccountId}`
+        );
+      }
       const sdkClientError = new SDKClientError(e, e.message);
 
       this.logger.warn(

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@hashgraph/sdk": "^2.50.0-beta.3",
+    "@hashgraph/sdk": "^2.53.0",
     "@koa/cors": "^5.0.0",
     "@types/chai": "^4.3.0",
     "@types/cors": "^2.8.12",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
-    "@hashgraph/sdk": "^2.53.0",
+    "@hashgraph/sdk": "^2.54.0-beta.1",
     "@koa/cors": "^5.0.0",
     "@types/chai": "^4.3.0",
     "@types/cors": "^2.8.12",

--- a/packages/ws-server/package.json
+++ b/packages/ws-server/package.json
@@ -21,7 +21,7 @@
     "pino-pretty": "^7.6.1"
   },
   "devDependencies": {
-    "@hashgraph/sdk": "^2.50.0-beta.3",
+    "@hashgraph/sdk": "^2.53.0",
     "@koa/cors": "^5.0.0",
     "@types/chai": "^4.3.0",
     "@types/cors": "^2.8.12",

--- a/packages/ws-server/package.json
+++ b/packages/ws-server/package.json
@@ -21,7 +21,7 @@
     "pino-pretty": "^7.6.1"
   },
   "devDependencies": {
-    "@hashgraph/sdk": "^2.53.0",
+    "@hashgraph/sdk": "^2.54.0-beta.1",
     "@koa/cors": "^5.0.0",
     "@types/chai": "^4.3.0",
     "@types/cors": "^2.8.12",


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->


The Relay server currently lacks visibility into which node account ID a transaction was submitted to when it fails due to an SDK error. With the [recent update](https://github.com/hashgraph/hedera-sdk-js/pull/2631) to the `hedera-sdk-js`, the error object now includes the node account ID for failed transactions. 

This new capability in the Relay's logging system is expected to improve troubleshooting and provide better insights into node-specific transaction failures.

**Solution**:

Update the Relay server's logging system to extract and log the node account ID from the error object provided by the SDK

**Related issue(s)**:

Fixes #3278 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
