### PR TITLE
fix: enhanced reliability of eth RPC methods with null checks and retry mechanisms

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -1,8 +1,8 @@
-/* -
+/*-
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -620,7 +620,10 @@ export class MirrorNodeClient {
       requestDetails,
     );
 
-    await this.cacheService.set(cachedLabel, block, MirrorNodeClient.GET_BLOCK_ENDPOINT, requestDetails);
+    if (block) {
+      await this.cacheService.set(cachedLabel, block, MirrorNodeClient.GET_BLOCK_ENDPOINT, requestDetails);
+    }
+
     return block;
   }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -724,6 +724,11 @@ export class SDKClient {
       );
       return transactionResponse;
     } catch (e: any) {
+      this.logger.warn(
+        e,
+        `${requestDetails.formattedRequestId} Transaction failed while executing transaction via the SDK: transactionId=${transaction.transactionId}, callerName=${callerName}, txConstructorName=${txConstructorName}`,
+      );
+
       if (e instanceof JsonRpcError) {
         throw e;
       }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2,7 +2,7 @@
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1922,13 +1922,17 @@ export class EthImpl implements Eth {
     transactionIndex: string,
     requestDetails: RequestDetails,
   ): Promise<Transaction | null> {
-    const contractResults = await this.mirrorNodeClient.getContractResults(
+    const contractResults = await this.mirrorNodeClient.getContractResultWithRetry(
+      this.mirrorNodeClient.getContractResults.name,
+      [
+        requestDetails,
+        {
+          [blockParam.title]: blockParam.value,
+          transactionIndex: Number(transactionIndex),
+        },
+        undefined,
+      ],
       requestDetails,
-      {
-        [blockParam.title]: blockParam.value,
-        transactionIndex: Number(transactionIndex),
-      },
-      undefined,
     );
 
     if (!contractResults[0]) return null;
@@ -2540,10 +2544,11 @@ export class EthImpl implements Eth {
     if (blockResponse == null) return null;
     const timestampRange = blockResponse.timestamp;
     const timestampRangeParams = [`gte:${timestampRange.from}`, `lte:${timestampRange.to}`];
-    const contractResults = await this.mirrorNodeClient.getContractResults(
+
+    const contractResults = await this.mirrorNodeClient.getContractResultWithRetry(
+      this.mirrorNodeClient.getContractResults.name,
+      [requestDetails, { timestamp: timestampRangeParams }, undefined],
       requestDetails,
-      { timestamp: timestampRangeParams },
-      undefined,
     );
     const gasUsed = blockResponse.gas_used;
     const params = { timestamp: timestampRangeParams };

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1,8 +1,8 @@
-/* -
+/*-
  *
  * Hedera JSON RPC Relay
  *
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2201,7 +2201,11 @@ export class EthImpl implements Eth {
       this.logger.trace(`${requestIdPrefix} getTransactionByHash(hash=${hash})`, hash);
     }
 
-    const contractResult = await this.mirrorNodeClient.getContractResultWithRetry(hash, requestDetails);
+    const contractResult = await this.mirrorNodeClient.getContractResultWithRetry(
+      this.mirrorNodeClient.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     if (contractResult === null || contractResult.hash === undefined) {
       // handle synthetic transactions
       const syntheticLogs = await this.common.getLogsWithParams(
@@ -2265,7 +2269,12 @@ export class EthImpl implements Eth {
       return cachedResponse;
     }
 
-    const receiptResponse = await this.mirrorNodeClient.getContractResultWithRetry(hash, requestDetails);
+    const receiptResponse = await this.mirrorNodeClient.getContractResultWithRetry(
+      this.mirrorNodeClient.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
+
     if (receiptResponse === null || receiptResponse.hash === undefined) {
       // handle synthetic transactions
       const syntheticLogs = await this.common.getLogsWithParams(

--- a/packages/relay/src/lib/services/debugService/index.ts
+++ b/packages/relay/src/lib/services/debugService/index.ts
@@ -18,18 +18,19 @@
  *
  */
 
+import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import type { Logger } from 'pino';
-import type { MirrorNodeClient } from '../../clients';
-import type { IDebugService } from './IDebugService';
-import type { CommonService } from '../ethService';
+
 import { decodeErrorMessage, mapKeysAndValues, numberTo0x, strip0x } from '../../../formatters';
+import type { MirrorNodeClient } from '../../clients';
+import { IOpcode } from '../../clients/models/IOpcode';
+import { IOpcodesResponse } from '../../clients/models/IOpcodesResponse';
 import constants, { CallType, TracerType } from '../../constants';
 import { predefined } from '../../errors/JsonRpcError';
 import { EthImpl } from '../../eth';
