### PR TITLE
feat: add `web3_sha3` support

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -949,6 +949,18 @@
       }
     },
     {
+      "name": "web3_sha3",
+      "summary": "Returns sha3 of the input.",
+      "description": "![](https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/images/ws_label.png)",
+      "params": [],
+      "result": {
+        "name": "The sha3 result.",
+        "schema": {
+          "$ref": "#/components/schemas/hash32"
+        }
+      }
+    },
+    {
       "name": "eth_subscribe",
       "summary": "Creates a new subscription for desired events. Sends data as soon as it occurs.",
       "description": "![](https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/images/ws_label.png)",

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -72,3 +72,4 @@ The following table highlights each relay endpoint and the TIER associated with 
 | `net_listening`                           | TIER_3_RATE_LIMIT |
 | `net_version`                             | TIER_3_RATE_LIMIT |
 | `web3_clientVersion`                      | TIER_3_RATE_LIMIT |
+| `web3_sha3`                               | TIER_3_RATE_LIMIT |

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Block, Log, Receipt, Transaction } from './lib/model';
-import { IContractCallRequest, RequestDetails } from './lib/types';
-import { JsonRpcError, predefined } from './lib/errors/JsonRpcError';
-import WebSocketError from './lib/errors/WebSocketError';
-import { MirrorNodeClientError } from './lib/errors/MirrorNodeClientError';
 import { MirrorNodeClient } from './lib/clients';
-import { IFilterService } from './lib/services/ethService/ethFilterService/IFilterService';
+import { JsonRpcError, predefined } from './lib/errors/JsonRpcError';
+import { MirrorNodeClientError } from './lib/errors/MirrorNodeClientError';
+import WebSocketError from './lib/errors/WebSocketError';
+import { Block, Log, Receipt, Transaction } from './lib/model';
 import { IDebugService } from './lib/services/debugService/IDebugService';
+import { IFilterService } from './lib/services/ethService/ethFilterService/IFilterService';
+import { IContractCallRequest, RequestDetails } from './lib/types';
 
 export { JsonRpcError, predefined, MirrorNodeClientError, WebSocketError };
 
