### PR TITLE
fix: improves getContractAddressFromReceipt

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2390,8 +2390,8 @@ export class EthImpl implements Eth {
     }
 
     // Handle system contract creation
-    // reason for substring from the 90th character is described in the design doc in this repo: docs/design/hts_address_tx_receipt.md
-    const tokenAddress = receiptResponse.call_result.substring(90);
+    // reason for substring is described in the design doc in this repo: docs/design/hts_address_tx_receipt.md
+    const tokenAddress = receiptResponse.call_result.substring(receiptResponse.call_result.length - 40);
     return prepend0x(tokenAddress);
   }
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
#### Changes
Changed method getContractAddressFromReceipt to align with design doc and be more clear


#### Technical Details

The reason we substring the last 40 characters is the fact that the last 20 bytes are the returned tokenAddress as a response

**Related issue(s)**:

Fixes #3322 


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
