### PR TITLE
feat: added DEPENDENT_SERVICE_IMMATURE_RECORDS predefined error for immature records scenarios

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -47,6 +47,10 @@ export const predefined = {
       data,
     });
   },
+  DEPENDENT_SERVICE_IMMATURE_RECORDS: new JsonRpcError({
+    code: -32015,
+    message: 'Dependent service returned immature records',
+  }),
   GAS_LIMIT_TOO_HIGH: (gasLimit, maxGas) =>
     new JsonRpcError({
       code: -32005,

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -22,7 +22,7 @@ import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services'
 import * as _ from 'lodash';
 import { Logger } from 'pino';
 
-import { nullableNumberTo0x, numberTo0x, parseNumericEnvVar, toHash32 } from '../../../../formatters';
+import { numberTo0x, parseNumericEnvVar, toHash32 } from '../../../../formatters';
 import { MirrorNodeClient } from '../../../clients';
 import constants from '../../../constants';
 import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
@@ -346,26 +346,6 @@ export class CommonService implements ICommonService {
 
     const logs: Log[] = [];
     for (const log of logResults) {
-      if (
-        log.transaction_index == null ||
-        log.block_number == null ||
-        log.index == null ||
-        log.block_hash === EthImpl.emptyHex
-      ) {
-        if (this.logger.isLevelEnabled('debug')) {
-          this.logger.debug(
-            `${
-              requestDetails.formattedRequestId
-            } Log entry is missing required fields: block_number, index, or block_hash is an empty hex (0x). log=${JSON.stringify(
-              log,
-            )}`,
-          );
-        }
-        throw predefined.INTERNAL_ERROR(
-          `The log entry from the remote Mirror Node server is missing required fields. `,
-        );
-      }
-
       logs.push(
         new Log({
           address: log.address,

--- a/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
@@ -393,7 +393,7 @@ describe('@ethGetBlockByHash using MirrorNode', async function () {
         expect.fail('should have thrown an error');
       } catch (error) {
         expect(error).to.exist;
-        expect(error.message).to.include('The log entry from the remote Mirror Node server is missing required fields');
+        expect(error).to.eq(predefined.DEPENDENT_SERVICE_IMMATURE_RECORDS);
       }
     }
   });

--- a/packages/relay/tests/lib/eth/eth_getBlockByNumber.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByNumber.spec.ts
@@ -638,7 +638,7 @@ describe('@ethGetBlockByNumber using MirrorNode', async function () {
         expect.fail('should have thrown an error');
       } catch (error) {
         expect(error).to.exist;
-        expect(error.message).to.include('The log entry from the remote Mirror Node server is missing required fields');
+        expect(error).to.eq(predefined.DEPENDENT_SERVICE_IMMATURE_RECORDS);
       }
     }
   });

--- a/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
@@ -24,7 +24,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { ethers } from 'ethers';
 import sinon from 'sinon';
 
-import { Eth } from '../../../src';
+import { Eth, predefined } from '../../../src';
 import { SDKClient } from '../../../src/lib/clients';
 import { CacheService } from '../../../src/lib/services/cacheService/cacheService';
 import HAPIService from '../../../src/lib/services/hapiService/hapiService';
@@ -195,7 +195,7 @@ describe('@ethGetLogs using MirrorNode', async function () {
       expect.fail('should have thrown an error');
     } catch (error) {
       expect(error).to.exist;
-      expect(error.message).to.include('The log entry from the remote Mirror Node server is missing required fields.');
+      expect(error).to.eq(predefined.DEPENDENT_SERVICE_IMMATURE_RECORDS);
     }
   });
 

--- a/packages/relay/tests/lib/eth/eth_getTransactionByHash.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionByHash.spec.ts
@@ -34,6 +34,7 @@ import {
   NO_TRANSACTIONS,
 } from './eth-config';
 import { generateEthTestEnv } from './eth-helpers';
+import { predefined } from '../../../src';
 
 use(chaiAsPromised);
 
@@ -233,9 +234,7 @@ describe('@ethGetTransactionByHash eth_getTransactionByHash tests', async functi
       expect.fail('should have thrown an error');
     } catch (error) {
       expect(error).to.exist;
-      expect(error.message).to.include(
-        'The contract result response from the remote Mirror Node server is missing required fields.',
-      );
+      expect(error).to.eq(predefined.DEPENDENT_SERVICE_IMMATURE_RECORDS);
     }
   });
 
