### PR TITLE
fix: let 0 value transactions pass

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -162,7 +162,7 @@ export const predefined = {
   }),
   VALUE_TOO_LOW: new JsonRpcError({
     code: -32602,
-    message: "Value can't be negative or between 1 wei and 10_000_000_000 wei which is 1 tinybar",
+    message: "Value can't be non-zero and less than 10_000_000_000 wei which is 1 tinybar",
   }),
   INVALID_CONTRACT_ADDRESS: (address) => {
     let message = `Invalid Contract Address: ${address}.`;

--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -162,7 +162,7 @@ export const predefined = {
   }),
   VALUE_TOO_LOW: new JsonRpcError({
     code: -32602,
-    message: 'Value below 10_000_000_000 wei which is 1 tinybar',
+    message: "Value can't be negative or between 1 wei and 10_000_000_000 wei which is 1 tinybar",
   }),
   INVALID_CONTRACT_ADDRESS: (address) => {
     let message = `Invalid Contract Address: ${address}.`;

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -657,11 +657,11 @@ export class EthImpl implements Eth {
 
     if (isSimpleTransfer) {
       // Handle Simple Transaction and Hollow Account creation
-      const isNonZeroValue = Number(transaction.value) > 0;
-      if (!isNonZeroValue) {
+      const isZeroOrHigher = Number(transaction.value) >= 0;
+      if (!isZeroOrHigher) {
         return predefined.INVALID_PARAMETER(
           0,
-          `Invalid 'value' field in transaction param. Value must be greater than 0`,
+          `Invalid 'value' field in transaction param. Value must be greater than or equal to 0`,
         );
       }
       // when account exists return default base gas

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -18,13 +18,14 @@
  *
  */
 
-import { JsonRpcError, predefined } from './errors/JsonRpcError';
-import { MirrorNodeClient } from './clients';
-import { EthImpl } from './eth';
-import { Logger } from 'pino';
-import constants from './constants';
 import { ethers, Transaction } from 'ethers';
+import { Logger } from 'pino';
+
 import { prepend0x } from '../formatters';
+import { MirrorNodeClient } from './clients';
+import constants from './constants';
+import { JsonRpcError, predefined } from './errors/JsonRpcError';
+import { EthImpl } from './eth';
 import { RequestDetails } from './types';
 
 /**
@@ -57,16 +58,6 @@ export class Precheck {
   }
 
   /**
-   * Checks if the value of the transaction is valid.
-   * @param {Transaction} tx - The transaction.
-   */
-  value(tx: Transaction): void {
-    if (tx.data === EthImpl.emptyHex && tx.value < constants.TINYBAR_TO_WEIBAR_COEF) {
-      throw predefined.VALUE_TOO_LOW;
-    }
-  }
-
-  /**
    * Sends a raw transaction after performing various prechecks.
    * @param {ethers.Transaction} parsedTx - The parsed transaction.
    * @param {number} networkGasPriceInWeiBars - The predefined gas price of the network in weibar.
@@ -82,7 +73,6 @@ export class Precheck {
     const mirrorAccountInfo = await this.verifyAccount(parsedTx, requestDetails);
     this.nonce(parsedTx, mirrorAccountInfo.ethereum_nonce, requestDetails);
     this.chainId(parsedTx, requestDetails);
-    this.value(parsedTx);
     this.gasPrice(parsedTx, networkGasPriceInWeiBars, requestDetails);
     this.balance(parsedTx, mirrorAccountInfo, requestDetails);
   }

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -25,7 +25,6 @@ import { prepend0x } from '../formatters';
 import { MirrorNodeClient } from './clients';
 import constants from './constants';
 import { JsonRpcError, predefined } from './errors/JsonRpcError';
-import { EthImpl } from './eth';
 import { RequestDetails } from './types';
 
 /**

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -62,10 +62,7 @@ export class Precheck {
    * @param {Transaction} tx - The transaction.
    */
   value(tx: Transaction): void {
-    if (
-      tx.data === EthImpl.emptyHex &&
-      ((tx.value > 0 && tx.value < constants.TINYBAR_TO_WEIBAR_COEF) || tx.value < 0)
-    ) {
+    if ((tx.value > 0 && tx.value < constants.TINYBAR_TO_WEIBAR_COEF) || tx.value < 0) {
       throw predefined.VALUE_TOO_LOW;
     }
   }

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -58,6 +58,19 @@ export class Precheck {
   }
 
   /**
+   * Checks if the value of the transaction is valid.
+   * @param {Transaction} tx - The transaction.
+   */
+  value(tx: Transaction): void {
+    if (
+      tx.data === EthImpl.emptyHex &&
+      ((tx.value > 0 && tx.value < constants.TINYBAR_TO_WEIBAR_COEF) || tx.value < 0)
+    ) {
+      throw predefined.VALUE_TOO_LOW;
+    }
+  }
+
+  /**
    * Sends a raw transaction after performing various prechecks.
    * @param {ethers.Transaction} parsedTx - The parsed transaction.
    * @param {number} networkGasPriceInWeiBars - The predefined gas price of the network in weibar.
@@ -73,6 +86,7 @@ export class Precheck {
     const mirrorAccountInfo = await this.verifyAccount(parsedTx, requestDetails);
     this.nonce(parsedTx, mirrorAccountInfo.ethereum_nonce, requestDetails);
     this.chainId(parsedTx, requestDetails);
+    this.value(parsedTx);
     this.gasPrice(parsedTx, networkGasPriceInWeiBars, requestDetails);
     this.balance(parsedTx, mirrorAccountInfo, requestDetails);
   }

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -128,7 +128,7 @@ describe('Precheck', async function () {
       } catch (e: any) {
         expect(e).to.exist;
         expect(e.code).to.eq(-32602);
-        expect(e.message).to.eq("Value can't be negative or between 1 wei and 10_000_000_000 wei which is 1 tinybar");
+        expect(e.message).to.eq("Value can't be non-zero and less than 10_000_000_000 wei which is 1 tinybar");
         hasError = true;
       }
 
@@ -159,7 +159,7 @@ describe('Precheck', async function () {
       } catch (e: any) {
         expect(e).to.exist;
         expect(e.code).to.eq(-32602);
-        expect(e.message).to.eq("Value can't be negative or between 1 wei and 10_000_000_000 wei which is 1 tinybar");
+        expect(e.message).to.eq("Value can't be non-zero and less than 10_000_000_000 wei which is 1 tinybar");
         hasError = true;
       }
       expect(hasError).to.be.true;
@@ -174,7 +174,7 @@ describe('Precheck', async function () {
       } catch (e: any) {
         expect(e).to.exist;
         expect(e.code).to.eq(-32602);
-        expect(e.message).to.eq("Value can't be negative or between 1 wei and 10_000_000_000 wei which is 1 tinybar");
+        expect(e.message).to.eq("Value can't be non-zero and less than 10_000_000_000 wei which is 1 tinybar");
         hasError = true;
       }
 
@@ -190,7 +190,7 @@ describe('Precheck', async function () {
       } catch (e: any) {
         expect(e).to.exist;
         expect(e.code).to.eq(-32602);
-        expect(e.message).to.eq("Value can't be negative or between 1 wei and 10_000_000_000 wei which is 1 tinybar");
+        expect(e.message).to.eq("Value can't be non-zero and less than 10_000_000_000 wei which is 1 tinybar");
         hasError = true;
       }
 

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -151,12 +151,18 @@ describe('Precheck', async function () {
       }
     });
 
-    it('should pass if value is less than 1 tinybar, above 0, and data is not empty', async function () {
+    it('should throw an exception if value is less than 1 tinybar, above 0, and data is not empty', async function () {
+      let hasError = false;
+
       try {
         precheck.value(parsedTxWithValueLessThanOneTinybarAndNotEmptyData);
       } catch (e: any) {
-        expect(e).to.not.exist;
+        expect(e).to.exist;
+        expect(e.code).to.eq(-32602);
+        expect(e.message).to.eq("Value can't be negative or between 1 wei and 10_000_000_000 wei which is 1 tinybar");
+        hasError = true;
       }
+      expect(hasError).to.be.true;
     });
 
     it('should throw an exception if value is negative', async function () {

--- a/packages/relay/tests/lib/precheck.spec.ts
+++ b/packages/relay/tests/lib/precheck.spec.ts
@@ -19,11 +19,19 @@
  */
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
-import { expect } from 'chai';
-import { Registry } from 'prom-client';
 import { Hbar, HbarUnit } from '@hashgraph/sdk';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { expect } from 'chai';
+import { ethers, Transaction } from 'ethers';
 import pino from 'pino';
+import { Registry } from 'prom-client';
+
+import { JsonRpcError, predefined } from '../../src';
+import { MirrorNodeClient } from '../../src/lib/clients';
+import constants from '../../src/lib/constants';
 import { Precheck } from '../../src/lib/precheck';
+import { CacheService } from '../../src/lib/services/cacheService/cacheService';
 import {
   blobVersionedHash,
   contractAddress1,
@@ -32,13 +40,6 @@ import {
   overrideEnvsInMochaDescribe,
   signTransaction,
 } from '../helpers';
-import { MirrorNodeClient } from '../../src/lib/clients';
-import axios from 'axios';
-import MockAdapter from 'axios-mock-adapter';
-import { ethers, Transaction } from 'ethers';
-import constants from '../../src/lib/constants';
-import { JsonRpcError, predefined } from '../../src';
-import { CacheService } from '../../src/lib/services/cacheService/cacheService';
 import { ONE_TINYBAR_IN_WEI_HEX } from './eth/eth-config';
 
 const registry = new Registry();
@@ -114,38 +115,6 @@ describe('Precheck', async function () {
   this.beforeEach(() => {
     // reset mock
     mock.reset();
-  });
-
-  describe('value', async function () {
-    it('should throw an exception if value is less than 1 tinybar', async function () {
-      let hasError = false;
-      try {
-        precheck.value(parsedTxWithValueLessThanOneTinybar);
-      } catch (e: any) {
-        expect(e).to.exist;
-        expect(e.code).to.eq(-32602);
-        expect(e.message).to.eq('Value below 10_000_000_000 wei which is 1 tinybar');
-        hasError = true;
-      }
-
-      expect(hasError).to.be.true;
-    });
-
-    it('should pass if value is more than 1 tinybar', async function () {
-      try {
-        precheck.value(parsedTxWithValueMoreThanOneTinyBar);
-      } catch (e) {
-        expect(e).to.not.exist;
-      }
-    });
-
-    it('should pass if value is less than 1 tinybar and data is not empty', async function () {
-      try {
-        precheck.value(parsedTxWithValueLessThanOneTinybarAndNotEmptyData);
-      } catch (e: any) {
-        expect(e).to.not.exist;
-      }
-    });
   });
 
   describe('chainId', async function () {


### PR DESCRIPTION
**Description**:
This PR fixes the case where transactions with a value of 0 would not pass. This is needed because they would pass as valid transactions on the Ethereum network as 0 is a valid value there.

**Related issue(s)**:

Fixes #3105 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
