### PR TITLE
chore: cherry pick #3349 - fix: enhanced reliability of eth RPC methods with null checks and retry mechanisms to release/0.63

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -724,6 +724,11 @@ export class SDKClient {
       );
       return transactionResponse;
     } catch (e: any) {
+      this.logger.warn(
+        e,
+        `${requestDetails.formattedRequestId} Transaction failed while executing transaction via the SDK: transactionId=${transaction.transactionId}, callerName=${callerName}, txConstructorName=${txConstructorName}`,
+      );
+
       if (e instanceof JsonRpcError) {
         throw e;
       }

--- a/packages/relay/src/lib/services/debugService/index.ts
+++ b/packages/relay/src/lib/services/debugService/index.ts
@@ -18,18 +18,19 @@
  *
  */
 
+import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import type { Logger } from 'pino';
-import type { MirrorNodeClient } from '../../clients';
-import type { IDebugService } from './IDebugService';
-import type { CommonService } from '../ethService';
+
 import { decodeErrorMessage, mapKeysAndValues, numberTo0x, strip0x } from '../../../formatters';
+import type { MirrorNodeClient } from '../../clients';
+import { IOpcode } from '../../clients/models/IOpcode';
+import { IOpcodesResponse } from '../../clients/models/IOpcodesResponse';
 import constants, { CallType, TracerType } from '../../constants';
 import { predefined } from '../../errors/JsonRpcError';
 import { EthImpl } from '../../eth';
-import { IOpcodesResponse } from '../../clients/models/IOpcodesResponse';
-import { IOpcode } from '../../clients/models/IOpcode';
 import { ICallTracerConfig, IOpcodeLoggerConfig, ITracerConfig, RequestDetails } from '../../types';
-import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
+import type { CommonService } from '../ethService';
+import type { IDebugService } from './IDebugService';
 
 /**
  * Represents a DebugService for tracing and debugging transactions and debugging
@@ -300,7 +301,11 @@ export class DebugService implements IDebugService {
     try {
       const [actionsResponse, transactionsResponse] = await Promise.all([
         this.mirrorNodeClient.getContractsResultsActions(transactionHash, requestDetails),
-        this.mirrorNodeClient.getContractResultWithRetry(transactionHash, requestDetails),
+        this.mirrorNodeClient.getContractResultWithRetry(
+          this.mirrorNodeClient.getContractResult.name,
+          [transactionHash, requestDetails],
+          requestDetails,
+        ),
       ]);
       if (!actionsResponse || !transactionsResponse) {
         throw predefined.RESOURCE_NOT_FOUND(`Failed to retrieve contract results for transaction ${transactionHash}`);

--- a/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
@@ -19,20 +19,21 @@
  */
 
 import { expect, use } from 'chai';
-import sinon from 'sinon';
 import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
 
+import { ASCIIToHex, numberTo0x, prepend0x } from '../../../dist/formatters';
 import { predefined } from '../../../src';
+import { SDKClient } from '../../../src/lib/clients';
 import { EthImpl } from '../../../src/lib/eth';
+import { RequestDetails } from '../../../src/lib/types';
+import RelayAssertions from '../../assertions';
 import {
   blockLogsBloom,
   defaultContractResults,
   defaultDetailedContractResults,
   overrideEnvsInMochaDescribe,
 } from '../../helpers';
-import { SDKClient } from '../../../src/lib/clients';
-import RelayAssertions from '../../assertions';
-import { ASCIIToHex, numberTo0x, prepend0x } from '../../../dist/formatters';
 import {
   ACCOUNT_WITHOUT_TRANSACTIONS,
   BLOCK_HASH,
@@ -54,13 +55,13 @@ import {
   DEFAULT_BLOCK_RECEIPTS_ROOT_HASH,
   DEFAULT_CONTRACT,
   DEFAULT_ETH_GET_BLOCK_BY_LOGS,
+  DEFAULT_LOGS,
   DEFAULT_NETWORK_FEES,
   LINKS_NEXT_RES,
   MOCK_ACCOUNT_WITHOUT_TRANSACTIONS,
   NO_SUCH_BLOCK_EXISTS_RES,
 } from './eth-config';
 import { generateEthTestEnv } from './eth-helpers';
-import { RequestDetails } from '../../../src/lib/types';
 
 use(chaiAsPromised);
 
@@ -70,7 +71,7 @@ let ethImplLowTransactionCount: EthImpl;
 
 describe('@ethGetBlockByHash using MirrorNode', async function () {
   this.timeout(10000);
-  let { restMock, hapiServiceInstance, ethImpl, cacheService, mirrorNodeInstance, logger, registry } =
+  const { restMock, hapiServiceInstance, ethImpl, cacheService, mirrorNodeInstance, logger, registry } =
     generateEthTestEnv(true);
   const results = defaultContractResults.results;
   const TOTAL_GAS_USED = numberTo0x(results[0].gas_used + results[1].gas_used);
@@ -364,5 +365,36 @@ describe('@ethGetBlockByHash using MirrorNode', async function () {
         showDetails,
       );
     });
+  });
+
+  it('eth_getBlockByHash should throw an error if nulbale entities found in logs', async function () {
+    // mirror node request mocks
+    restMock.onGet(`blocks/${BLOCK_HASH}`).reply(200, DEFAULT_BLOCK);
+    restMock.onGet(CONTRACT_RESULTS_WITH_FILTER_URL).reply(200, defaultContractResults);
+    restMock.onGet('network/fees').reply(200, DEFAULT_NETWORK_FEES);
+
+    const nullEntitiedLogs = [
+      {
+        logs: [{ ...DEFAULT_LOGS.logs[0], block_number: null }],
+      },
+      {
+        logs: [{ ...DEFAULT_LOGS.logs[0], index: null }],
+      },
+      {
+        logs: [{ ...DEFAULT_LOGS.logs[0], block_hash: '0x' }],
+      },
+    ];
+
+    for (const logEntry of nullEntitiedLogs) {
+      try {
+        restMock.onGet(CONTRACT_RESULTS_LOGS_WITH_FILTER_URL).reply(200, logEntry);
+
+        await ethImpl.getBlockByHash(BLOCK_HASH, false, requestDetails);
+        expect.fail('should have thrown an error');
+      } catch (error) {
+        expect(error).to.exist;
+        expect(error.message).to.include('The log entry from the remote Mirror Node server is missing required fields');
+      }
+    }
   });
 });

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -19,22 +19,24 @@
  */
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
-import { expect } from 'chai';
-import { Registry } from 'prom-client';
-import { MirrorNodeClient } from '../../src/lib/clients';
-import constants from '../../src/lib/constants';
 import axios, { AxiosInstance } from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { getRequestId, mockData, random20BytesAddress, withOverriddenEnvsInMochaTest } from '../helpers';
