### PR TITLE
chore: cherry pick #3368 fix: added polling logic to ensure the retrieval of fully mature records from MN

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -754,45 +754,75 @@ export class MirrorNodeClient {
   }
 
   /**
-   * In some very rare cases the /contracts/results api is called before all the data is saved in
-   * the mirror node DB and `transaction_index` or `block_number` is returned as `undefined` or `block_hash` as `0x`.
-   * A single re-fetch is sufficient to resolve this problem.
+   * Retrieves contract results with a retry mechanism to handle immature records.
+   * When querying the /contracts/results api, there are cases where the records are "immature" - meaning
+   * some fields are not yet properly populated in the mirror node DB at the time of the request.
+   *
+   * An immature record can be characterized by:
+   * - `transaction_index` being null/undefined
+   * - `block_number` being null/undefined
+   * - `block_hash` being '0x' (empty hex)
+   *
+   * This method implements a retry mechanism to handle immature records by polling until either:
+   * - The record matures (all fields are properly populated)
+   * - The maximum retry count is reached
    *
    * @param {string} methodName - The name of the method used to fetch contract results.
    * @param {any[]} args - The arguments to be passed to the specified method for fetching contract results.
    * @param {RequestDetails} requestDetails - Details used for logging and tracking the request.
-   * @returns {Promise<any>} - A promise resolving to the fetched contract result, either on the first attempt or after a retry.
+   * @returns {Promise<any>} - A promise resolving to the fetched contract result, either mature or the last fetched result after retries.
    */
   public async getContractResultWithRetry(
     methodName: string,
     args: any[],
     requestDetails: RequestDetails,
   ): Promise<any> {
-    const shortDelay = 500;
-    const contractResult = await this[methodName](...args);
+    const mirrorNodeRetryDelay = this.getMirrorNodeRetryDelay();
+    const mirrorNodeRequestRetryCount = this.getMirrorNodeRequestRetryCount();
 
-    if (contractResult) {
-      const contractObjects = Array.isArray(contractResult) ? contractResult : [contractResult];
-      for (const contractObject of contractObjects) {
-        if (
-          contractObject &&
-          (contractObject.transaction_index == null ||
-            contractObject.block_number == null ||
-            contractObject.block_hash == EthImpl.emptyHex)
-        ) {
-          if (this.logger.isLevelEnabled('debug')) {
-            this.logger.debug(
-              `${requestDetails.formattedRequestId} Contract result contains undefined transaction_index, block_number, or block_hash is an empty hex (0x): transaction_hash:${contractObject.hash}, transaction_index:${contractObject.transaction_index}, block_number=${contractObject.block_number}, block_hash=${contractObject.block_hash}. Retrying after a delay of ${shortDelay} ms `,
-            );
+    let contractResult = await this[methodName](...args);
+
+    for (let i = 0; i < mirrorNodeRequestRetryCount; i++) {
+      if (contractResult) {
+        const contractObjects = Array.isArray(contractResult) ? contractResult : [contractResult];
+
+        let foundImmatureRecord = false;
+
+        for (const contractObject of contractObjects) {
+          if (
+            contractObject &&
+            (contractObject.transaction_index == null ||
+              contractObject.block_number == null ||
+              contractObject.block_hash == EthImpl.emptyHex)
+          ) {
+            // Found immature record, log the info, set flag and exit record traversal
+            if (this.logger.isLevelEnabled('debug')) {
+              this.logger.debug(
+                `${
+                  requestDetails.formattedRequestId
+                } Contract result contains nullable transaction_index or block_number, or block_hash is an empty hex (0x): contract_result=${JSON.stringify(
+                  contractObject,
+                )}. Retrying after a delay of ${mirrorNodeRetryDelay} ms `,
+              );
+            }
+
+            foundImmatureRecord = true;
+            break;
           }
-
-          // Backoff before repeating request
-          await new Promise((r) => setTimeout(r, shortDelay));
-          return await this[methodName](...args);
         }
+
+        // if foundImmatureRecord is still false after record traversal, it means no immature record was found. Simply return contractResult to stop the polling process
+        if (!foundImmatureRecord) return contractResult;
+
+        // if immature record found, wait and retry and update contractResult
+        await new Promise((r) => setTimeout(r, mirrorNodeRetryDelay));
+        contractResult = await this[methodName](...args);
+      } else {
+        break;
       }
     }
 
+    // Return final result after all retry attempts, regardless of record maturity
     return contractResult;
   }
 
@@ -895,24 +925,36 @@ export class MirrorNodeClient {
   }
 
   /**
-   * In some very rare cases the /contracts/results/logs api is called before all the data is saved in
-   * the mirror node DB and `transaction_index`, `block_number`, `index` is returned as `undefined`, or block_hash is an empty hex (0x).
-   * A single re-fetch is sufficient to resolve this problem.
+   * Retrieves contract results log with a retry mechanism to handle immature records.
+   * When querying the /contracts/results/logs api, there are cases where the records are "immature" - meaning
+   * some fields are not yet properly populated in the mirror node DB at the time of the request.
+   *
+   * An immature record can be characterized by:
+   * - `transaction_index` being null/undefined
+   * - `log index` being null/undefined
+   * - `block_number` being null/undefined
+   * - `block_hash` being '0x' (empty hex)
+   *
+   * This method implements a retry mechanism to handle immature records by polling until either:
+   * - The record matures (all fields are properly populated)
+   * - The maximum retry count is reached
    *
    * @param {RequestDetails} requestDetails - Details used for logging and tracking the request.
    * @param {IContractLogsResultsParams} [contractLogsResultsParams] - Parameters for querying contract logs results.
    * @param {ILimitOrderParams} [limitOrderParams] - Parameters for limit and order when fetching the logs.
-   * @returns {Promise<any[]>} - A promise resolving to the paginated contract logs results.
+   * @returns {Promise<any[]>} - A promise resolving to the paginated contract logs results, either mature or the last fetched result after retries.
    */
   public async getContractResultsLogsWithRetry(
     requestDetails: RequestDetails,
     contractLogsResultsParams?: IContractLogsResultsParams,
     limitOrderParams?: ILimitOrderParams,
   ): Promise<any[]> {
-    const shortDelay = 500;
+    const mirrorNodeRetryDelay = this.getMirrorNodeRetryDelay();
+    const mirrorNodeRequestRetryCount = this.getMirrorNodeRequestRetryCount();
+
     const queryParams = this.prepareLogsParams(contractLogsResultsParams, limitOrderParams);
 
-    const logResults = await this.getPaginatedResults(
+    let logResults = await this.getPaginatedResults(
       `${MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT}${queryParams}`,
       MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT,
       MirrorNodeClient.CONTRACT_RESULT_LOGS_PROPERTY,
@@ -922,33 +964,50 @@ export class MirrorNodeClient {
       MirrorNodeClient.mirrorNodeContractResultsLogsPageMax,
     );
 
-    if (logResults) {
-      for (const log of logResults) {
-        if (
-          log &&
-          (log.transaction_index == null ||
-            log.block_number == null ||
-            log.index == null ||
-            log.block_hash === EthImpl.emptyHex)
-        ) {
-          if (this.logger.isLevelEnabled('debug')) {
-            this.logger.debug(
-              `${requestDetails.formattedRequestId} Contract result log contains undefined transaction_index, block_number, index, or block_hash is an empty hex (0x): transaction_hash:${log.transaction_hash}, transaction_index:${log.transaction_index}, block_number=${log.block_number}, log_index=${log.index}, block_hash=${log.block_hash}. Retrying after a delay of ${shortDelay} ms.`,
-            );
-          }
+    for (let i = 0; i < mirrorNodeRequestRetryCount; i++) {
+      if (logResults) {
+        let foundImmatureRecord = false;
 
-          // Backoff before repeating request
-          await new Promise((r) => setTimeout(r, shortDelay));
-          return await this.getPaginatedResults(
-            `${MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT}${queryParams}`,
-            MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT,
-            MirrorNodeClient.CONTRACT_RESULT_LOGS_PROPERTY,
-            requestDetails,
-            [],
-            1,
-            MirrorNodeClient.mirrorNodeContractResultsLogsPageMax,
-          );
+        for (const log of logResults) {
+          if (
+            log &&
+            (log.transaction_index == null ||
+              log.block_number == null ||
+              log.index == null ||
+              log.block_hash === EthImpl.emptyHex)
+          ) {
+            // Found immature record, log the info, set flag and exit record traversal
+            if (this.logger.isLevelEnabled('debug')) {
+              this.logger.debug(
+                `${
+                  requestDetails.formattedRequestId
+                } Contract result log contains undefined transaction_index, block_number, index, or block_hash is an empty hex (0x): log=${JSON.stringify(
+                  log,
+                )}. Retrying after a delay of ${mirrorNodeRetryDelay} ms.`,
+              );
+            }
+
+            foundImmatureRecord = true;
+            break;
+          }
         }
+
+        // if foundImmatureRecord is still false after record traversal, it means no immature record was found. Simply return logResults to stop the polling process
+        if (!foundImmatureRecord) return logResults;
+
+        // if immature record found, wait and retry and update logResults
+        await new Promise((r) => setTimeout(r, mirrorNodeRetryDelay));
+        logResults = await this.getPaginatedResults(
+          `${MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT}${queryParams}`,
+          MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_ENDPOINT,
+          MirrorNodeClient.CONTRACT_RESULT_LOGS_PROPERTY,
+          requestDetails,
+          [],
+          1,
+          MirrorNodeClient.mirrorNodeContractResultsLogsPageMax,
+        );
+      } else {
+        break;
       }
     }
 

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -346,7 +346,12 @@ export class CommonService implements ICommonService {
 
     const logs: Log[] = [];
     for (const log of logResults) {
-      if (log.block_number == null || log.index == null || log.block_hash === EthImpl.emptyHex) {
+      if (
+        log.transaction_index == null ||
+        log.block_number == null ||
+        log.index == null ||
+        log.block_hash === EthImpl.emptyHex
+      ) {
         if (this.logger.isLevelEnabled('debug')) {
           this.logger.debug(
             `${
@@ -371,7 +376,7 @@ export class CommonService implements ICommonService {
           removed: false,
           topics: log.topics,
           transactionHash: toHash32(log.transaction_hash),
-          transactionIndex: nullableNumberTo0x(log.transaction_index),
+          transactionIndex: numberTo0x(log.transaction_index),
         }),
       );
     }

--- a/packages/relay/tests/lib/eth/eth_getTransactionByHash.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionByHash.spec.ts
@@ -20,8 +20,11 @@
 
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { Transaction, Transaction2930, Transaction1559 } from '../../../src/lib/model';
+
+import { Transaction, Transaction1559, Transaction2930 } from '../../../src/lib/model';
+import { RequestDetails } from '../../../src/lib/types';
 import RelayAssertions from '../../assertions';
+import { defaultDetailedContractResultByHash, defaultFromLongZeroAddress } from '../../helpers';
 import {
   DEFAULT_DETAILED_CONTRACT_RESULT_BY_HASH_REVERTED,
   DEFAULT_TRANSACTION,
@@ -30,14 +33,13 @@ import {
   EMPTY_LOGS_RESPONSE,
   NO_TRANSACTIONS,
 } from './eth-config';
-import { defaultDetailedContractResultByHash, defaultFromLongZeroAddress } from '../../helpers';
 import { generateEthTestEnv } from './eth-helpers';
-import { RequestDetails } from '../../../src/lib/types';
 
 use(chaiAsPromised);
 
 describe('@ethGetTransactionByHash eth_getTransactionByHash tests', async function () {
-  let { restMock, ethImpl } = generateEthTestEnv();
+  this.timeout(100000);
+  const { restMock, ethImpl } = generateEthTestEnv();
   const from = '0x00000000000000000000000000000000000003f7';
   const evm_address = '0xc37f417fa09933335240fca72dd257bfbde9c275';
   const contractResultMock = {
@@ -217,7 +219,7 @@ describe('@ethGetTransactionByHash eth_getTransactionByHash tests', async functi
     if (result) expect(result.v).to.eq('0x0');
   });
 
-  it('handles transactions with undefined transaction_index', async function () {
+  it('should throw an error if transaction_index is falsy', async function () {
     const detailedResultsWithNullNullableValues = {
       ...defaultDetailedContractResultByHash,
       transaction_index: undefined,
@@ -225,14 +227,19 @@ describe('@ethGetTransactionByHash eth_getTransactionByHash tests', async functi
     const uniqueTxHash = '0x14aad7b827375d12d73af57b6a3e84353645fd31305ea58ff52dda53ec640534';
 
     restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, detailedResultsWithNullNullableValues);
-    const result = await ethImpl.getTransactionByHash(uniqueTxHash, requestDetails);
-    expect(result).to.not.be.null;
 
-    expect(result).to.exist;
-    if (result) expect(result.transactionIndex).to.be.null;
+    try {
+      await ethImpl.getTransactionByHash(uniqueTxHash, requestDetails);
+      expect.fail('should have thrown an error');
+    } catch (error) {
+      expect(error).to.exist;
+      expect(error.message).to.include(
+        'The contract result response from the remote Mirror Node server is missing required fields.',
+      );
+    }
   });
 
-  it('handles transactions with undefined block_number', async function () {
+  it('should throw an error if block_number is falsy', async function () {
     const detailedResultsWithNullNullableValues = {
       ...defaultDetailedContractResultByHash,
       block_number: undefined,
@@ -240,14 +247,18 @@ describe('@ethGetTransactionByHash eth_getTransactionByHash tests', async functi
     const uniqueTxHash = '0x14aad7b827375d12d73af57b6a3e84353645fd31305ea58ff52dda53ec640511';
 
     restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, detailedResultsWithNullNullableValues);
-    const result = await ethImpl.getTransactionByHash(uniqueTxHash, requestDetails);
-    expect(result).to.not.be.null;
-
-    expect(result).to.exist;
-    if (result) expect(result.blockNumber).to.be.null;
+    try {
+      await ethImpl.getTransactionByHash(uniqueTxHash, requestDetails);
+      expect.fail('should have thrown an error');
+    } catch (error) {
+      expect(error).to.exist;
+      expect(error.message).to.include(
+        'The contract result response from the remote Mirror Node server is missing required fields.',
+      );
+    }
   });
 
-  it('handles transactions with undefined transaction_index and block_number', async function () {
+  it('should throw an error if transaction_index and block_number are falsy', async function () {
     const detailedResultsWithNullNullableValues = {
       ...defaultDetailedContractResultByHash,
       block_number: undefined,
@@ -257,13 +268,14 @@ describe('@ethGetTransactionByHash eth_getTransactionByHash tests', async functi
     const uniqueTxHash = '0x14aad7b827375d12d73af57b6a3e84353645fd31305ea58ff52d1a53ec640511';
 
     restMock.onGet(`contracts/results/${uniqueTxHash}`).reply(200, detailedResultsWithNullNullableValues);
-    const result = await ethImpl.getTransactionByHash(uniqueTxHash, requestDetails);
-    expect(result).to.not.be.null;
-
-    expect(result).to.exist;
-    if (result) {
-      expect(result.blockNumber).to.be.null;
-      expect(result.transactionIndex).to.be.null;
+    try {
+      await ethImpl.getTransactionByHash(uniqueTxHash, requestDetails);
+      expect.fail('should have thrown an error');
+    } catch (error) {
+      expect(error).to.exist;
+      expect(error.message).to.include(
+        'The contract result response from the remote Mirror Node server is missing required fields.',
+      );
     }
   });
 


### PR DESCRIPTION
**Description**:
This PR cherry-picks [#3368 fix: added polling logic to ensure the retrieval of fully mature records from MN](https://github.com/hashgraph/hedera-json-rpc-relay/pull/3368) into release/0.63

**Related issue(s)**:

Fixes #3366 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