@@ -252,9 +251,7 @@ describe('@ethGetTransactionByHash eth_getTransactionByHash tests', async functi
       expect.fail('should have thrown an error');
     } catch (error) {
       expect(error).to.exist;
-      expect(error.message).to.include(
-        'The contract result response from the remote Mirror Node server is missing required fields.',
-      );
+      expect(error).to.eq(predefined.DEPENDENT_SERVICE_IMMATURE_RECORDS);
     }
   });
 
@@ -273,9 +270,7 @@ describe('@ethGetTransactionByHash eth_getTransactionByHash tests', async functi
       expect.fail('should have thrown an error');
     } catch (error) {
       expect(error).to.exist;
-      expect(error.message).to.include(
-        'The contract result response from the remote Mirror Node server is missing required fields.',
-      );
+      expect(error).to.eq(predefined.DEPENDENT_SERVICE_IMMATURE_RECORDS);
     }
   });
 

--- a/packages/relay/tests/lib/eth/eth_getTransactionReceipt.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionReceipt.spec.ts
@@ -29,6 +29,7 @@ import RelayAssertions from '../../assertions';
 import { defaultErrorMessageHex } from '../../helpers';
 import { DEFAULT_BLOCK, EMPTY_LOGS_RESPONSE } from './eth-config';
 import { generateEthTestEnv } from './eth-helpers';
+import { predefined } from '../../../src';
 
 use(chaiAsPromised);
 
@@ -313,9 +314,7 @@ describe('@ethGetTransactionReceipt eth_getTransactionReceipt tests', async func
       expect.fail('should have thrown an error');
     } catch (error) {
       expect(error).to.exist;
-      expect(error.message).to.include(
-        'The contract result response from the remote Mirror Node server is missing required fields.',
-      );
+      expect(error).to.eq(predefined.DEPENDENT_SERVICE_IMMATURE_RECORDS);
     }
   });
 

--- a/packages/server/src/koaJsonRpc/lib/HttpStatusCodeAndMessage.ts
+++ b/packages/server/src/koaJsonRpc/lib/HttpStatusCodeAndMessage.ts
@@ -1,3 +1,22 @@
+/*-
+ *
+ * Hedera JSON RPC Relay
+ *
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 export class HttpStatusCodeAndMessage {
   public statusCode: number;
   public StatusName: string;
@@ -15,10 +34,12 @@ const IP_RATE_LIMIT_EXCEEDED = 'IP RATE LIMIT EXCEEDED';
 const JSON_RPC_ERROR = 'JSON RPC ERROR';
 const CONTRACT_REVERT = 'CONTRACT REVERT';
 const METHOD_NOT_FOUND = 'METHOD NOT FOUND';
+const DEPENDENT_SERVICE_IMMATURE_RECORDS = 'DEPENDENT SERVICE IMMATURE RECORDS';
 
 export const RpcErrorCodeToStatusMap = {
   '3': new HttpStatusCodeAndMessage(200, CONTRACT_REVERT),
   '-32603': new HttpStatusCodeAndMessage(500, INTERNAL_ERROR),
+  '-32015': new HttpStatusCodeAndMessage(503, DEPENDENT_SERVICE_IMMATURE_RECORDS),
   '-32600': new HttpStatusCodeAndMessage(400, INVALID_REQUEST),
   '-32602': new HttpStatusCodeAndMessage(400, INVALID_PARAMS_ERROR),
   '-32601': new HttpStatusCodeAndMessage(400, METHOD_NOT_FOUND),


### PR DESCRIPTION
**Description**:
This PR introduces a new predefined error, DEPENDENT_SERVICE_IMMATURE_RECORDS, with the JSON-RPC code `-32015`, mapped to the HTTP status code `503`. This improves error handling for cases where the dependent Mirror Node service returns immature records.

- `-32015`: Chosen as it fits within the JSON-RPC application-defined server error range (-32000 to -32099) and avoids conflicts with existing error codes.
- `HTTP 503`: Represents a temporary unavailability of a dependent service, signaling clients to retry.

**Related issue(s)**:

Fixes #3392 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
