### PR TITLE
fix(test): equipped a more appropriate block range for eth_getLogs WS release test

### DIFF
--- a/packages/ws-server/tests/acceptance/getLogs.spec.ts
+++ b/packages/ws-server/tests/acceptance/getLogs.spec.ts
@@ -79,7 +79,7 @@ describe('@web-socket-batch-2 eth_getLogs', async function () {
   const SIMPLE_CONTRACT_BYTECODE =
     '0x6080604052348015600f57600080fd5b507f4e7df42af9a017b7c655a28ef10cbc8f05b2b088f087ee02416cfa1a96ac3be26007604051603e91906091565b60405180910390a160aa565b6000819050919050565b6000819050919050565b6000819050919050565b6000607d6079607584604a565b605e565b6054565b9050919050565b608b816068565b82525050565b600060208201905060a460008301846084565b92915050565b603f8060b76000396000f3fe6080604052600080fdfea264697066735822122084db7fe76bde5c9c041d61bb40294c56dc6d339bdbc8e0cd285fc4008ccefc2c64736f6c63430008180033';
   // @ts-ignore
-  const { mirrorNode }: { mirrorNode: MirrorClient } = global;
+  const { mirrorNode, relay }: { mirrorNode: MirrorClient; relay: RelayClient } = global;
   const requestId = 'getLogsTest_ws-server';
   const requestDetails = new RequestDetails({ requestId: requestId, ipAddress: '0.0.0.0' });
 
@@ -103,13 +103,16 @@ describe('@web-socket-batch-2 eth_getLogs', async function () {
     );
     global.accounts.push(...accounts);
 
+    const currentBlock = Number(await relay.call('eth_blockNumber', []));
+    const currentBlockHexlified = `0x${currentBlock.toString(16)}`; // Convert decimal to hexadecimal
+
     // deploy contract
     const contract = await Utils.deployContract(SIMPLE_CONTRACT_ABI, SIMPLE_CONTRACT_BYTECODE, accounts[0].wallet);
 
     // prepare filter object
     wsFilterObj = {
       address: contract.target,
-      fromBlock: '0x0',
+      fromBlock: currentBlockHexlified,
       toBlock: 'latest',
     };
   });


### PR DESCRIPTION
**Description**:
This PR equipps a more appropriate block range for eth_getLogs WS release test

**Related issue(s)**:

Fixes #3451 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
