### PR TITLE
feat: enhanced eth_getLogs with timestamp range validation and new error handling

### DIFF
--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -135,7 +135,7 @@ export const predefined = {
     }),
   TIMESTAMP_RANGE_TOO_LARGE: (fromBlock: string, fromTimestamp: number, toBlock: string, toTimestamp: number) =>
     new JsonRpcError({
-      code: -32000,
+      code: -32004,
       message: `The provided fromBlock and toBlock contain timestamps that exceed the maximum allowed duration of 7 days (604800 seconds): fromBlock: ${fromBlock} (${fromTimestamp}), toBlock: ${toBlock} (${toTimestamp})`,
     }),
   REQUEST_BEYOND_HEAD_BLOCK: (requested: number, latest: number) =>

--- a/packages/relay/src/lib/errors/JsonRpcError.ts
+++ b/packages/relay/src/lib/errors/JsonRpcError.ts
@@ -133,6 +133,11 @@ export const predefined = {
       code: -32000,
       message: `Exceeded maximum block range: ${blockRange}`,
     }),
+  TIMESTAMP_RANGE_TOO_LARGE: (fromBlock: string, fromTimestamp: number, toBlock: string, toTimestamp: number) =>
+    new JsonRpcError({
+      code: -32000,
+      message: `The provided fromBlock and toBlock contain timestamps that exceed the maximum allowed duration of 7 days (604800 seconds): fromBlock: ${fromBlock} (${fromTimestamp}), toBlock: ${toBlock} (${toTimestamp})`,
+    }),
   REQUEST_BEYOND_HEAD_BLOCK: (requested: number, latest: number) =>
     new JsonRpcError({
       code: -32000,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2767,6 +2767,37 @@ export class EthImpl implements Eth {
     return await this.getAcccountNonceFromContractResult(address, blockNum, requestDetails);
   }
 
+  /**
+   * Retrieves logs based on the provided parameters.
+   *
+   * The function handles log retrieval as follows:
+   *
+   * - Using `blockHash`:
+   *   - If `blockHash` is provided, logs are retrieved based on the timestamp of the block associated with the `blockHash`.
+   *
+   * - Without `blockHash`:
+   *
+   *   - If only `fromBlock` is provided:
+   *     - Logs are retrieved from `fromBlock` to the latest block.
+   *     - If `fromBlock` does not exist, an empty array is returned.
+   *
+   *   - If only `toBlock` is provided:
+   *     - A predefined error `MISSING_FROM_BLOCK_PARAM` is thrown because `fromBlock` is required.
+   *
+   *   - If both `fromBlock` and `toBlock` are provided:
+   *     - Logs are retrieved from `fromBlock` to `toBlock`.
+   *     - If `toBlock` does not exist, an empty array is returned.
+   *     - If the timestamp range between `fromBlock` and `toBlock` exceeds 7 days, a predefined error `TIMESTAMP_RANGE_TOO_LARGE` is thrown.
+   *
+   * @param {string | null} blockHash - The block hash to prioritize log retrieval.
+   * @param {string | 'latest'} fromBlock - The starting block for log retrieval.
+   * @param {string | 'latest'} toBlock - The ending block for log retrieval.
+   * @param {string | string[] | null} address - The address(es) to filter logs by.
+   * @param {any[] | null} topics - The topics to filter logs by.
+   * @param {RequestDetails} requestDetails - The details of the request.
+   * @returns {Promise<Log[]>} - A promise that resolves to an array of logs or an empty array if no logs are found.
+   * @throws {Error} Throws specific errors like `MISSING_FROM_BLOCK_PARAM` or `TIMESTAMP_RANGE_TOO_LARGE` when applicable.
+   */
   async getLogs(
     blockHash: string | null,
     fromBlock: string | 'latest',

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -140,9 +140,13 @@ export class CommonService implements ICommonService {
     } else {
       fromBlockNum = parseInt(fromBlockResponse.number);
       const toBlockResponse = await this.getHistoricalBlockResponse(requestDetails, toBlock, true);
-      if (toBlockResponse != null) {
-        params.timestamp.push(`lte:${toBlockResponse.timestamp.to}`);
-        toBlockNum = parseInt(toBlockResponse.number);
+      if (!toBlockResponse) {
+        return false;
+      }
+
+      params.timestamp.push(`lte:${toBlockResponse.timestamp.to}`);
+      toBlockNum = parseInt(toBlockResponse.number);
+
       }
 
       if (fromBlockNum > toBlockNum) {

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -173,7 +173,7 @@ export class CommonService implements ICommonService {
       }
 
       if (fromBlockNum > toBlockNum) {
-        return false;
+        throw predefined.INVALID_BLOCK_RANGE;
       }
 
       const blockRangeLimit = this.getLogsBlockRangeLimit();

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -190,6 +190,53 @@ export class CommonService implements ICommonService {
     return true;
   }
 
+  public async validateBlockRange(fromBlock: string, toBlock: string, requestDetails: RequestDetails) {
+    let fromBlockNumber: any = null;
+    let toBlockNumber: any = null;
+
+    if (this.blockTagIsLatestOrPending(toBlock)) {
+      toBlock = CommonService.blockLatest;
+    } else {
+      toBlockNumber = Number(toBlock);
+
+      const latestBlockNumber: string = await this.getLatestBlockNumber(requestDetails);
+
+      // - When `fromBlock` is not explicitly provided, it defaults to `latest`.
+      // - Then if `toBlock` equals `latestBlockNumber`, it means both `toBlock` and `fromBlock` essentially refer to the latest block, so the `MISSING_FROM_BLOCK_PARAM` error is not necessary.
+      // - If `toBlock` is explicitly provided and does not equals to `latestBlockNumber`, it establishes a solid upper bound.
+      // - If `fromBlock` is missing, indicating the absence of a lower bound, throw the `MISSING_FROM_BLOCK_PARAM` error.
+      if (Number(toBlock) !== Number(latestBlockNumber) && !fromBlock) {
+        throw predefined.MISSING_FROM_BLOCK_PARAM;
+      }
+    }
+
+    if (this.blockTagIsLatestOrPending(fromBlock)) {
+      fromBlock = CommonService.blockLatest;
+    } else {
+      fromBlockNumber = Number(fromBlock);
+    }
+
+    // If either or both fromBlockNumber and toBlockNumber are not set, it means fromBlock and/or toBlock is set to latest, involve MN to retrieve their block number.
+    if (!fromBlockNumber || !toBlockNumber) {
+      const fromBlockResponse = await this.getHistoricalBlockResponse(requestDetails, fromBlock, true);
+      const toBlockResponse = await this.getHistoricalBlockResponse(requestDetails, toBlock, true);
+
+      if (fromBlockResponse) {
+        fromBlockNumber = parseInt(fromBlockResponse.number);
+      }
+
+      if (toBlockResponse) {
+        toBlockNumber = parseInt(toBlockResponse.number);
+      }
+    }
+
+    if (fromBlockNumber > toBlockNumber) {
+      throw predefined.INVALID_BLOCK_RANGE;
+    }
+
+    return true;
+  }
+
   /**
    * returns the block response
    * otherwise return undefined.

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -147,6 +147,15 @@ export class CommonService implements ICommonService {
       params.timestamp.push(`lte:${toBlockResponse.timestamp.to}`);
       toBlockNum = parseInt(toBlockResponse.number);
 
+      // Add timestamp range validation (7 days = 604800 seconds)
+      const timestampDiff = toBlockResponse.timestamp.to - fromBlockResponse.timestamp.from;
+      if (timestampDiff > 604800) {
+        throw predefined.TIMESTAMP_RANGE_TOO_LARGE(
+          `0x${fromBlockNum.toString(16)}`,
+          fromBlockResponse.timestamp.from,
+          `0x${toBlockNum.toString(16)}`,
+          toBlockResponse.timestamp.to,
+        );
       }
 
       if (fromBlockNum > toBlockNum) {

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -140,6 +140,13 @@ export class CommonService implements ICommonService {
     } else {
       fromBlockNum = parseInt(fromBlockResponse.number);
       const toBlockResponse = await this.getHistoricalBlockResponse(requestDetails, toBlock, true);
+
+      /**
+       * If `toBlock` is not provided, the `lte` field cannot be set,
+       * resulting in a request to the Mirror Node that includes only the `gte` parameter.
+       * Such requests will be rejected, hence causing the whole request to fail.
+       * Return false to handle this gracefully and return an empty response to end client.
+       */
       if (!toBlockResponse) {
         return false;
       }

--- a/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/index.ts
@@ -114,13 +114,16 @@ export class CommonService implements ICommonService {
   ) {
     if (this.blockTagIsLatestOrPending(toBlock)) {
       toBlock = CommonService.blockLatest;
-    }
+    } else {
+      const latestBlockNumber: string = await this.getLatestBlockNumber(requestDetails);
 
-    const latestBlockNumber: string = await this.getLatestBlockNumber(requestDetails);
-
-    // toBlock is a number and is less than the current block number and fromBlock is not defined
-    if (Number(toBlock) < Number(latestBlockNumber) && !fromBlock) {
-      throw predefined.MISSING_FROM_BLOCK_PARAM;
+      // - When `fromBlock` is not explicitly provided, it defaults to `latest`.
+      // - Then if `toBlock` equals `latestBlockNumber`, it means both `toBlock` and `fromBlock` essentially refer to the latest block, so the `MISSING_FROM_BLOCK_PARAM` error is not necessary.
+      // - If `toBlock` is explicitly provided and does not equals to `latestBlockNumber`, it establishes a solid upper bound.
+      // - If `fromBlock` is missing, indicating the absence of a lower bound, throw the `MISSING_FROM_BLOCK_PARAM` error.
+      if (Number(toBlock) !== Number(latestBlockNumber) && !fromBlock) {
+        throw predefined.MISSING_FROM_BLOCK_PARAM;
+      }
     }
 
     if (this.blockTagIsLatestOrPending(fromBlock)) {

--- a/packages/relay/src/lib/services/ethService/ethFilterService/index.ts
+++ b/packages/relay/src/lib/services/ethService/ethFilterService/index.ts
@@ -134,9 +134,7 @@ export class FilterService implements IFilterService {
     try {
       FilterService.requireFiltersEnabled();
 
-      if (
-        !(await this.common.validateBlockRangeAndAddTimestampToParams({}, fromBlock, toBlock, requestDetails, address))
-      ) {
+      if (!(await this.common.validateBlockRange(fromBlock, toBlock, requestDetails))) {
         throw predefined.INVALID_BLOCK_RANGE;
       }
 

--- a/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getLogs.spec.ts
@@ -464,10 +464,10 @@ describe('@ethGetLogs using MirrorNode', async function () {
     restMock.onGet(BLOCKS_LIMIT_ORDER_URL).reply(200, { blocks: [latestBlock] });
     restMock.onGet('blocks/16').reply(200, fromBlock);
     restMock.onGet('blocks/5').reply(200, DEFAULT_BLOCK);
-    const result = await ethImpl.getLogs(null, '0x10', '0x5', null, null, requestDetails);
 
-    expect(result).to.exist;
-    expect(result).to.be.empty;
+    await expect(ethImpl.getLogs(null, '0x10', '0x5', null, null, requestDetails)).to.be.rejectedWith(
+      predefined.INVALID_BLOCK_RANGE.message,
+    );
   });
 
   it('with only toBlock', async function () {

--- a/packages/relay/tests/lib/services/eth/filter.spec.ts
+++ b/packages/relay/tests/lib/services/eth/filter.spec.ts
@@ -275,7 +275,7 @@ describe('Filter API Test Suite', async function () {
     });
 
     it('validates fromBlock and toBlock', async function () {
-      // fromBlock is larger than toBlock
+      // reject if fromBlock is larger than toBlock
       await RelayAssertions.assertRejection(
         predefined.INVALID_BLOCK_RANGE,
         filterService.newFilter,
@@ -291,13 +291,13 @@ describe('Filter API Test Suite', async function () {
         ['latest', blockNumberHexes[1400], requestDetails],
       );
 
-      // block range is too large
+      // reject when no fromBlock is provided
       await RelayAssertions.assertRejection(
-        predefined.RANGE_TOO_LARGE(1000),
+        predefined.MISSING_FROM_BLOCK_PARAM,
         filterService.newFilter,
         true,
         filterService,
-        [blockNumberHexes[5], blockNumberHexes[2000], requestDetails],
+        [null, blockNumberHexes[1400], requestDetails],
       );
 
       // block range is valid

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -317,6 +317,24 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         }
       });
 
+      it('should return empty logs if `toBlock` is not found', async () => {
+        const notExistedLog = latestBlock + 99;
+
+        const logs = await relay.call(
+          RelayCalls.ETH_ENDPOINTS.ETH_GET_LOGS,
+          [
+            {
+              fromBlock: log0Block.blockNumber,
+              toBlock: `0x${notExistedLog.toString(16)}`,
+              address: [contractAddress, contractAddress2],
+            },
+          ],
+          requestIdPrefix,
+        );
+
+        expect(logs.length).to.eq(0);
+      });
+
       it('should be able to use `address` param', async () => {
         //when we pass only address, it defaults to the latest block
         const logs = await relay.call(


### PR DESCRIPTION
**Description**:
This pull request improves the eth_getLogs functionality by:
- Introducing a new error: TIMESTAMP_RANGE_TOO_LARGE for handling large timestamp ranges.
- Adding validation to ensure the timestamp range between fromBlock and toBlock is within acceptable limits, 7 days (604800 seconds). (Fixes #3428)
- Ensuring eth_getLogs gracefully handles cases where toBlock is not provided. Without toBlock, the `params.lte` field is omitted, leading to request rejected by MN. To address this, the function now returns an empty response to the client. (Fixes #3430)

Tests and comments have been added to support and clarify these changes.

**Related issue(s)**:

Fixes #3428

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
