### PR TITLE
feat: adds support for arrays in ConfigService

### DIFF
--- a/packages/config-service/src/services/globalConfig.ts
+++ b/packages/config-service/src/services/globalConfig.ts
@@ -11,12 +11,13 @@
 type ExtractTypeStringFromKey<K extends string> = K extends keyof typeof _CONFIG ? (typeof _CONFIG)[K]['type'] : never;
 
 /**
- * Maps string representations of types (`'string'`, `'boolean'`, `'number'`) to their actual TypeScript types.
+ * Maps string representations of types (`'string'`, `'boolean'`, `'number'`, `'array'`) to their actual TypeScript types.
  *
  * Example:
  * - `'string'` → string
  * - `'boolean'` → boolean
  * - `'number'` → number
+ * - `'array'` → any[]
  */
 type StringTypeToActualType<Tstr extends string> = Tstr extends 'string'
   ? string
@@ -24,6 +25,8 @@ type StringTypeToActualType<Tstr extends string> = Tstr extends 'string'
   ? boolean
   : Tstr extends 'number'
   ? number
+  : Tstr extends 'array'
+  ? any[]
   : never;
 
 /**
@@ -62,9 +65,9 @@ export type GetTypeOfConfigKey<K extends string> = CanBeUndefined<K> extends tru
  */
 export interface ConfigProperty {
   envName: string; // Environment variable name
-  type: 'string' | 'number' | 'boolean'; // Data type of the configuration property
+  type: 'string' | 'number' | 'boolean' | 'array'; // Data type of the configuration property
   required: boolean; // Whether the property is required
-  defaultValue: string | number | boolean | null; // Default value (if any)
+  defaultValue: string | number | boolean | readonly any[] | null; // Default value (if any)
 }
 
 /**
@@ -75,17 +78,17 @@ export interface ConfigProperty {
 const _CONFIG = {
   BATCH_REQUESTS_DISALLOWED_METHODS: {
     envName: 'BATCH_REQUESTS_DISALLOWED_METHODS',
-    type: 'string',
+    type: 'array',
     required: false,
-    defaultValue: `[
-      "debug_traceTransaction",
-      "eth_newFilter",
-      "eth_uninstallFilter",
-      "eth_getFilterChanges",
-      "eth_getFilterLogs",
-      "eth_newBlockFilter",
-      "eth_newPendingTransactionFilter"
-    ]`,
+    defaultValue: [
+      'debug_traceTransaction',
+      'eth_newFilter',
+      'eth_uninstallFilter',
+      'eth_getFilterChanges',
+      'eth_getFilterLogs',
+      'eth_newBlockFilter',
+      'eth_newPendingTransactionFilter',
+    ],
   },
   BATCH_REQUESTS_ENABLED: {
     envName: 'BATCH_REQUESTS_ENABLED',
@@ -185,9 +188,9 @@ const _CONFIG = {
   },
   ETH_CALL_ACCEPTED_ERRORS: {
     envName: 'ETH_CALL_ACCEPTED_ERRORS',
-    type: 'string',
+    type: 'array',
     required: false,
-    defaultValue: '[]',
+    defaultValue: [],
   },
   ETH_CALL_CACHE_TTL: {
     envName: 'ETH_CALL_CACHE_TTL',
@@ -197,9 +200,9 @@ const _CONFIG = {
   },
   ETH_CALL_CONSENSUS_SELECTORS: {
     envName: 'ETH_CALL_CONSENSUS_SELECTORS',
-    type: 'string',
+    type: 'array',
     required: false,
-    defaultValue: '[]',
+    defaultValue: [],
   },
   ETH_CALL_DEFAULT_TO_CONSENSUS_NODE: {
     envName: 'ETH_CALL_DEFAULT_TO_CONSENSUS_NODE',
@@ -245,9 +248,9 @@ const _CONFIG = {
   },
   HEDERA_SPECIFIC_REVERT_STATUSES: {
     envName: 'HEDERA_SPECIFIC_REVERT_STATUSES',
-    type: 'string',
+    type: 'array',
     required: false,
-    defaultValue: '["WRONG_NONCE", "INVALID_ACCOUNT_ID"]',
+    defaultValue: ['WRONG_NONCE', 'INVALID_ACCOUNT_ID'],
   },
   FEE_HISTORY_MAX_RESULTS: {
     envName: 'FEE_HISTORY_MAX_RESULTS',
@@ -329,9 +332,9 @@ const _CONFIG = {
   },
   HAPI_CLIENT_ERROR_RESET: {
     envName: 'HAPI_CLIENT_ERROR_RESET',
-    type: 'string',
+    type: 'array',
     required: false,
-    defaultValue: '[21, 50]',
+    defaultValue: [21, 50],
   },
   HAPI_CLIENT_TRANSACTION_RESET: {
     envName: 'HAPI_CLIENT_TRANSACTION_RESET',
@@ -497,9 +500,9 @@ const _CONFIG = {
   },
   MIRROR_NODE_RETRY_CODES: {
     envName: 'MIRROR_NODE_RETRY_CODES',
-    type: 'string',
+    type: 'array',
     required: false,
-    defaultValue: '[]',
+    defaultValue: [],
   },
   MIRROR_NODE_RETRY_DELAY: {
     envName: 'MIRROR_NODE_RETRY_DELAY',
@@ -632,7 +635,7 @@ const _CONFIG = {
     envName: 'SERVER_HOST',
     type: 'string',
     required: false,
-    defaultValue: null,
+    defaultValue: 'localhost',
   },
   SERVER_PORT: {
     envName: 'SERVER_PORT',

--- a/packages/config-service/src/services/globalConfig.ts
+++ b/packages/config-service/src/services/globalConfig.ts
@@ -638,7 +638,7 @@ const _CONFIG = {
     envName: 'SERVER_HOST',
     type: 'string',
     required: false,
-    defaultValue: 'localhost',
+    defaultValue: null,
   },
   SERVER_PORT: {
     envName: 'SERVER_PORT',

--- a/packages/config-service/src/services/globalConfig.ts
+++ b/packages/config-service/src/services/globalConfig.ts
@@ -11,13 +11,14 @@
 type ExtractTypeStringFromKey<K extends string> = K extends keyof typeof _CONFIG ? (typeof _CONFIG)[K]['type'] : never;
 
 /**
- * Maps string representations of types (`'string'`, `'boolean'`, `'number'`, `'array'`) to their actual TypeScript types.
+ * Maps string representations of types (`'string'`, `'boolean'`, `'number'`, `'strArray'`, `'numArray'`) to their actual TypeScript types.
  *
  * Example:
  * - `'string'` → string
  * - `'boolean'` → boolean
  * - `'number'` → number
- * - `'array'` → any[]
+ * - `'strArray'` → string[]
+ * - `'numArray'` → number[]
  */
 type StringTypeToActualType<Tstr extends string> = Tstr extends 'string'
   ? string
