### PR TITLE
feat: return hts token address for new fungible token

### DIFF
--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -71,7 +71,9 @@ export enum CallType {
 
 const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE =
   'createNonFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)))';
-const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE =
+const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1 =
+  'createFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),uint64,uint32)';
+const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2 =
   'createFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)),int64,int32)';
 
 export default {
@@ -216,7 +218,8 @@ export default {
 
   MASKED_IP_ADDRESS: 'xxx.xxx.xxx.xxx',
   HTS_CREATE_FUNCTIONS_SIGNATURE: [
-    CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE,
+    CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1,
+    CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2,
     CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE,
   ],
 

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -69,6 +69,11 @@ export enum CallType {
   CALL = 'CALL',
 }
 
+const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE =
+  'createNonFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)))';
+const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE =
+  'createFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)),int64,int32)';
+
 export default {
   HBAR_TO_TINYBAR_COEF: 100_000_000,
   TINYBAR_TO_WEIBAR_COEF: 10_000_000_000,
@@ -210,6 +215,10 @@ export default {
   DEFAULT_ROOT_HASH: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 
   MASKED_IP_ADDRESS: 'xxx.xxx.xxx.xxx',
+  HTS_CREATE_FUNCTIONS_SIGNATURE: [
+    CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE,
+    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE,
+  ],
 
   // The fee is calculated via the fee calculator: https://docs.hedera.com/hedera/networks/mainnet/fees
   // The maximum fileAppendChunkSize is currently set to 5KB by default; therefore, the estimated fees for FileCreate below are based on a file size of 5KB.

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -69,12 +69,29 @@ export enum CallType {
   CALL = 'CALL',
 }
 
-const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE =
+const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1 =
+  'createNonFungibleToken((string,string,address,string,bool,uint32,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)))';
+const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2 =
+  'createNonFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)))';
+const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V3 =
   'createNonFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)))';
+const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V1 =
+  'createNonFungibleTokenWithCustomFees((string,string,address,string,bool,uint32,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),(uint32,address,bool,bool,address)[],(uint32,uint32,uint32,address,bool,address)[])';
+const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V2 =
+  'createNonFungibleTokenWithCustomFees((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),(uint32,address,bool,bool,address)[],(uint32,uint32,uint32,address,bool,address)[])';
+const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V3 =
+  'createNonFungibleTokenWithCustomFees((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)),(int64,address,bool,bool,address)[],(int64,int64,int64,address,bool,address)[])';
+
 const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1 =
-  'createFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),uint64,uint32)';
+  'createFungibleToken((string,string,address,string,bool,int64,bool,(uint,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),uint64,uint32)';
 const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2 =
+  'createFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),uint64,uint32)';
+const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V3 =
   'createFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)),int64,int32)';
+const CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SIGNATURE_V2 =
+  'createFungibleTokenWithCustomFees((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),uint64,uint32,(uint32,address,bool,bool,address)[],(uint32,uint32,uint32,uint32,bool,address)[])';
+const CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SIGNATURE_V3 =
+  'createFungibleTokenWithCustomFees((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)),int64,int32,(int64,address,bool,bool,address)[],(int64,int64,int64,int64,bool,address)[])';
 
 export default {
   HBAR_TO_TINYBAR_COEF: 100_000_000,
@@ -220,7 +237,15 @@ export default {
   HTS_CREATE_FUNCTIONS_SIGNATURE: [
     CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1,
     CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2,
-    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE,
+    CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V3,
+    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SIGNATURE_V2,
+    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SIGNATURE_V3,
+    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1,
+    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2,
+    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V3,
+    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V1,
+    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V2,
+    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V3,
   ],
 
   // The fee is calculated via the fee calculator: https://docs.hedera.com/hedera/networks/mainnet/fees

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -69,29 +69,19 @@ export enum CallType {
   CALL = 'CALL',
 }
 
-const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1 =
-  'createNonFungibleToken((string,string,address,string,bool,uint32,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)))';
-const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2 =
-  'createNonFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)))';
-const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V3 =
-  'createNonFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)))';
-const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V1 =
-  'createNonFungibleTokenWithCustomFees((string,string,address,string,bool,uint32,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),(uint32,address,bool,bool,address)[],(uint32,uint32,uint32,address,bool,address)[])';
-const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V2 =
-  'createNonFungibleTokenWithCustomFees((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),(uint32,address,bool,bool,address)[],(uint32,uint32,uint32,address,bool,address)[])';
-const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V3 =
-  'createNonFungibleTokenWithCustomFees((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)),(int64,address,bool,bool,address)[],(int64,int64,int64,address,bool,address)[])';
-
-const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1 =
-  'createFungibleToken((string,string,address,string,bool,int64,bool,(uint,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),uint64,uint32)';
-const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2 =
-  'createFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),uint64,uint32)';
-const CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V3 =
-  'createFungibleToken((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)),int64,int32)';
-const CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SIGNATURE_V2 =
-  'createFungibleTokenWithCustomFees((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(uint32,address,uint32)),uint64,uint32,(uint32,address,bool,bool,address)[],(uint32,uint32,uint32,uint32,bool,address)[])';
-const CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SIGNATURE_V3 =
-  'createFungibleTokenWithCustomFees((string,string,address,string,bool,int64,bool,(uint256,(bool,address,bytes,bytes,address))[],(int64,address,int64)),int64,int32,(int64,address,bool,bool,address)[],(int64,int64,int64,int64,bool,address)[])';
+// HTS create function selectors taken from https://github.com/hashgraph/hedera-smart-contracts/tree/main/contracts/system-contracts/hedera-token-service
+const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V1 = '0x9dc711e0';
+const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V2 = '0x9c89bb35';
+const CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V3 = '0xea83f293';
+const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SELECTOR_V1 = '0x5bc7c0e6';
+const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SELECTOR_V2 = '0x45733969';
+const CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SELECTOR_V3 = '0xabb54eb5';
+const CREATE_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V1 = '0x27d97be3';
+const CREATE_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V2 = '0xc23baeb6';
+const CREATE_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V3 = '0x0fb65bf3';
+const CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SELECTOR_V1 = '0xef2d1098';
+const CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SELECTOR_V2 = '0xb937581a';
+const CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SELECTOR_V3 = '0x2af0c59a';
 
 export default {
   HBAR_TO_TINYBAR_COEF: 100_000_000,
@@ -234,18 +224,19 @@ export default {
   DEFAULT_ROOT_HASH: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
 
   MASKED_IP_ADDRESS: 'xxx.xxx.xxx.xxx',
-  HTS_CREATE_FUNCTIONS_SIGNATURE: [
-    CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1,
-    CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2,
-    CREATE_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V3,
-    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SIGNATURE_V2,
-    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SIGNATURE_V3,
-    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V1,
-    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V2,
-    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SIGNATURE_V3,
-    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V1,
-    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V2,
-    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SIGNATURE_V3,
+  HTS_CREATE_FUNCTIONS_SELECTORS: [
+    CREATE_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V1,
+    CREATE_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V2,
+    CREATE_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V3,
+    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SELECTOR_V1,
+    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SELECTOR_V2,
+    CREATE_FUNGIBLE_TOKEN_WITH_CUSTOM_FEES_FUNCTION_SELECTOR_V3,
+    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V1,
+    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V2,
+    CREATE_NON_FUNGIBLE_TOKEN_FUNCTION_SELECTOR_V3,
+    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SELECTOR_V1,
+    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SELECTOR_V2,
+    CREATE_NON_FUNGIBLE_WITH_CUSTOM_FEES_TOKEN_FUNCTION_SELECTOR_V3,
   ],
 
   // The fee is calculated via the fee calculator: https://docs.hedera.com/hedera/networks/mainnet/fees

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2336,11 +2336,14 @@ export class EthImpl implements Eth {
           transactionIndex: nullableNumberTo0x(receiptResponse.transaction_index),
         });
       });
-      const isCreationViaSystemContract = receiptResponse.function_parameters
-        .substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH)
-        .includes('0x0fb65bf3');
+      const functionSelectors = constants.HTS_CREATE_FUNCTIONS_SIGNATURE.map((signature) =>
+        Utils.calculateFunctionSelector(signature),
+      );
+      const isCreationViaSystemContract = functionSelectors.includes(
+        receiptResponse.function_parameters.substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH),
+      );
       const tokenAddress = receiptResponse.call_result.substring(90);
-      const contractAddress = isCreationViaSystemContract ? `0x${tokenAddress}` : receiptResponse.address;
+      const contractAddress = isCreationViaSystemContract ? prepend0x(tokenAddress) : receiptResponse.address;
       const receipt: ITransactionReceipt = {
         blockHash: toHash32(receiptResponse.block_hash),
         blockNumber: numberTo0x(receiptResponse.block_number),

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2390,6 +2390,7 @@ export class EthImpl implements Eth {
     }
 
     // Handle system contract creation
+    // reason for substring from the 90th character is described in the design doc in this repo: docs/design/hts_address_tx_receipt.md
     const tokenAddress = receiptResponse.call_result.substring(90);
     return prepend0x(tokenAddress);
   }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2316,11 +2316,6 @@ export class EthImpl implements Eth {
       );
       return receipt;
     } else {
-      if (
-        receiptResponse.function_parameters.substring(2, constants.FUNCTION_SELECTOR_CHAR_LENGTH).includes('0x0fb65bf3')
-      ) {
-        console.log('WE ARE HEREEE');
-      }
       const effectiveGas = await this.getCurrentGasPriceForBlock(receiptResponse.block_hash, requestDetails);
       // support stricter go-eth client which requires the transaction hash property on logs
       const logs = receiptResponse.logs.map((log) => {

--- a/packages/relay/src/utils.ts
+++ b/packages/relay/src/utils.ts
@@ -21,7 +21,6 @@
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { PrivateKey } from '@hashgraph/sdk';
 import crypto from 'crypto';
-import { keccak256, toUtf8Bytes } from 'ethers';
 import createHash from 'keccak';
 
 import { hexToASCII, prepend0x, strip0x } from './formatters';

--- a/packages/relay/src/utils.ts
+++ b/packages/relay/src/utils.ts
@@ -18,13 +18,14 @@
  *
  */
 
-import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { PrivateKey } from '@hashgraph/sdk';
+import { keccak256, toUtf8Bytes } from 'ethers';
+import constants from './lib/constants';
+import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import crypto from 'crypto';
 import createHash from 'keccak';
 
 import { hexToASCII, prepend0x, strip0x } from './formatters';
-import constants from './lib/constants';
 
 export class Utils {
   public static readonly IP_ADDRESS_REGEX = /\b((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}\b/g;
@@ -128,6 +129,7 @@ export class Utils {
     );
   }
 
+<<<<<<< HEAD
   /**
    * Computes the Keccak-256 hash of a transaction buffer and prepends '0x'
    * @param {Buffer} transactionBuffer - The raw transaction buffer to hash
@@ -135,5 +137,10 @@ export class Utils {
    */
   public static computeTransactionHash(transactionBuffer: Buffer): string {
     return prepend0x(createHash('keccak256').update(transactionBuffer).digest('hex'));
+=======
+  public static calculateFunctionSelector(functionSignature: string): string {
+    const hash = keccak256(toUtf8Bytes(functionSignature));
+    return hash.substring(0, 10); // First 4 bytes (8 characters) + '0x' prefix
+>>>>>>> df0ec361 (Simplify and improve redadbility of code)
   }
 }

--- a/packages/relay/src/utils.ts
+++ b/packages/relay/src/utils.ts
@@ -18,14 +18,14 @@
  *
  */
 
-import { PrivateKey } from '@hashgraph/sdk';
-import { keccak256, toUtf8Bytes } from 'ethers';
-import constants from './lib/constants';
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
+import { PrivateKey } from '@hashgraph/sdk';
 import crypto from 'crypto';
+import { keccak256, toUtf8Bytes } from 'ethers';
 import createHash from 'keccak';
 
 import { hexToASCII, prepend0x, strip0x } from './formatters';
+import constants from './lib/constants';
 
 export class Utils {
   public static readonly IP_ADDRESS_REGEX = /\b((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}\b/g;
@@ -129,7 +129,6 @@ export class Utils {
     );
   }
 
-<<<<<<< HEAD
   /**
    * Computes the Keccak-256 hash of a transaction buffer and prepends '0x'
    * @param {Buffer} transactionBuffer - The raw transaction buffer to hash
@@ -137,10 +136,20 @@ export class Utils {
    */
   public static computeTransactionHash(transactionBuffer: Buffer): string {
     return prepend0x(createHash('keccak256').update(transactionBuffer).digest('hex'));
-=======
+  }
+
+  /**
+   * Calculates the function selector from a given function signature.
+   *
+   * This method takes a function signature as a string, converts it to UTF-8 bytes,
+   * generates a Keccak-256 hash, and returns the first 4 bytes (8 characters) of the hash
+   * prefixed with '0x'.
+   *
+   * @param {string} functionSignature - The function signature to calculate the selector from.
+   * @returns {string} The calculated function selector as a string prefixed with '0x'.
+   */
   public static calculateFunctionSelector(functionSignature: string): string {
     const hash = keccak256(toUtf8Bytes(functionSignature));
     return hash.substring(0, 10); // First 4 bytes (8 characters) + '0x' prefix
->>>>>>> df0ec361 (Simplify and improve redadbility of code)
   }
 }

--- a/packages/relay/src/utils.ts
+++ b/packages/relay/src/utils.ts
@@ -137,19 +137,4 @@ export class Utils {
   public static computeTransactionHash(transactionBuffer: Buffer): string {
     return prepend0x(createHash('keccak256').update(transactionBuffer).digest('hex'));
   }
-
-  /**
-   * Calculates the function selector from a given function signature.
-   *
-   * This method takes a function signature as a string, converts it to UTF-8 bytes,
-   * generates a Keccak-256 hash, and returns the first 4 bytes (8 characters) of the hash
-   * prefixed with '0x'.
-   *
-   * @param {string} functionSignature - The function signature to calculate the selector from.
-   * @returns {string} The calculated function selector as a string prefixed with '0x'.
-   */
-  public static calculateFunctionSelector(functionSignature: string): string {
-    const hash = keccak256(toUtf8Bytes(functionSignature));
-    return hash.substring(0, 10); // First 4 bytes (8 characters) + '0x' prefix
-  }
 }

--- a/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
@@ -76,7 +76,14 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
   const accounts: AliasAccount[] = [];
   let requestId;
 
-  let IERC20Metadata, IERC20, IERC721Metadata, IERC721Enumerable, IERC721, TokenManager, TokenManagementSigner;
+  let IERC20Metadata,
+    IERC20,
+    IERC721Metadata,
+    IERC721Enumerable,
+    IERC721,
+    TokenManager,
+    TokenManagementSigner,
+    IHederaTokenService;
   let nftSerial,
     tokenAddress,
     nftAddress,
@@ -92,6 +99,8 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
     tokenAddressFractionalFees,
     tokenAddressAllFees,
     nftAddressRoyaltyFees,
+    tokenAddresses,
+    nftAddresses,
     createTokenCost;
 
   before(async () => {
@@ -665,6 +674,14 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
       ];
     });
 
+    async function getTokenInfoFromMirrorNode(transactionHash: string) {
+      setTimeout(() => {
+        console.log('waiting for mirror node...');
+      }, 1000);
+      const tokenInfo = await mirrorNode.get(`contracts/results/${transactionHash}`);
+      return tokenInfo;
+    }
+
     it('calls createFungibleToken', async () => {
       const contract = new ethers.Contract(HTS_SYTEM_CONTRACT_ADDRESS, IHederaTokenServiceJson.abi, accounts[0].wallet);
       const tx = await contract.createFungibleToken(myImmutableFungibleToken, 100, 18, {
@@ -673,7 +690,11 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
       });
       const receipt = await tx.wait();
 
-      expect(receipt.address).to.not.equal(HTS_SYTEM_CONTRACT_ADDRESS);
+      const tokenInfo = await getTokenInfoFromMirrorNode(receipt.hash);
+      const tokenAddress = receipt.contractAddress.toLowerCase();
+
+      expect(tokenAddress).to.not.equal(HTS_SYTEM_CONTRACT_ADDRESS);
+      expect(tokenAddress).to.equal(`0x${tokenInfo.call_result.substring(90).toLowerCase()}`);
     });
 
     it('calls createFungibleToken with custom fees', async () => {
@@ -692,7 +713,11 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
       );
       const receipt = await tx.wait();
 
-      expect(receipt.address).to.not.equal(HTS_SYTEM_CONTRACT_ADDRESS);
+      const tokenInfo = await getTokenInfoFromMirrorNode(receipt.hash);
+      const tokenAddress = receipt.contractAddress.toLowerCase();
+
+      expect(tokenAddress).to.not.equal(HTS_SYTEM_CONTRACT_ADDRESS);
+      expect(tokenAddress).to.equal(`0x${tokenInfo.call_result.substring(90).toLowerCase()}`);
     });
 
     it('calls createNonFungibleToken', async () => {
@@ -703,19 +728,14 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
       });
       const receipt = await tx.wait();
 
-      expect(receipt.address).to.not.equal(HTS_SYTEM_CONTRACT_ADDRESS);
+      const tokenInfo = await getTokenInfoFromMirrorNode(receipt.hash);
+      const tokenAddress = receipt.contractAddress.toLowerCase();
+
+      expect(tokenAddress).to.not.equal(HTS_SYTEM_CONTRACT_ADDRESS);
+      expect(tokenAddress).to.equal(`0x${tokenInfo.call_result.substring(90).toLowerCase()}`);
     });
 
     it('calls createNonFungibleToken with fees', async () => {
-      const fixedFee = [
-        {
-          amount: 10,
-          tokenId: ethers.ZeroAddress,
-          useHbarsForPayment: true,
-          useCurrentTokenForPayment: false,
-          feeCollector: accounts[0].wallet.address,
-        },
-      ];
       const royaltyFee = [
         {
           numerator: 10,
@@ -733,7 +753,11 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
       });
       const receipt = await tx.wait();
 
-      expect(receipt.address).to.not.equal(HTS_SYTEM_CONTRACT_ADDRESS);
+      const tokenInfo = await getTokenInfoFromMirrorNode(receipt.hash);
+      const tokenAddress = receipt.contractAddress.toLowerCase();
+
+      expect(tokenAddress).to.not.equal(HTS_SYTEM_CONTRACT_ADDRESS);
+      expect(tokenAddress).to.equal(`0x${tokenInfo.call_result.substring(90).toLowerCase()}`);
     });
   });
 

--- a/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
+++ b/packages/server/tests/acceptance/htsPrecompile/precompileCalls.spec.ts
@@ -85,7 +85,6 @@ describe('@precompile-calls Tests for eth_call with HTS', async function () {
     adminAccountLongZero,
     account1LongZero,
     account2LongZero;
-  myNFT, myImmutableFungibleToken;
 
   let tokenAddressFixedHbarFees,
     tokenAddressFixedTokenFees,


### PR DESCRIPTION
**Description**:

#### Changes

- Added `getContractAddressFromReceipt` method to:
  - Detect if a transaction is a token creation call to the HTS system contract by checking function selectors
  - Extract the token's EVM address from the call result for HTS token creation transactions
  - Return the appropriate contract address in the transaction receipt

#### Technical Details

- The method checks if the transaction's function selector matches any of the HTS token creation methods defined in `HTS_CREATE_FUNCTIONS_SELECTORS`
- For HTS token creations, extracts the token address from the call_result a.k.a the method response
- For regular contract deployments, returns the original contract address

#### Impact

This change improves compatibility with Ethereum tooling by ensuring that token creation transactions return the correct token address in their receipts, making it easier for users to

**Related issue(s)**:

Fixes #3249 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