-import { IOpcodesResponse } from '../../clients/models/IOpcodesResponse';
-import { IOpcode } from '../../clients/models/IOpcode';
 import { ICallTracerConfig, IOpcodeLoggerConfig, ITracerConfig, RequestDetails } from '../../types';
-import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
+import type { CommonService } from '../ethService';
+import type { IDebugService } from './IDebugService';
 
 /**
  * Represents a DebugService for tracing and debugging transactions and debugging
@@ -300,7 +301,11 @@ export class DebugService implements IDebugService {
     try {
       const [actionsResponse, transactionsResponse] = await Promise.all([
         this.mirrorNodeClient.getContractsResultsActions(transactionHash, requestDetails),
-        this.mirrorNodeClient.getContractResultWithRetry(transactionHash, requestDetails),
+        this.mirrorNodeClient.getContractResultWithRetry(
+          this.mirrorNodeClient.getContractResult.name,
+          [transactionHash, requestDetails],
+          requestDetails,
+        ),
       ]);
       if (!actionsResponse || !transactionsResponse) {
         throw predefined.RESOURCE_NOT_FOUND(`Failed to retrieve contract results for transaction ${transactionHash}`);

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -18,19 +18,20 @@
  *
  */
 
+import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
+import * as _ from 'lodash';
+import { Logger } from 'pino';
+
+import { nullableNumberTo0x, numberTo0x, parseNumericEnvVar, toHash32 } from '../../../../formatters';
+import { MirrorNodeClient } from '../../../clients';
 import constants from '../../../constants';
 import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
-import { ICommonService } from './ICommonService';
-import { Logger } from 'pino';
-import { MirrorNodeClient } from '../../../clients';
-import { nullableNumberTo0x, numberTo0x, parseNumericEnvVar, toHash32 } from '../../../../formatters';
-import { SDKClientError } from '../../../errors/SDKClientError';
 import { MirrorNodeClientError } from '../../../errors/MirrorNodeClientError';
+import { SDKClientError } from '../../../errors/SDKClientError';
 import { Log } from '../../../model';
