### PR TITLE
fix: fixes flaky CI tests in RPC Batch 2

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -1699,16 +1699,16 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
         it(`should execute "eth_sendRawTransaction" if receiver's account has receiver_sig_required disabled`, async function () {
           const newPrivateKey = PrivateKey.generateED25519();
-          const newAccount = await new AccountCreateTransaction()
+          const accountCreateTx = await new AccountCreateTransaction()
             .setKey(newPrivateKey.publicKey)
             .setInitialBalance(100)
-            .setReceiverSignatureRequired(false)
-            .freezeWith(servicesNode.client)
-            .sign(newPrivateKey);
+            .setReceiverSignatureRequired(false);
 
+          await accountCreateTx.freezeWith(servicesNode.client);
+          const newAccount = await accountCreateTx.sign(newPrivateKey);
           const transaction = await newAccount.execute(servicesNode.client);
           const receipt = await transaction.getReceipt(servicesNode.client);
-          await Utils.wait(3000);
+          await Utils.wait(5000);
 
           if (!receipt.accountId) {
             throw new Error('Failed to create new account - accountId is null');

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -1203,6 +1203,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         };
         const signedTx = await accounts[2].wallet.signTransaction(transaction);
         const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
+        await relay.pollForValidTransactionReceipt(transactionHash);
         const info = await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
         expect(info).to.exist;
         expect(info.result).to.equal('SUCCESS');
@@ -1284,8 +1285,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
         // Since the transactionId is not available in this context
         // Wait for the transaction to be processed and imported in the mirror node with axios-retry
-        await Utils.wait(5000);
-
+        await relay.pollForValidTransactionReceipt(transactionHash);
         await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
         const receiverEndBalance = await relay.getBalance(parentContractAddress, 'latest', requestId);
         const balanceChange = receiverEndBalance - receiverInitialBalance;
@@ -1400,6 +1400,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
         const signedTx = await accounts[2].wallet.signTransaction(transaction);
         const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
+        await relay.pollForValidTransactionReceipt(transactionHash);
         const info = await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
         expect(info).to.have.property('contract_id');
         expect(info.contract_id).to.not.be.null;
@@ -1421,6 +1422,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
         const signedTx = await accounts[2].wallet.signTransaction(transaction);
         const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
+        await relay.pollForValidTransactionReceipt(transactionHash);
         const info = await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
         expect(info).to.have.property('contract_id');
         expect(info.contract_id).to.not.be.null;
@@ -1449,6 +1451,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
         const signedTx = await accounts[2].wallet.signTransaction(transaction);
         const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
+        await relay.pollForValidTransactionReceipt(transactionHash);
         const info = await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
         const balanceAfter = await relay.getBalance(accounts[2].wallet.address, 'latest', requestId);
         expect(info).to.have.property('contract_id');
@@ -1654,29 +1657,35 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestDetails]);
         });
 