@@ -25,8 +26,10 @@ type StringTypeToActualType<Tstr extends string> = Tstr extends 'string'
   ? boolean
   : Tstr extends 'number'
   ? number
-  : Tstr extends 'array'
-  ? any[]
+  : Tstr extends 'strArray'
+  ? string[]
+  : Tstr extends 'numArray'
+  ? number[]
   : never;
 
 /**
@@ -65,9 +68,9 @@ export type GetTypeOfConfigKey<K extends string> = CanBeUndefined<K> extends tru
  */
 export interface ConfigProperty {
   envName: string; // Environment variable name
-  type: 'string' | 'number' | 'boolean' | 'array'; // Data type of the configuration property
+  type: 'string' | 'number' | 'boolean' | 'strArray' | 'numArray'; // Updated types
   required: boolean; // Whether the property is required
-  defaultValue: string | number | boolean | readonly any[] | null; // Default value (if any)
+  defaultValue: string | number | boolean | readonly string[] | readonly number[] | null; // Default value (if any)
 }
 
 /**
@@ -78,7 +81,7 @@ export interface ConfigProperty {
 const _CONFIG = {
   BATCH_REQUESTS_DISALLOWED_METHODS: {
     envName: 'BATCH_REQUESTS_DISALLOWED_METHODS',
-    type: 'array',
+    type: 'strArray',
     required: false,
     defaultValue: [
       'debug_traceTransaction',
@@ -188,7 +191,7 @@ const _CONFIG = {
   },
   ETH_CALL_ACCEPTED_ERRORS: {
     envName: 'ETH_CALL_ACCEPTED_ERRORS',
-    type: 'array',
+    type: 'numArray',
     required: false,
     defaultValue: [],
   },
@@ -200,7 +203,7 @@ const _CONFIG = {
   },
   ETH_CALL_CONSENSUS_SELECTORS: {
     envName: 'ETH_CALL_CONSENSUS_SELECTORS',
-    type: 'array',
+    type: 'strArray',
     required: false,
     defaultValue: [],
   },
@@ -248,7 +251,7 @@ const _CONFIG = {
   },
   HEDERA_SPECIFIC_REVERT_STATUSES: {
     envName: 'HEDERA_SPECIFIC_REVERT_STATUSES',
-    type: 'array',
+    type: 'strArray',
     required: false,
     defaultValue: ['WRONG_NONCE', 'INVALID_ACCOUNT_ID'],
   },
@@ -332,7 +335,7 @@ const _CONFIG = {
   },
   HAPI_CLIENT_ERROR_RESET: {
     envName: 'HAPI_CLIENT_ERROR_RESET',
-    type: 'array',
+    type: 'numArray',
     required: false,
     defaultValue: [21, 50],
   },
@@ -500,7 +503,7 @@ const _CONFIG = {
   },
   MIRROR_NODE_RETRY_CODES: {
     envName: 'MIRROR_NODE_RETRY_CODES',
-    type: 'array',
+    type: 'strArray',
     required: false,
     defaultValue: [],
   },

--- a/packages/config-service/src/services/validationService.ts
+++ b/packages/config-service/src/services/validationService.ts
@@ -46,7 +46,7 @@ export class ValidationService {
    * - If the env var is missing but has a default value, use the default
    * - For 'number' type, converts to Number
    * - For 'boolean' type, converts 'true' string to true boolean
-   * - For 'array' type, parses JSON string to array
+   * - For 'numArray' or 'strArray' types, parses JSON string to array
    * - For 'string' type, keeps as string
    *
    * @param envs - Dictionary of environment variables and their string values

--- a/packages/config-service/src/services/validationService.ts
+++ b/packages/config-service/src/services/validationService.ts
@@ -24,7 +24,7 @@ export class ValidationService {
           try {
             parsed = JSON.parse(envs[entryName] as string);
           } catch (e) {
-            throw new Error(`Configuration error: ${entryName} must be a valid JSON array.`);
+            throw new Error(`Configuration error: ${entryName} must be a valid JSON string.`);
           }
           if (!Array.isArray(parsed)) {
             throw new Error(`Configuration error: ${entryName} must be a valid JSON array.`);

--- a/packages/config-service/tests/src/services/validationService.spec.ts
+++ b/packages/config-service/tests/src/services/validationService.spec.ts
@@ -10,7 +10,7 @@ import { ValidationService } from '../../../dist/services/validationService';
 chai.use(chaiAsPromised);
 
 describe('ValidationService tests', async function () {
-  describe('startUp', () => {
+  describe.only('startUp', () => {
     const mandatoryStartUpFields = {
       CHAIN_ID: '0x12a',
       HEDERA_NETWORK: '{"127.0.0.1:50211":"0.0.3"}',
@@ -46,7 +46,7 @@ describe('ValidationService tests', async function () {
           ...mandatoryStartUpFields,
           BATCH_REQUESTS_DISALLOWED_METHODS: 'not-an-array',
         }),
-      ).to.throw('Configuration error: BATCH_REQUESTS_DISALLOWED_METHODS must be a valid JSON array.');
+      ).to.throw('Configuration error: BATCH_REQUESTS_DISALLOWED_METHODS must be a valid JSON string.');
       GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = false;
     });
 
@@ -57,7 +57,18 @@ describe('ValidationService tests', async function () {
           ...mandatoryStartUpFields,
           HAPI_CLIENT_ERROR_RESET: 'not-an-array',
         }),
-      ).to.throw('Configuration error: HAPI_CLIENT_ERROR_RESET must be a valid JSON array.');
+      ).to.throw('Configuration error: HAPI_CLIENT_ERROR_RESET must be a valid JSON string.');
+    });
+
+    it('should correctly detect if a string is valid JSON but not a valid JSON array', async () => {
+      GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = true;
+      expect(() =>
+        ValidationService.startUp({
+          ...mandatoryStartUpFields,
+          BATCH_REQUESTS_DISALLOWED_METHODS: '{"foo": "bar"}',
+        }),
+      ).to.throw('Configuration error: BATCH_REQUESTS_DISALLOWED_METHODS must be a valid JSON array.');
+      GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = false;
     });
 
     it('should validate string array content', async () => {

--- a/packages/config-service/tests/src/services/validationService.spec.ts
+++ b/packages/config-service/tests/src/services/validationService.spec.ts
@@ -10,7 +10,7 @@ import { ValidationService } from '../../../dist/services/validationService';
 chai.use(chaiAsPromised);
 
 describe('ValidationService tests', async function () {
-  describe.only('startUp', () => {
+  describe('startUp', () => {
     const mandatoryStartUpFields = {
       CHAIN_ID: '0x12a',
       HEDERA_NETWORK: '{"127.0.0.1:50211":"0.0.3"}',

--- a/packages/config-service/tests/src/services/validationService.spec.ts
+++ b/packages/config-service/tests/src/services/validationService.spec.ts
@@ -2,9 +2,10 @@
 
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+
+import { overrideEnvsInMochaDescribe } from '../../../../relay/tests/helpers';
 import { GlobalConfig } from '../../../dist/services/globalConfig';
 import { ValidationService } from '../../../dist/services/validationService';
-import { overrideEnvsInMochaDescribe } from '../../../../relay/tests/helpers';
 
 chai.use(chaiAsPromised);
 
@@ -37,6 +38,49 @@ describe('ValidationService tests', async function () {
       ).to.throw('SERVER_PORT must be a valid number.');
       GlobalConfig.ENTRIES.SERVER_PORT.required = false;
     });
+
+    it.only('should validate string array type', async () => {
+      GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = true;
+      expect(() =>
+        ValidationService.startUp({
+          ...mandatoryStartUpFields,
+          BATCH_REQUESTS_DISALLOWED_METHODS: 'not-an-array',
+        }),
+      ).to.throw('Configuration error: BATCH_REQUESTS_DISALLOWED_METHODS must be a valid JSON array.');
+      GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = false;
+    });
+
+    it.only('should validate number array type', async () => {
+      GlobalConfig.ENTRIES.HAPI_CLIENT_ERROR_RESET.required = true;
+      expect(() =>
+        ValidationService.startUp({
+          ...mandatoryStartUpFields,
+          HAPI_CLIENT_ERROR_RESET: 'not-an-array',
+        }),
+      ).to.throw('Configuration error: HAPI_CLIENT_ERROR_RESET must be a valid JSON array.');
+    });
+
+    it.only('should validate string array content', async () => {
+      GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = true;
+      expect(() =>
+        ValidationService.startUp({
+          ...mandatoryStartUpFields,
+          BATCH_REQUESTS_DISALLOWED_METHODS: '["test", 123]',
+        }),
+      ).to.throw('Configuration error: BATCH_REQUESTS_DISALLOWED_METHODS must contain only strings.');
+      GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = false;
+    });
+
+    it.only('should validate number array content', async () => {
+      GlobalConfig.ENTRIES.HAPI_CLIENT_ERROR_RESET.required = true;
+      expect(() =>
+        ValidationService.startUp({
+          ...mandatoryStartUpFields,
+          HAPI_CLIENT_ERROR_RESET: '["method1", 456]',
+        }),
+      ).to.throw('Configuration error: HAPI_CLIENT_ERROR_RESET must contain only numbers.');
+      GlobalConfig.ENTRIES.HAPI_CLIENT_ERROR_RESET.required = false;
+    });
   });
 
   describe('package-version', () => {
@@ -63,7 +107,7 @@ describe('ValidationService tests', async function () {
     });
   });
 
-  describe('typeCasting', () => {
+  describe.only('typeCasting', () => {
     it('should be able to use default value for missing env if default value is set', async () => {
       const castedEnvs = ValidationService.typeCasting({});
       expect(castedEnvs).to.haveOwnProperty(GlobalConfig.ENTRIES.E2E_RELAY_HOST.envName);
@@ -103,6 +147,44 @@ describe('ValidationService tests', async function () {
 
       expect(castedEnvs[GlobalConfig.ENTRIES.BATCH_REQUESTS_ENABLED.envName]).to.be.true;
       expect(GlobalConfig.ENTRIES.BATCH_REQUESTS_ENABLED.type).to.equal('boolean');
+    });
+
+    it('should cast string array type', async () => {
+      const castedEnvs = ValidationService.typeCasting({
+        [GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.envName]: '["method1", "method2"]',
+      });
+
+      expect(castedEnvs[GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.envName]).to.deep.equal([
+        'method1',
+        'method2',
+      ]);
+      expect(GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.type).to.equal('strArray');
+    });
+
+    it('should cast number array type', async () => {
+      const castedEnvs = ValidationService.typeCasting({
+        [GlobalConfig.ENTRIES.HAPI_CLIENT_ERROR_RESET.envName]: '[21, 50]',
+      });
+
+      expect(castedEnvs[GlobalConfig.ENTRIES.HAPI_CLIENT_ERROR_RESET.envName]).to.deep.equal([21, 50]);
+      expect(GlobalConfig.ENTRIES.HAPI_CLIENT_ERROR_RESET.type).to.equal('numArray');
+    });
+
+    it('should handle empty arrays', async () => {
+      const castedEnvs = ValidationService.typeCasting({
+        [GlobalConfig.ENTRIES.ETH_CALL_ACCEPTED_ERRORS.envName]: '[]',
+      });
+
+      expect(castedEnvs[GlobalConfig.ENTRIES.ETH_CALL_ACCEPTED_ERRORS.envName]).to.deep.equal([]);
+      expect(GlobalConfig.ENTRIES.ETH_CALL_ACCEPTED_ERRORS.type).to.equal('numArray');
+    });
+
+    it('should use default value for missing array', async () => {
+      const castedEnvs = ValidationService.typeCasting({});
+
+      expect(castedEnvs[GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.envName]).to.deep.equal(
+        GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.defaultValue,
+      );
     });
   });
 });

--- a/packages/config-service/tests/src/services/validationService.spec.ts
+++ b/packages/config-service/tests/src/services/validationService.spec.ts
@@ -39,7 +39,7 @@ describe('ValidationService tests', async function () {
       GlobalConfig.ENTRIES.SERVER_PORT.required = false;
     });
 
-    it.only('should validate string array type', async () => {
+    it('should validate string array type', async () => {
       GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = true;
       expect(() =>
         ValidationService.startUp({
@@ -50,7 +50,7 @@ describe('ValidationService tests', async function () {
       GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = false;
     });
 
-    it.only('should validate number array type', async () => {
+    it('should validate number array type', async () => {
       GlobalConfig.ENTRIES.HAPI_CLIENT_ERROR_RESET.required = true;
       expect(() =>
         ValidationService.startUp({
@@ -60,7 +60,7 @@ describe('ValidationService tests', async function () {
       ).to.throw('Configuration error: HAPI_CLIENT_ERROR_RESET must be a valid JSON array.');
     });
 
-    it.only('should validate string array content', async () => {
+    it('should validate string array content', async () => {
       GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = true;
       expect(() =>
         ValidationService.startUp({
@@ -71,7 +71,7 @@ describe('ValidationService tests', async function () {
       GlobalConfig.ENTRIES.BATCH_REQUESTS_DISALLOWED_METHODS.required = false;
     });
 
-    it.only('should validate number array content', async () => {
+    it('should validate number array content', async () => {
       GlobalConfig.ENTRIES.HAPI_CLIENT_ERROR_RESET.required = true;
       expect(() =>
         ValidationService.startUp({
@@ -107,7 +107,7 @@ describe('ValidationService tests', async function () {
     });
   });
 
-  describe.only('typeCasting', () => {
+  describe('typeCasting', () => {
     it('should be able to use default value for missing env if default value is set', async () => {
       const castedEnvs = ValidationService.typeCasting({});
       expect(castedEnvs).to.haveOwnProperty(GlobalConfig.ENTRIES.E2E_RELAY_HOST.envName);

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -11,7 +11,7 @@ import JSONBigInt from 'json-bigint';
 import { Logger } from 'pino';
 import { Histogram, Registry } from 'prom-client';
 
-import { formatRequestIdMessage, formatTransactionId, parseNumericEnvVar } from '../../formatters';
+import { formatRequestIdMessage, formatTransactionId } from '../../formatters';
 import { predefined } from '../errors/JsonRpcError';
 import { MirrorNodeClientError } from '../errors/MirrorNodeClientError';
 import { SDKClientError } from '../errors/SDKClientError';
@@ -156,7 +156,7 @@ export class MirrorNodeClient {
     const mirrorNodeRetriesDevMode = ConfigService.get('MIRROR_NODE_RETRIES_DEVMODE');
     const mirrorNodeRetryDelay = this.MIRROR_NODE_RETRY_DELAY;
     const mirrorNodeRetryDelayDevMode = ConfigService.get('MIRROR_NODE_RETRY_DELAY_DEVMODE');
-    const mirrorNodeRetryErrorCodes = JSON.parse(ConfigService.get('MIRROR_NODE_RETRY_CODES')); // we are in the process of deprecating this feature by default will be true, unless explicitly set to false.
+    const mirrorNodeRetryErrorCodes = ConfigService.get('MIRROR_NODE_RETRY_CODES'); // we are in the process of deprecating this feature by default will be true, unless explicitly set to false.
     const useCacheableDnsLookup: boolean = ConfigService.get('MIRROR_NODE_AGENT_CACHEABLE_DNS');
 
     const httpAgent = new http.Agent({
@@ -272,7 +272,7 @@ export class MirrorNodeClient {
     this.cacheService = cacheService;
 
     // set  up eth call  accepted error codes.
-    const parsedAcceptedError = JSON.parse(ConfigService.get('ETH_CALL_ACCEPTED_ERRORS'));
+    const parsedAcceptedError = ConfigService.get('ETH_CALL_ACCEPTED_ERRORS');
     if (parsedAcceptedError.length != 0) {
       MirrorNodeClient.acceptedErrorStatusesResponsePerRequestPathMap.set(
         MirrorNodeClient.CONTRACT_CALL_ENDPOINT,

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -140,7 +140,7 @@ export default {
   WEB_SOCKET_HTTP_PORT: ConfigService.get('WEB_SOCKET_HTTP_PORT'),
 
   RELAY_PORT: ConfigService.get('SERVER_PORT'),
-  RELAY_HOST: ConfigService.get('SERVER_HOST') || 'localhost',
+  RELAY_HOST: ConfigService.get('SERVER_HOST'),
 
   FUNCTION_SELECTOR_CHAR_LENGTH: 10,
   BASE_HEX_REGEX: '^0[xX][a-fA-F0-9]',

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1860,7 +1860,7 @@ export class EthImpl implements Eth {
     // When eth_call is invoked with a selector listed in specialSelectors, it will be routed through the consensus node, regardless of ETH_CALL_DEFAULT_TO_CONSENSUS_NODE.
     // note: this feature is a workaround for when a feature is supported by consensus node but not yet by mirror node.
     // Follow this ticket https://github.com/hashgraph/hedera-json-rpc-relay/issues/2984 to revisit and remove special selectors.
-    const specialSelectors: string[] = JSON.parse(ConfigService.get('ETH_CALL_CONSENSUS_SELECTORS'));
+    const specialSelectors = ConfigService.get('ETH_CALL_CONSENSUS_SELECTORS');
     const shouldForceToConsensus = selector !== '' && specialSelectors.includes(selector);
 
     // ETH_CALL_DEFAULT_TO_CONSENSUS_NODE = false enables the use of Mirror node

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -185,7 +185,7 @@ export default class HAPIService {
     const currentDateNow = Date.now();
     this.initialTransactionCount = ConfigService.get('HAPI_CLIENT_TRANSACTION_RESET');
     this.initialResetDuration = ConfigService.get('HAPI_CLIENT_DURATION_RESET');
-    this.initialErrorCodes = JSON.parse(ConfigService.get('HAPI_CLIENT_ERROR_RESET'));
+    this.initialErrorCodes = ConfigService.get('HAPI_CLIENT_ERROR_RESET');
 
     this.transactionCount = this.initialTransactionCount;
     this.resetDuration = currentDateNow + this.initialResetDuration;

--- a/packages/relay/src/utils.ts
+++ b/packages/relay/src/utils.ts
@@ -103,8 +103,8 @@ export class Utils {
     result: string;
     error_message: any;
   }): boolean {
-    // @ts-ignore
-    const statuses = JSON.parse(ConfigService.get('HEDERA_SPECIFIC_REVERT_STATUSES'));
+    // Use JSON.parse for backward compatibility until all code is updated to use array type
+    const statuses = ConfigService.get('HEDERA_SPECIFIC_REVERT_STATUSES');
     return (
       statuses.includes(contractResult.result) ||
       statuses.includes(hexToASCII(strip0x(contractResult.error_message ?? '')))

--- a/packages/relay/src/utils.ts
+++ b/packages/relay/src/utils.ts
@@ -103,7 +103,6 @@ export class Utils {
     result: string;
     error_message: any;
   }): boolean {
-    // Use JSON.parse for backward compatibility until all code is updated to use array type
     const statuses = ConfigService.get('HEDERA_SPECIFIC_REVERT_STATUSES');
     return (
       statuses.includes(contractResult.result) ||

--- a/packages/relay/tests/lib/hapiService.spec.ts
+++ b/packages/relay/tests/lib/hapiService.spec.ts
@@ -52,7 +52,7 @@ describe('HAPI Service', async function () {
   overrideEnvsInMochaDescribe({
     HAPI_CLIENT_TRANSACTION_RESET: 0,
     HAPI_CLIENT_DURATION_RESET: 0,
-    HAPI_CLIENT_ERROR_RESET: '[50]',
+    HAPI_CLIENT_ERROR_RESET: [50],
   });
 
   it('should be able to initialize SDK instance', async function () {
@@ -103,9 +103,10 @@ describe('HAPI Service', async function () {
     });
   });
 
-  withOverriddenEnvsInMochaTest({ HAPI_CLIENT_ERROR_RESET: '[50]' }, () => {
+  withOverriddenEnvsInMochaTest({ HAPI_CLIENT_ERROR_RESET: [50] }, () => {
     it('should be able to reinitialise SDK instance upon error status code encounter', async function () {
-      const hapiClientErrorReset: Array<number> = JSON.parse(ConfigService.get('HAPI_CLIENT_ERROR_RESET'));
+      // Use type assertion for backward compatibility until all code is updated
+      const hapiClientErrorReset = ConfigService.get('HAPI_CLIENT_ERROR_RESET');
 
       hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);
       expect(hapiService.getErrorCodes()[0]).to.eq(hapiClientErrorReset[0]);
@@ -124,7 +125,7 @@ describe('HAPI Service', async function () {
 
   withOverriddenEnvsInMochaTest(
     {
-      HAPI_CLIENT_ERROR_RESET: '[50]',
+      HAPI_CLIENT_ERROR_RESET: [50],
       HAPI_CLIENT_TRANSACTION_RESET: 50,
       HAPI_CLIENT_DURATION_RESET: 36000,
     },
@@ -151,7 +152,7 @@ describe('HAPI Service', async function () {
 
   withOverriddenEnvsInMochaTest(
     {
-      HAPI_CLIENT_ERROR_RESET: '[50]',
+      HAPI_CLIENT_ERROR_RESET: [50],
       HAPI_CLIENT_TRANSACTION_RESET: 50,
       HAPI_CLIENT_DURATION_RESET: 36000,
     },
@@ -184,7 +185,7 @@ describe('HAPI Service', async function () {
     {
       HAPI_CLIENT_TRANSACTION_RESET: 0,
       HAPI_CLIENT_DURATION_RESET: 0,
-      HAPI_CLIENT_ERROR_RESET: '[]',
+      HAPI_CLIENT_ERROR_RESET: [],
     },
     () => {
       it('should not be able to reinitialise and decrement counters, if it is disabled', async function () {

--- a/packages/relay/tests/lib/hapiService.spec.ts
+++ b/packages/relay/tests/lib/hapiService.spec.ts
@@ -105,7 +105,6 @@ describe('HAPI Service', async function () {
 
   withOverriddenEnvsInMochaTest({ HAPI_CLIENT_ERROR_RESET: [50] }, () => {
     it('should be able to reinitialise SDK instance upon error status code encounter', async function () {
-      // Use type assertion for backward compatibility until all code is updated
       const hapiClientErrorReset = ConfigService.get('HAPI_CLIENT_ERROR_RESET');
 
       hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);

--- a/packages/relay/tests/lib/utils.spec.ts
+++ b/packages/relay/tests/lib/utils.spec.ts
@@ -65,7 +65,6 @@ describe('Utils', () => {
       ).to.be.false;
     });
 
-    // Use JSON.parse for backward compatibility until all code is updated to use array type
     ConfigService.get('HEDERA_SPECIFIC_REVERT_STATUSES').forEach((status) => {
       it(`should exclude transaction with result ${status}`, () => {
         expect(Utils.isRevertedDueToHederaSpecificValidation({ result: status, error_message: null })).to.be.true;

--- a/packages/relay/tests/lib/utils.spec.ts
+++ b/packages/relay/tests/lib/utils.spec.ts
@@ -65,7 +65,8 @@ describe('Utils', () => {
       ).to.be.false;
     });
 
-    JSON.parse(ConfigService.get('HEDERA_SPECIFIC_REVERT_STATUSES')).forEach((status) => {
+    // Use JSON.parse for backward compatibility until all code is updated to use array type
+    ConfigService.get('HEDERA_SPECIFIC_REVERT_STATUSES').forEach((status) => {
       it(`should exclude transaction with result ${status}`, () => {
         expect(Utils.isRevertedDueToHederaSpecificValidation({ result: status, error_message: null })).to.be.true;
       });

--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -156,7 +156,7 @@ export default class KoaJsonRpc {
 
     // we do the requests in parallel to save time, but we need to keep track of the order of the responses (since the id might be optional)
     const promises: Promise<any>[] = body.map(async (item: any) => {
-      if (JSON.parse(ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS')).includes(item.method)) {
+      if ((ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS') as unknown as string[]).includes(item.method)) {
         return jsonResp(item.id, predefined.BATCH_REQUESTS_METHOD_NOT_PERMITTED(item.method), undefined);
       }
       const startTime = Date.now();

--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -156,7 +156,7 @@ export default class KoaJsonRpc {
 
     // we do the requests in parallel to save time, but we need to keep track of the order of the responses (since the id might be optional)
     const promises: Promise<any>[] = body.map(async (item: any) => {
-      if ((ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS') as unknown as string[]).includes(item.method)) {
+      if (ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS').includes(item.method)) {
         return jsonResp(item.id, predefined.BATCH_REQUESTS_METHOD_NOT_PERMITTED(item.method), undefined);
       }
       const startTime = Date.now();

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -779,7 +779,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       let initialEthCallSelectorsAlwaysToConsensus: any, hrc719Contract: ethers.Contract;
 
       before(async () => {
-        initialEthCallSelectorsAlwaysToConsensus = JSON.parse(ConfigService.get('ETH_CALL_CONSENSUS_SELECTORS'));
+        initialEthCallSelectorsAlwaysToConsensus = ConfigService.get('ETH_CALL_CONSENSUS_SELECTORS');
 
         hrc719Contract = await Utils.deployContract(
           HRC719ContractJson.abi,
@@ -796,7 +796,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       });
 
       it('should NOT allow eth_call to process IHRC719.isAssociated() method', async () => {
-        const selectorsList = JSON.parse(ConfigService.get('ETH_CALL_CONSENSUS_SELECTORS'));
+        const selectorsList = ConfigService.get('ETH_CALL_CONSENSUS_SELECTORS');
         expect(selectorsList.length).to.eq(0);
 
         // If the selector for `isAssociated` is not included in `ETH_CALL_CONSENSUS_SELECTORS`, the request will fail with a `CALL_EXCEPTION` error code.
@@ -813,7 +813,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         );
 
         // Add the selector for isAssociated to ETH_CALL_CONSENSUS_SELECTORS to ensure isAssociated() passes
-        ConfigServiceTestHelper.dynamicOverride('ETH_CALL_CONSENSUS_SELECTORS', JSON.stringify([isAssociatedSelector]));
+        ConfigServiceTestHelper.dynamicOverride('ETH_CALL_CONSENSUS_SELECTORS', [isAssociatedSelector]);
         const isAssociatedResult = await hrc719Contract.isAssociated(tokenAddress);
         expect(isAssociatedResult).to.be.false; // associate status of the token with the caller
       });
@@ -2037,7 +2037,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
     overrideEnvsInMochaDescribe({ BATCH_REQUESTS_ENABLED: true });
 
     it('@release Should return errors for blacklisted methods', async function () {
-      const disallowedMethods = JSON.parse(ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS'));
+      const disallowedMethods = ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS');
       const payload: any[] = [];
       for (let index = 0; index < disallowedMethods.length; index++) {
         payload.push({

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -137,7 +137,7 @@ app.ws.use(async (ctx: Koa.Context) => {
 
       // process requests
       const requestPromises = request.map((item: any) => {
-        if (JSON.parse(ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS')).includes(item.method)) {
+        if (ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS').includes(item.method)) {
           return jsonResp(item.id, predefined.BATCH_REQUESTS_METHOD_NOT_PERMITTED(item.method), undefined);
         }
         return getRequestResult(ctx, relay, logger, item, limiter, mirrorNodeClient, wsMetricRegistry, requestDetails);

--- a/packages/ws-server/tests/acceptance/batchRequest.spec.ts
+++ b/packages/ws-server/tests/acceptance/batchRequest.spec.ts
@@ -81,7 +81,7 @@ describe('@web-socket-batch-request Batch Requests', async function () {
     });
 
     it('@release Should return errors for blacklisted methods', async function () {
-      const disallowedMethods = JSON.parse(ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS'));
+      const disallowedMethods = ConfigService.get('BATCH_REQUESTS_DISALLOWED_METHODS');
       const requests: any[] = [];
       for (let index = 0; index < disallowedMethods.length; index++) {
         requests.push({


### PR DESCRIPTION
**Description**:
This PR adds support for array type environment variables in the Hedera JSON RPC Relay configuration system. Previously, array-type environment variables were stored as strings and had to be explicitly parsed with JSON.parse() on each usage. This implementation provides a more type-safe approach .

**Related issue(s)**:

Fixes #3178 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