@@ -35,6 +35,8 @@ export interface Subs {
 
 export interface Web3 {
   clientVersion(): string;
+
+  sha3(input: string): string;
 }
 
 export interface Net {

--- a/packages/relay/src/lib/web3.ts
+++ b/packages/relay/src/lib/web3.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Web3 } from '../index';
-import { Client } from '@hashgraph/sdk';
+import { keccak256 } from '@ethersproject/keccak256';
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
+import { Client } from '@hashgraph/sdk';
+
+import { Web3 } from '../index';
 
 export class Web3Impl implements Web3 {
   private client: Client;
@@ -13,5 +15,9 @@ export class Web3Impl implements Web3 {
 
   clientVersion(): string {
     return 'relay/' + ConfigService.get('npm_package_version');
+  }
+
+  sha3(input: string): string {
+    return keccak256(input);
   }
 }

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -136,7 +136,9 @@ describe('Open RPC Specification', function () {
     mock.onGet(`blocks/${defaultBlock.number}`).reply(200, JSON.stringify(defaultBlock));
     mock.onGet(`blocks/${blockHash}`).reply(200, JSON.stringify(defaultBlock));
     mock.onGet('network/fees').reply(200, JSON.stringify(defaultNetworkFees));
-    mock.onGet(`network/fees?timestamp=lte:${defaultBlock.timestamp.to}`).reply(200, JSON.stringify(defaultNetworkFees));
+    mock
+      .onGet(`network/fees?timestamp=lte:${defaultBlock.timestamp.to}`)
+      .reply(200, JSON.stringify(defaultNetworkFees));
     mock.onGet(`contracts/${contractAddress1}`).reply(200, JSON.stringify(null));
     mock
       .onGet(
@@ -165,41 +167,61 @@ describe('Open RPC Specification', function () {
     mock
       .onGet(`contracts/${contractAddress2}/results/${contractTimestamp2}`)
       .reply(200, JSON.stringify(defaultDetailedContractResults));
-    mock.onGet(`contracts/${contractId1}/results/${contractTimestamp1}`).reply(200, JSON.stringify(defaultDetailedContractResults));
-    mock.onGet(`contracts/${contractId1}/results/${contractTimestamp2}`).reply(200, JSON.stringify(defaultDetailedContractResults2));
-    mock.onGet(`contracts/${contractId2}/results/${contractTimestamp3}`).reply(200, JSON.stringify(defaultDetailedContractResults3));
+    mock
+      .onGet(`contracts/${contractId1}/results/${contractTimestamp1}`)
+      .reply(200, JSON.stringify(defaultDetailedContractResults));
+    mock
+      .onGet(`contracts/${contractId1}/results/${contractTimestamp2}`)
+      .reply(200, JSON.stringify(defaultDetailedContractResults2));
+    mock
+      .onGet(`contracts/${contractId2}/results/${contractTimestamp3}`)
+      .reply(200, JSON.stringify(defaultDetailedContractResults3));
     mock.onGet(`tokens/0.0.${parseInt(defaultCallData.to, 16)}`).reply(404, JSON.stringify(null));
-    mock.onGet(`accounts/${contractAddress1}?limit=100`).reply(200, JSON.stringify({
-      account: contractAddress1,
-      balance: {
-        balance: 2000000000000,
-      },
-    }));
-    mock.onGet(`accounts/${contractAddress3}${noTransactions}`).reply(200, JSON.stringify({
-      account: contractAddress3,
-      balance: {
-        balance: 100000000000,
-      },
-    }));
+    mock.onGet(`accounts/${contractAddress1}?limit=100`).reply(
+      200,
+      JSON.stringify({
+        account: contractAddress1,
+        balance: {
+          balance: 2000000000000,
+        },
+      }),
+    );
+    mock.onGet(`accounts/${contractAddress3}${noTransactions}`).reply(
+      200,
+      JSON.stringify({
+        account: contractAddress3,
+        balance: {
+          balance: 100000000000,
+        },
+      }),
+    );
     mock
       .onGet(`accounts/0xbC989b7b17d18702663F44A6004cB538b9DfcBAc?limit=100`)
       .reply(200, JSON.stringify({ account: '0xbC989b7b17d18702663F44A6004cB538b9DfcBAc' }));
 
-    mock.onGet(`network/exchangerate`).reply(200, JSON.stringify({
-      current_rate: {
-        cent_equivalent: 12,
-        expiration_time: 4102444800,
-        hbar_equivalent: 1,
-      },
-    }));
+    mock.onGet(`network/exchangerate`).reply(
+      200,
+      JSON.stringify({
+        current_rate: {
+          cent_equivalent: 12,
+          expiration_time: 4102444800,
+          hbar_equivalent: 1,
+        },
+      }),
+    );
 
-    mock.onGet(`accounts/${defaultFromLongZeroAddress}${noTransactions}`).reply(200, JSON.stringify({
-      from: `${defaultEvmAddress}`,
-    }));
+    mock.onGet(`accounts/${defaultFromLongZeroAddress}${noTransactions}`).reply(
+      200,
+      JSON.stringify({
+        from: `${defaultEvmAddress}`,
+      }),
+    );
     for (const log of defaultLogs.logs) {
       mock.onGet(`contracts/${log.address}`).reply(200, JSON.stringify(defaultContract));
     }
-    mock.onPost(`contracts/call`, { ...defaultCallData, estimate: false }).reply(200, JSON.stringify({ result: '0x12' }));
+    mock
+      .onPost(`contracts/call`, { ...defaultCallData, estimate: false })
+      .reply(200, JSON.stringify({ result: '0x12' }));
     sdkClientStub.getAccountBalanceInWeiBar.resolves(BigNumber(1000));
     sdkClientStub.getAccountBalanceInTinyBar.resolves(BigNumber(100000000000));
     sdkClientStub.getContractByteCode.resolves(Buffer.from(bytecode.replace('0x', ''), 'hex'));
@@ -209,7 +231,9 @@ describe('Open RPC Specification', function () {
     mock.onGet(`accounts/${defaultContractResults.results[1].from}?transactions=false`).reply(200);
     mock.onGet(`accounts/${defaultContractResults.results[0].to}?transactions=false`).reply(200);
     mock.onGet(`accounts/${defaultContractResults.results[1].to}?transactions=false`).reply(200);
-    mock.onGet(`accounts/${CONTRACT_RESULT_MOCK.from}?transactions=false`).reply(200, JSON.stringify(CONTRACT_RESULT_MOCK));
+    mock
+      .onGet(`accounts/${CONTRACT_RESULT_MOCK.from}?transactions=false`)
+      .reply(200, JSON.stringify(CONTRACT_RESULT_MOCK));
     mock.onGet(`contracts/${defaultContractResults.results[0].from}`).reply(404, JSON.stringify(NOT_FOUND_RES));
     mock.onGet(`contracts/${defaultContractResults.results[1].from}`).reply(404, JSON.stringify(NOT_FOUND_RES));
     mock.onGet(`contracts/${defaultContractResults.results[0].to}`).reply(200);
@@ -362,9 +386,12 @@ describe('Open RPC Specification', function () {
           `&topic2=${defaultLogTopics[2]}&topic3=${defaultLogTopics[3]}&limit=100&order=asc`,
       )
       .reply(200, JSON.stringify(filteredLogs));
-    mock.onGet('blocks?block.number=gte:0x5&block.number=lte:0x10').reply(200, JSON.stringify({
-      blocks: [defaultBlock],
-    }));
+    mock.onGet('blocks?block.number=gte:0x5&block.number=lte:0x10').reply(
+      200,
+      JSON.stringify({
+        blocks: [defaultBlock],
+      }),
+    );
     for (const log of filteredLogs.logs) {
       mock.onGet(`contracts/${log.address}`).reply(200, JSON.stringify(defaultContract));
     }
@@ -531,5 +558,11 @@ describe('Open RPC Specification', function () {
     const response = Relay.web3().clientVersion();
 
     validateResponseSchema(methodsResponseSchema.web3_clientVersion, response);
+  });
+
+  it('should execute "web3_sha3"', function () {
+    const response = Relay.web3().sha3('0x5644');
+
+    validateResponseSchema(methodsResponseSchema.web3_sha3, response);
   });
 });

--- a/packages/relay/tests/lib/web3.spec.ts
+++ b/packages/relay/tests/lib/web3.spec.ts
@@ -26,4 +26,8 @@ describe('Web3', function () {
       );
     });
   });
+
+  it('should return sha3 of the input', () => {
+    expect(Relay.web3().sha3('0x5644')).to.equal('0xf956fddff3899ff3cf7ac1773fdbf443ffbfb625c1a673abdba8947251f81bae');
+  });
 });

--- a/packages/server/src/koaJsonRpc/lib/methodConfiguration.ts
+++ b/packages/server/src/koaJsonRpc/lib/methodConfiguration.ts
@@ -19,6 +19,9 @@ export const methodConfiguration: IMethodRateLimitConfiguration = {
   web3_clientVersion: {
     total: tier3rateLimit,
   },
+  web3_sha3: {
+    total: tier3rateLimit,
+  },
   net_listening: {
     total: tier3rateLimit,
   },

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -405,6 +405,10 @@ app.useRpc('web3_clientVersion', async () => {
   return logAndHandleResponse('web3_clientVersion', [], () => relay.web3().clientVersion());
 });
 
+app.useRpc('web3_sha3', async (params: any) => {
+  return logAndHandleResponse('web3_sha3', params, () => relay.web3().sha3(params?.[0]));
+});
+
 /**
  * Returns an empty array.
  *

--- a/packages/server/src/validator/methods.ts
+++ b/packages/server/src/validator/methods.ts
@@ -181,4 +181,10 @@ export const METHODS: { [key: string]: IMethodValidation } = {
       type: 'tracerConfig',
     },
   },
+  web3_sha3: {
+    0: {
+      required: true,
+      type: 'hex',
+    },
+  },
 };

--- a/packages/server/tests/acceptance/data/conformity-tests-batch-3.json
+++ b/packages/server/tests/acceptance/data/conformity-tests-batch-3.json
@@ -16,6 +16,10 @@
       "request": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"web3_clientVersion\",\"params\":[]}",
       "response": "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"relay/0.55.0-SNAPSHOT\"}"
     },
+    "web3_sha3": {
+      "request": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"web3_sha3\",\"params\":[\"0x5644\"]}",
+      "response": "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"0xf956fddff3899ff3cf7ac1773fdbf443ffbfb625c1a673abdba8947251f81bae\"}"
+    },
     "debug_traceTransaction - existing tx": {
       "request": "{\"jsonrpc\":\"2.0\",\"method\":\"debug_traceTransaction\",\"params\":[\"0x75a7d81c08d33daf327635bd62b7ecaf33c6d3c8cc17d8b19224e7f3e6811cb8\",{\"tracer\":\"callTracer\",\"tracerConfig\":{\"onlyTopCall\":true}}],\"id\":1}",
       "response": "{\"result\":{\"type\":\"CALL\",\"from\":\"0xc37f417fa09933335240fca72dd257bfbde9c275\",\"to\":\"0x67d8d32e9bf1a9968a5ff53b87d777aa8ebbee69\",\"value\":\"0x14\",\"gas\":\"0x3d090\",\"gasUsed\":\"0x30d40\",\"input\":\"0x\",\"output\":\"0x\"},\"jsonrpc\":\"2.0\",\"id\":1}"

--- a/packages/server/tests/helpers/constants.ts
+++ b/packages/server/tests/helpers/constants.ts
@@ -4,6 +4,7 @@
 const ETH_ENDPOINTS = {
   WEB3_CLIENT_VERSION: 'web3_client_version',
   WEB3_CLIENTVERSION: 'web3_clientVersion',
+  WEB3_SHA3: 'web3_sha3',
   ETH_CALL: 'eth_call',
   ETH_SEND_RAW_TRANSACTION: 'eth_sendRawTransaction',
   ETH_GET_TRANSACTION_RECEIPT: 'eth_getTransactionReceipt',

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -175,6 +175,18 @@ describe('RPC Server', function () {
     expect(res.data.result).to.be.equal('relay/' + ConfigService.get('npm_package_version'));
   });
 
+  it('should execute "web3_sha3"', async function () {
+    const res = await testClient.post('/', {
+      id: '2',
+      jsonrpc: '2.0',
+      method: RelayCalls.ETH_ENDPOINTS.WEB3_SHA3,
+      params: ['0x5644'],
+    });
+
+    BaseTest.defaultResponseChecks(res);
+    expect(res.data.result).to.be.equal('0xf956fddff3899ff3cf7ac1773fdbf443ffbfb625c1a673abdba8947251f81bae');
+  });
+
   it('should execute "eth_getTransactionByHash with missing transaction"', async function () {
     try {
       await testClient.post('/', {

--- a/packages/server/tests/postman.json
+++ b/packages/server/tests/postman.json
@@ -970,6 +970,45 @@
       "response": []
     },
     {
+      "name": "web3_sha3",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
+              "    pm.expect(response.result).to.match(/^relay[/]/);",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"web3_sha3\",\n    \"params\": [\"0x5644\"]\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
       "name": "eth_getTransactionCount",
       "event": [
         {

--- a/packages/server/tests/postman.json
+++ b/packages/server/tests/postman.json
@@ -979,7 +979,7 @@
               "pm.test(\"Success\", () => {",
               "    var response = pm.response.json();",
               "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-              "    pm.expect(response.result).to.match(/^relay[/]/);",
+              "    pm.expect(response.result).to.match(/^0xf956fddff3899ff3cf7ac1773fdbf443ffbfb625c1a673abdba8947251f81bae/);",
               "    pm.expect(response.id).to.equal(\"test_id\");",
               "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
               "});",

--- a/packages/ws-server/src/utils/constants.ts
+++ b/packages/ws-server/src/utils/constants.ts
@@ -91,5 +91,6 @@ export const WS_CONSTANTS = {
     ETH_GETTRANSACTIONRECEIPT: 'eth_getTransactionReceipt',
     ETH_MAXPRIORITYFEEPERGAS: 'eth_maxPriorityFeePerGas',
     WEB3_CLIENTVERSION: 'web3_clientVersion',
+    WEB3_SHA3: 'web3_sha3',
   },
 };


### PR DESCRIPTION
**Description**:

Add support for `web3_sha3`.

**Action plan**:
- add new route definition into server.ts
- add web3_sha3 definition into validator/methods.ts making the first parameter (input) required
- append the newly created method to tier3rateLimit (like web3_clientVersion) via methodConfiguration.ts
- add web3_sha3 to the web3 interface
- add the implementation within web3.ts which will create keccak256 of the input
- add tests
- add documentation

**Related issue(s)**:

Fixes #3484 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