-        it('should fail "eth_sendRawTransaction" if receiver\'s account has receiver_sig_required enabled', async function () {
+        async function createTestAccount(
+          receiverSigRequired: boolean,
+        ): Promise<{ toAddress: string; verifyAccount: any }> {
           const newPrivateKey = PrivateKey.generateED25519();
-          const newAccount = await new AccountCreateTransaction()
+          const accountCreateTx = new AccountCreateTransaction()
             .setKey(newPrivateKey.publicKey)
             .setInitialBalance(100)
-            .setReceiverSignatureRequired(true)
-            .freezeWith(servicesNode.client)
-            .sign(newPrivateKey);
-
-          const transaction = await newAccount.execute(servicesNode.client);
+            .setReceiverSignatureRequired(receiverSigRequired);
+          await accountCreateTx.freezeWith(servicesNode.client);
+          const signedAccountTx = await accountCreateTx.sign(newPrivateKey);
+          const transaction = await signedAccountTx.execute(servicesNode.client);
           const receipt = await transaction.getReceipt(servicesNode.client);
-
           if (!receipt.accountId) {
             throw new Error('Failed to create new account - accountId is null');
           }
-
           const toAddress = Utils.idToEvmAddress(receipt.accountId.toString());
-          const verifyAccount = await mirrorNode.get(`/accounts/${toAddress}`, requestId);
-
-          if (verifyAccount && !verifyAccount.account) {
-            verifyAccount == (await mirrorNode.get(`/accounts/${toAddress}`, requestId));
+          let verifyAccount;
+          for (let i = 0; i < 5; i++) {
+            verifyAccount = await mirrorNode.get(`/accounts/${toAddress}`, requestId);
+            if (verifyAccount?.account) {
+              break;
+            }
+            await Utils.wait(1000);
           }
+          return { toAddress, verifyAccount };
+        }
 
+        it('should fail "eth_sendRawTransaction" if receiver\'s account has receiver_sig_required enabled', async function () {
+          const { toAddress, verifyAccount } = await createTestAccount(true);
           expect(verifyAccount.receiver_sig_required).to.be.true;
 
           const tx = {
@@ -1686,40 +1695,16 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             to: toAddress,
             from: accounts[0].address,
           };
-
           const signedTx = await accounts[0].wallet.signTransaction(tx);
-
           const error = predefined.RECEIVER_SIGNATURE_ENABLED;
-
           await Assertions.assertPredefinedRpcError(error, sendRawTransaction, false, relay, [
             signedTx,
             requestDetails,
           ]);
         });
 
-        it(`should execute "eth_sendRawTransaction" if receiver's account has receiver_sig_required disabled`, async function () {
-          const newPrivateKey = PrivateKey.generateED25519();
-          const accountCreateTx = await new AccountCreateTransaction()
-            .setKey(newPrivateKey.publicKey)
-            .setInitialBalance(100)
-            .setReceiverSignatureRequired(false);
-
-          await accountCreateTx.freezeWith(servicesNode.client);
-          const newAccount = await accountCreateTx.sign(newPrivateKey);
-          const transaction = await newAccount.execute(servicesNode.client);
-          const receipt = await transaction.getReceipt(servicesNode.client);
-          await Utils.wait(5000);
-
-          if (!receipt.accountId) {
-            throw new Error('Failed to create new account - accountId is null');
-          }
-
-          const toAddress = Utils.idToEvmAddress(receipt.accountId.toString());
-          const verifyAccount = await mirrorNode.get(`/accounts/${toAddress}`, requestId);
-          if (verifyAccount && !verifyAccount.account) {
-            verifyAccount == (await mirrorNode.get(`/accounts/${toAddress}`, requestId));
-          }
-
+        it('should execute "eth_sendRawTransaction" if receiver\'s account has receiver_sig_required disabled', async function () {
+          const { toAddress, verifyAccount } = await createTestAccount(false);
           expect(verifyAccount.receiver_sig_required).to.be.false;
 
           const tx = {
@@ -1729,13 +1714,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             to: toAddress,
             from: accounts[0].address,
           };
-
           const signedTx = await accounts[0].wallet.signTransaction(tx);
-          const transactionHash = await relay.sendRawTransaction(signedTx, requestId);
+          const transactionHash = await relay.sendRawTransaction(signedTx, requestDetails);
           await relay.pollForValidTransactionReceipt(transactionHash);
 
           const info = await mirrorNode.get(`/contracts/results/${transactionHash}`, requestId);
-
           expect(info).to.exist;
           expect(info.result).to.equal('SUCCESS');
         });

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -106,12 +106,9 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
   this.beforeAll(async () => {
     requestId = Utils.generateRequestId();
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
+    expectedGasPrice = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, [], requestIdPrefix);
 
-    const [gasPrice, initialAccount] = await Promise.all([
-      relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, [], requestIdPrefix),
-      global.accounts[0],
-    ]);
-    expectedGasPrice = gasPrice;
+    const initialAccount: AliasAccount = global.accounts[0];
 
     const neededAccounts = 4;
     const newAccounts = await Utils.createMultipleAliasAccounts(


### PR DESCRIPTION
**Description**:
The beforeAll() block in the eth_getCode suite is timing out.

By optimizing the hook in the RPC API batch 2 and removing unnecessary and expensive calls, and then rerunning the job multiple times - now it fails much less often.

**Related issue(s)**:

Fixes partially #3353 

**Notes for reviewer**:

**Checklist**