-import * as _ from 'lodash';
-import { CacheService } from '../../cacheService/cacheService';
-import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { RequestDetails } from '../../../types';
+import { CacheService } from '../../cacheService/cacheService';
+import { ICommonService } from './ICommonService';
 
 /**
  * Create a new Common Service implementation.
@@ -334,7 +335,7 @@ export class CommonService implements ICommonService {
         new Log({
           address: log.address,
           blockHash: toHash32(log.block_hash),
-          blockNumber: numberTo0x(log.block_number),
+          blockNumber: nullableNumberTo0x(log.block_number),
           data: log.data,
           logIndex: nullableNumberTo0x(log.index),
           removed: false,

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -346,13 +346,28 @@ export class CommonService implements ICommonService {
 
     const logs: Log[] = [];
     for (const log of logResults) {
+      if (log.block_number == null || log.index == null || log.block_hash === EthImpl.emptyHex) {
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.debug(
+            `${
+              requestDetails.formattedRequestId
+            } Log entry is missing required fields: block_number, index, or block_hash is an empty hex (0x). log=${JSON.stringify(
+              log,
+            )}`,
+          );
+        }
+        throw predefined.INTERNAL_ERROR(
+          `The log entry from the remote Mirror Node server is missing required fields. `,
+        );
+      }
+
       logs.push(
         new Log({
           address: log.address,
           blockHash: toHash32(log.block_hash),
-          blockNumber: nullableNumberTo0x(log.block_number),
+          blockNumber: numberTo0x(log.block_number),
           data: log.data,
-          logIndex: nullableNumberTo0x(log.index),
+          logIndex: numberTo0x(log.index),
           removed: false,
           topics: log.topics,
           transactionHash: toHash32(log.transaction_hash),

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -28,6 +28,7 @@ import constants from '../../../constants';
 import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
 import { MirrorNodeClientError } from '../../../errors/MirrorNodeClientError';
 import { SDKClientError } from '../../../errors/SDKClientError';
+import { EthImpl } from '../../../eth';
 import { Log } from '../../../model';
 import { RequestDetails } from '../../../types';
 import { CacheService } from '../../cacheService/cacheService';
@@ -176,6 +177,20 @@ export class CommonService implements ICommonService {
     returnLatest?: boolean,
   ): Promise<any> {
     if (!returnLatest && this.blockTagIsLatestOrPending(blockNumberOrTagOrHash)) {
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          `${requestDetails.formattedRequestId} Detected a contradiction between blockNumberOrTagOrHash and returnLatest. The request does not target the latest block, yet blockNumberOrTagOrHash representing latest or pending: returnLatest=${returnLatest}, blockNumberOrTagOrHash=${blockNumberOrTagOrHash}`,
+        );
+      }
+      return null;
+    }
+
+    if (blockNumberOrTagOrHash === EthImpl.emptyHex) {
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          `${requestDetails.formattedRequestId} Invalid input detected in getHistoricalBlockResponse(): blockNumberOrTagOrHash=${blockNumberOrTagOrHash}.`,
+        );
+      }
       return null;
     }
 

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -322,7 +322,7 @@ export class CommonService implements ICommonService {
     if (address) {
       logResults = await this.getLogsByAddress(address, params, requestDetails);
     } else {
-      logResults = await this.mirrorNodeClient.getContractResultsLogs(requestDetails, params);
+      logResults = await this.mirrorNodeClient.getContractResultsLogsWithRetry(requestDetails, params);
     }
 
     if (!logResults) {

--- a/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
@@ -367,28 +367,34 @@ describe('@ethGetBlockByHash using MirrorNode', async function () {
     });
   });
 
-  it('eth_getBlockByHash should gracefully handle nulbale entities found in logs', async function () {
+  it('eth_getBlockByHash should throw an error if nulbale entities found in logs', async function () {
     // mirror node request mocks
     restMock.onGet(`blocks/${BLOCK_HASH}`).reply(200, DEFAULT_BLOCK);
     restMock.onGet(CONTRACT_RESULTS_WITH_FILTER_URL).reply(200, defaultContractResults);
     restMock.onGet('network/fees').reply(200, DEFAULT_NETWORK_FEES);
 
-    const nullEntitiedLogs = {
-      logs: [{ ...DEFAULT_LOGS.logs[0], block_number: null, transaction_index: null, logIndex: null }],
-    };
+    const nullEntitiedLogs = [
+      {
+        logs: [{ ...DEFAULT_LOGS.logs[0], block_number: null }],
+      },
+      {
+        logs: [{ ...DEFAULT_LOGS.logs[0], index: null }],
+      },
+      {
+        logs: [{ ...DEFAULT_LOGS.logs[0], block_hash: '0x' }],
+      },
+    ];
 
-    restMock.onGet(CONTRACT_RESULTS_LOGS_WITH_FILTER_URL).reply(200, nullEntitiedLogs);
+    for (const logEntry of nullEntitiedLogs) {
+      try {
+        restMock.onGet(CONTRACT_RESULTS_LOGS_WITH_FILTER_URL).reply(200, logEntry);
 
-    const result = await ethImpl.getBlockByHash(BLOCK_HASH, false, requestDetails);
-
-    RelayAssertions.assertBlock(result, {
-      hash: BLOCK_HASH_TRIMMED,
-      gasUsed: TOTAL_GAS_USED,
-      number: BLOCK_NUMBER_HEX,
-      parentHash: BLOCK_HASH_PREV_TRIMMED,
-      timestamp: BLOCK_TIMESTAMP_HEX,
-      transactions: [CONTRACT_HASH_1, CONTRACT_HASH_2],
-      receiptsRoot: DEFAULT_BLOCK_RECEIPTS_ROOT_HASH,
-    });
+        await ethImpl.getBlockByHash(BLOCK_HASH, false, requestDetails);
+        expect.fail('should have thrown an error');
+      } catch (error) {
+        expect(error).to.exist;
+        expect(error.message).to.include('The log entry from the remote Mirror Node server is missing required fields');
+      }
+    }
   });
 });

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -19,22 +19,24 @@
  */
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
-import { expect } from 'chai';
-import { Registry } from 'prom-client';
-import { MirrorNodeClient } from '../../src/lib/clients';
-import constants from '../../src/lib/constants';
 import axios, { AxiosInstance } from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { getRequestId, mockData, random20BytesAddress, withOverriddenEnvsInMochaTest } from '../helpers';
-import pino from 'pino';
+import { expect } from 'chai';
 import { ethers } from 'ethers';
+import pino from 'pino';
+import { Registry } from 'prom-client';
+
 import { MirrorNodeClientError, predefined } from '../../src';
+import { MirrorNodeClient } from '../../src/lib/clients';
+import constants from '../../src/lib/constants';
 import { CacheService } from '../../src/lib/services/cacheService/cacheService';
+import { getRequestId, mockData, random20BytesAddress, withOverriddenEnvsInMochaTest } from '../helpers';
 
 const registry = new Registry();
