### PR TITLE
feat: add handling for `net_peerCount` method by returning `UNSUPPORTED_METHOD`

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -936,6 +936,14 @@
       }
     },
     {
+      "name": "net_peerCount",
+      "summary": "Always returns UNSUPPORTED_METHOD error.",
+      "params": [],
+      "result": {
+        "$ref": "#/components/schemas/unsupportedError"
+      }
+    },
+    {
       "name": "web3_clientVersion",
       "summary": "Returns the current client version.",
       "description": "![](https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/images/http_label.png) ![](https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/docs/images/ws_label.png)",

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -26,7 +26,7 @@ RATE_LIMIT_DISABLED = false;
 The following table highlights each relay endpoint and the TIER associated with it as dictated by [methodConfiguration.ts](/packages/server/src/koaJsonRpc/lib/methodConfiguration.ts)
 
 | Method endpoint                           | Tier              |
-|-------------------------------------------|-------------------|
+| ----------------------------------------- | ----------------- |
 | `eth_accounts`                            | TIER_2_RATE_LIMIT |
 | `eth_blockNumber`                         | TIER_2_RATE_LIMIT |
 | `eth_call`                                | TIER_1_RATE_LIMIT |
@@ -71,5 +71,6 @@ The following table highlights each relay endpoint and the TIER associated with 
 | `eth_syncing`                             | TIER_1_RATE_LIMIT |
 | `net_listening`                           | TIER_3_RATE_LIMIT |
 | `net_version`                             | TIER_3_RATE_LIMIT |
+| `net_peerCount`                           | TIER_3_RATE_LIMIT |
 | `web3_clientVersion`                      | TIER_3_RATE_LIMIT |
 | `web3_sha3`                               | TIER_3_RATE_LIMIT |

--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -43,6 +43,8 @@ export interface Net {
   listening(): boolean;
 
   version(): string;
+
+  peerCount(): JsonRpcError;
 }
 
 export interface Eth {

--- a/packages/relay/src/lib/net.ts
+++ b/packages/relay/src/lib/net.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Net } from '../index';
-import { Client } from '@hashgraph/sdk';
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
+import { Client } from '@hashgraph/sdk';
+
+import { JsonRpcError, Net, predefined } from '../index';
 
 export class NetImpl implements Net {
   private client: Client;
@@ -26,5 +27,12 @@ export class NetImpl implements Net {
    */
   version(): string {
     return this.chainId;
+  }
+
+  /**
+   * Always returns UNSUPPORTED_METHOD error.
+   */
+  peerCount(): JsonRpcError {
+    return predefined.UNSUPPORTED_METHOD;
   }
 }

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -554,6 +554,12 @@ describe('Open RPC Specification', function () {
     validateResponseSchema(methodsResponseSchema.net_version, response);
   });
 
+  it('should execute "net_peerCount"', function () {
+    const response = Relay.net().peerCount();
+
+    validateResponseSchema(methodsResponseSchema.net_peerCount, response);
+  });
+
   it('should execute "web3_clientVersion"', function () {
     const response = Relay.web3().clientVersion();
 

--- a/packages/server/src/koaJsonRpc/lib/methodConfiguration.ts
+++ b/packages/server/src/koaJsonRpc/lib/methodConfiguration.ts
@@ -28,6 +28,9 @@ export const methodConfiguration: IMethodRateLimitConfiguration = {
   net_version: {
     total: tier3rateLimit,
   },
+  net_peerCount: {
+    total: tier3rateLimit,
+  },
   eth_blockNumber: {
     total: tier2rateLimit,
   },

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -257,6 +257,14 @@ app.useRpc('net_version', async () => {
 });
 
 /**
+ * Originally supposed to return number of peers currently connected to the client.
+ * Not supported on Hedera.
+ */
+app.useRpc('net_peerCount', async () => {
+  return logAndHandleResponse('net_peerCount', [], () => relay.net().peerCount());
+});
+
+/**
  * Returns the number of most recent block.
  *
  * returns: Block number - hex encoded integer

--- a/packages/server/tests/acceptance/data/conformity-tests-batch-3.json
+++ b/packages/server/tests/acceptance/data/conformity-tests-batch-3.json
@@ -12,6 +12,11 @@
       "request": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"net_version\",\"params\":[]}",
       "response": "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"298\"}"
     },
+    "net_peerCount": {
+      "status": 400,
+      "request": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"net_peerCount\"}",
+      "response": "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32601}}"
+    },
     "web3_clientVersion": {
       "request": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"web3_clientVersion\",\"params\":[]}",
       "response": "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"relay/0.55.0-SNAPSHOT\"}"

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -334,7 +334,7 @@ describe('RPC Server', function () {
 
       Assertions.expectedError();
     } catch (error: any) {
-      BaseTest.methodNotFoundCheck(error.response, RelayCalls.ETH_ENDPOINTS.NET_PEER_COUNT);
+      BaseTest.unsupportedJsonRpcMethodChecks(error.response);
     }
   });
 

--- a/packages/server/tests/postman.json
+++ b/packages/server/tests/postman.json
@@ -931,6 +931,45 @@
       "response": []
     },
     {
+      "name": "net_peerCount",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Success\", () => {",
+              "    var response = pm.response.json();",
+              "    pm.expect(response.error.code).to.equal(-32601);",
+              "    pm.expect(response.error.message.endsWith(\"Unsupported JSON-RPC method\")).to.be.true;",
+              "    pm.expect(response.id).to.equal(\"test_id\");",
+              "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
+              "});",
+              ""
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"net_peerCount\",\n    \"params\": []\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{baseUrl}}",
+          "host": ["{{baseUrl}}"]
+        }
+      },
+      "response": []
+    },
+    {
       "name": "web3_clientVersion",
       "event": [
         {


### PR DESCRIPTION
**Description**:
This PR adds handling for the `net_peerCount` method by returning UNSUPPORTED_METHOD now instead of not found

**Related issue(s)**:

Fixes #3485

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
