### PR TITLE
fix: Add websocket-batch-n to needs clause in manual-testing

### DIFF
--- a/.github/workflows/manual-testing.yml
+++ b/.github/workflows/manual-testing.yml
@@ -187,7 +187,9 @@ jobs:
       - tokenmanagement
       - htsprecompilev1
       - precompilecalls
-      - websocket
+      - websocket-batch-1
+      - websocket-batch-2
+      - websocket-batch-3
       - cacheservice
 
     runs-on: smart-contracts-linux-medium


### PR DESCRIPTION
**Description**:

Fixes breaking change in manual-testing.yaml where websocket was split into three batches but the batches were not included in the publish-results needs clause.

**Related Issue(s)**:

Fixes #3306

**Notes for Reviewer**:

- [x] Tested: [workflow validity](https://github.com/hashgraph/hedera-json-rpc-relay/actions/runs/12161730410)