-import { MirrorNodeTransactionRecord, RequestDetails } from '../../src/lib/types';
-import { SDKClientError } from '../../src/lib/errors/SDKClientError';
 import { BigNumber } from 'bignumber.js';
+
+import { SDKClientError } from '../../src/lib/errors/SDKClientError';
+import { MirrorNodeTransactionRecord, RequestDetails } from '../../src/lib/types';
 
 const logger = pino();
 const noTransactions = '?transactions=false';
@@ -83,7 +85,7 @@ describe('MirrorNodeClient', async function () {
 
     for (const code of nullResponseCodes) {
       it(`returns null when ${code} is returned`, async () => {
-        let error = new Error('test error');
+        const error = new Error('test error');
         error['response'] = 'test error';
 
         const result = mirrorNodeInstance.handleError(
@@ -101,7 +103,7 @@ describe('MirrorNodeClient', async function () {
     for (const code of errorRepsonseCodes) {
       it(`throws an error when ${code} is returned`, async () => {
         try {
-          let error = new Error('test error');
+          const error = new Error('test error');
           error['response'] = 'test error';
           mirrorNodeInstance.handleError(
             error,
@@ -568,7 +570,11 @@ describe('MirrorNodeClient', async function () {
     const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6399';
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
@@ -585,7 +591,11 @@ describe('MirrorNodeClient', async function () {
     mock.onGet(`contracts/results/${hash}`).replyOnce(200, { ...detailedContractResult, transaction_index: undefined });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
@@ -601,7 +611,11 @@ describe('MirrorNodeClient', async function () {
       .replyOnce(200, { ...detailedContractResult, transaction_index: undefined, block_number: undefined });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
@@ -616,7 +630,11 @@ describe('MirrorNodeClient', async function () {
     mock.onGet(`contracts/results/${hash}`).replyOnce(200, { ...detailedContractResult, block_number: undefined });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
@@ -630,7 +648,11 @@ describe('MirrorNodeClient', async function () {
     mock.onGet(`contracts/results/${hash}`).replyOnce(200, { ...detailedContractResult, block_hash: '0x' });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.block_hash).equal(detailedContractResult.block_hash);
     expect(mock.history.get.length).to.eq(2);
@@ -646,7 +668,11 @@ describe('MirrorNodeClient', async function () {
     });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.transaction_index).equal(detailedContractResult.transaction_index);
     expect(result.block_number).equal(detailedContractResult.block_number);
@@ -1558,7 +1584,7 @@ describe('MirrorNodeClient', async function () {
 
     it('should fetch contract for existing contract from cache on additional calls', async () => {
       mock.onGet(contractPath).reply(200, mockData.contract);
-      let id = await mirrorNodeInstance.getContractId(evmAddress, requestDetails);
+      const id = await mirrorNodeInstance.getContractId(evmAddress, requestDetails);
       expect(id).to.exist;
       expect(id).to.be.equal(mockData.contract.contract_id);
 

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -795,7 +795,7 @@ describe('MirrorNodeClient', async function () {
   it('`getContractResultsLogs` ', async () => {
     mock.onGet(`contracts/results/logs?limit=100&order=asc`).reply(200, { logs: [log] });
 
-    const results = await mirrorNodeInstance.getContractResultsLogs(requestDetails);
+    const results = await mirrorNodeInstance.getContractResultsLogsWithRetry(requestDetails);
     expect(results).to.exist;
     expect(results.length).to.gt(0);
     const firstResult = results[0];

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -1672,6 +1672,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
           const signedTx = await accounts[0].wallet.signTransaction(tx);
           const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
+          await relay.pollForValidTransactionReceipt(transactionHash);
+
           const info = await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
 
           expect(info).to.exist;


### PR DESCRIPTION
**Description**:
Numerous requests for `eth_getBlockByNumber` and `eth_getBlockByHash` have been reported as failing with errors such as `Cannot read properties of null` and `Received an invalid integer type: null`. 

Additionally, `eth_getTransactionReceipt` is also reported to be failing with `Error invoking RPC: Invalid parameter: hashOrNumber`.

These issues stem from regressions in the `getBlock()` method, which lacks adequate null checks in certain areas. This pull request addresses the problem by implementing proper null checks and enhancing fallback mechanisms and error handling.

Partially, the results of contracts and log responses from the Mirror Node occasionally contain undefined fields, such as transaction_index, block_hash, block_number, and log_index. This issue may arise because the Mirror Node database does not have sufficient time to save all the information before it is fetched. This PR adds a retry mechanism to the fetching methods that checks for these cases, waits for a specified duration, and then retries the fetch operation.

**Related issue(s)**:

Fixes #3345
Fixes #3351

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