-import pino from 'pino';
+import { expect } from 'chai';
 import { ethers } from 'ethers';
+import pino from 'pino';
+import { Registry } from 'prom-client';
+
 import { MirrorNodeClientError, predefined } from '../../src';
+import { MirrorNodeClient } from '../../src/lib/clients';
+import constants from '../../src/lib/constants';
 import { CacheService } from '../../src/lib/services/cacheService/cacheService';
+import { getRequestId, mockData, random20BytesAddress, withOverriddenEnvsInMochaTest } from '../helpers';
 
 const registry = new Registry();
-import { MirrorNodeTransactionRecord, RequestDetails } from '../../src/lib/types';
-import { SDKClientError } from '../../src/lib/errors/SDKClientError';
 import { BigNumber } from 'bignumber.js';
+
+import { SDKClientError } from '../../src/lib/errors/SDKClientError';
+import { MirrorNodeTransactionRecord, RequestDetails } from '../../src/lib/types';
 
 const logger = pino();
 const noTransactions = '?transactions=false';
@@ -83,7 +85,7 @@ describe('MirrorNodeClient', async function () {
 
     for (const code of nullResponseCodes) {
       it(`returns null when ${code} is returned`, async () => {
-        let error = new Error('test error');
+        const error = new Error('test error');
         error['response'] = 'test error';
 
         const result = mirrorNodeInstance.handleError(
@@ -101,7 +103,7 @@ describe('MirrorNodeClient', async function () {
     for (const code of errorRepsonseCodes) {
       it(`throws an error when ${code} is returned`, async () => {
         try {
-          let error = new Error('test error');
+          const error = new Error('test error');
           error['response'] = 'test error';
           mirrorNodeInstance.handleError(
             error,
@@ -568,7 +570,11 @@ describe('MirrorNodeClient', async function () {
     const hash = '0x4a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6399';
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
@@ -585,7 +591,11 @@ describe('MirrorNodeClient', async function () {
     mock.onGet(`contracts/results/${hash}`).replyOnce(200, { ...detailedContractResult, transaction_index: undefined });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
@@ -601,7 +611,11 @@ describe('MirrorNodeClient', async function () {
       .replyOnce(200, { ...detailedContractResult, transaction_index: undefined, block_number: undefined });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
@@ -616,7 +630,11 @@ describe('MirrorNodeClient', async function () {
     mock.onGet(`contracts/results/${hash}`).replyOnce(200, { ...detailedContractResult, block_number: undefined });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.contract_id).equal(detailedContractResult.contract_id);
     expect(result.to).equal(detailedContractResult.to);
@@ -630,7 +648,11 @@ describe('MirrorNodeClient', async function () {
     mock.onGet(`contracts/results/${hash}`).replyOnce(200, { ...detailedContractResult, block_hash: '0x' });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.block_hash).equal(detailedContractResult.block_hash);
     expect(mock.history.get.length).to.eq(2);
@@ -646,7 +668,11 @@ describe('MirrorNodeClient', async function () {
     });
     mock.onGet(`contracts/results/${hash}`).reply(200, detailedContractResult);
 
-    const result = await mirrorNodeInstance.getContractResultWithRetry(hash, requestDetails);
+    const result = await mirrorNodeInstance.getContractResultWithRetry(
+      mirrorNodeInstance.getContractResult.name,
+      [hash, requestDetails],
+      requestDetails,
+    );
     expect(result).to.exist;
     expect(result.transaction_index).equal(detailedContractResult.transaction_index);
     expect(result.block_number).equal(detailedContractResult.block_number);
@@ -769,7 +795,7 @@ describe('MirrorNodeClient', async function () {
   it('`getContractResultsLogs` ', async () => {
     mock.onGet(`contracts/results/logs?limit=100&order=asc`).reply(200, { logs: [log] });
 
-    const results = await mirrorNodeInstance.getContractResultsLogs(requestDetails);
+    const results = await mirrorNodeInstance.getContractResultsLogsWithRetry(requestDetails);
     expect(results).to.exist;
     expect(results.length).to.gt(0);
     const firstResult = results[0];
@@ -1558,7 +1584,7 @@ describe('MirrorNodeClient', async function () {
 
     it('should fetch contract for existing contract from cache on additional calls', async () => {
       mock.onGet(contractPath).reply(200, mockData.contract);
-      let id = await mirrorNodeInstance.getContractId(evmAddress, requestDetails);
+      const id = await mirrorNodeInstance.getContractId(evmAddress, requestDetails);
       expect(id).to.exist;
       expect(id).to.be.equal(mockData.contract.contract_id);
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -1672,6 +1672,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
           const signedTx = await accounts[0].wallet.signTransaction(tx);
           const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
+          await relay.pollForValidTransactionReceipt(transactionHash);
+
           const info = await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
 
           expect(info).to.exist;


### PR DESCRIPTION
**Description**:
This PR cherry-picks [#3349: Fix: Enhanced reliability of ETH RPC methods with null checks and retry mechanisms](https://github.com/hashgraph/hedera-json-rpc-relay/pull/3349) into release/0.63.

**Related issue(s)**:

Fixes #3345 
Fixes https://github.com/hashgraph/hedera-json-rpc-relay/issues/3351

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
