### PR TITLE
fix: Resolve BigInt type mismatch in eth_sendRawTransaction precheck

### DIFF
--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -170,7 +170,8 @@ export class Precheck {
    */
   gasPrice(tx: Transaction, networkGasPriceInWeiBars: number, requestDetails: RequestDetails): void {
     const networkGasPrice = BigInt(networkGasPriceInWeiBars);
-    const txGasPrice = tx.gasPrice || tx.maxFeePerGas! + tx.maxPriorityFeePerGas!;
+
+    const txGasPrice = BigInt(tx.gasPrice || tx.maxFeePerGas! + tx.maxPriorityFeePerGas!);
 
     // **notice: Pass gasPrice precheck if txGasPrice is greater than the minimum network's gas price value,
     //          OR if the transaction is the deterministic deployment transaction (a special case).
@@ -221,8 +222,9 @@ export class Precheck {
       passes: false,
       error: predefined.INSUFFICIENT_ACCOUNT_BALANCE,
     };
-    const txGas = tx.gasPrice || tx.maxFeePerGas! + tx.maxPriorityFeePerGas!;
-    const txTotalValue = tx.value + txGas * tx.gasLimit;
+
+    const txGasPrice = BigInt(tx.gasPrice || tx.maxFeePerGas! + tx.maxPriorityFeePerGas!);
+    const txTotalValue = tx.value + txGasPrice * tx.gasLimit;
 
     if (account == null) {
       if (this.logger.isLevelEnabled('trace')) {

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -1739,6 +1739,25 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           expect(info).to.exist;
           expect(info.result).to.equal('SUCCESS');
         });
+
+        it('should fail "eth_sendRawTransaction" for transaction with null gasPrice, null maxFeePerGas, and null maxPriorityFeePerGas', async function () {
+          const transaction = {
+            ...defaultLegacyTransactionData,
+            chainId: Number(CHAIN_ID),
+            gasPrice: null,
+            maxFeePerGas: null,
+            maxPriorityFeePerGas: null,
+            to: parentContractAddress,
+            nonce: await relay.getAccountNonce(accounts[2].address, requestId),
+          };
+          const signedTx = await accounts[2].wallet.signTransaction(transaction);
+          const error = predefined.GAS_PRICE_TOO_LOW(0, GAS_PRICE_REF);
+
+          await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [
+            signedTx,
+            requestDetails,
+          ]);
+        });
       });
 
       it('@release should execute "eth_getTransactionByHash" for existing transaction', async function () {


### PR DESCRIPTION
**Description**:
This PR fixes the BigInt type mismatch in the eth_sendRawTransaction precheck. It also adds unit and acceptance tests to ensure the precheck handles null values for gasPrice, maxFeePerGas, and maxPriorityFeePerGas gracefully.

**Related issue(s)**:

Fixes #3461 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
